### PR TITLE
docs(readme): put Institution marker after repo link (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ story in [What Is Neo.mjs?](https://github.com/neomjs/neo/blob/dev/learn/benefit
   runtime Agent Institution is built on.
 - [`neomjs/neo-agent-brain`](https://github.com/neomjs/neo-agent-brain) — **Brain / Agent OS**:
   institutional memory, repository knowledge, coordination, and runtime services.
-- **You are here:** [`neomjs/neo-agent-institution`](https://github.com/neomjs/neo-agent-institution)
-  — **Agent Institution**: the operator-facing product.
+- [`neomjs/neo-agent-institution`](https://github.com/neomjs/neo-agent-institution) — **Agent Institution**: the operator-facing product. **← You are here**
 - [`neomjs/devindex`](https://github.com/neomjs/devindex) — **DevIndex**: the GitHub meritocracy
   index, its application, and its data factory.
 - [`neomjs/neo-agent-skills`](https://github.com/neomjs/neo-agent-skills) — **Skills**: the canonical


### PR DESCRIPTION
Resolves #27

Repairs the merged Agent Institution repository map so every bullet starts with repository text and the current-location marker ends the Institution row as plain, unlinked text.

Evidence: L1 exact-Markdown proof achieved → L1 required; this one-row documentation correction claims no runtime effect.

## AC Evidence

| AC-1 | Map parser returns exactly five bullets and every row matches the repository-link-first shape. |
| AC-2 | Marker count is exactly one; the Agent Institution row ends with plain `← You are here` after the repository link. |
| AC-3 | `git diff --name-only` is only `README.md`; diff is exactly one insertion/two deletions replacing the current-repository row. |
| AC-4 | Existing README local/public targets are unchanged; Institution CI must remain green on the candidate head. |
| AC-5 | Merge-gated: a formal cross-family identity review is required after current-head CI is green. |

## Deltas from ticket

None substantive. This is the exact follow-up required because PR #26 merged while the corrected #25 AC and branch amendment were racing the merge.

## Test Evidence

- Map assertion — five repository-first rows; one suffix marker; marker outside link.
- `git diff --check` — pass.

## Post-Merge Validation

- None. The map row is directly inspectable from the PR head.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session d84687fa-f74c-466a-9c07-70e2efcc9be6.
