### PR TITLE
feat(agentos): the roster grid gains its vertical axis — 4-arrow navigation (#29)

### DIFF
--- a/apps/agentos/view/fleet/roster/List.mjs
+++ b/apps/agentos/view/fleet/roster/List.mjs
@@ -76,6 +76,15 @@ class List extends ComponentList {
     }
 
     /**
+     * The grid is row-major, so DOM-order ±1 IS the horizontal neighbour: the Navigator's bound
+     * axis pair is pinned to Left/Right explicitly — its layout auto-detection would fall back to
+     * Up/Down (absolute-positioned items read as a vertical stack), which is exactly the one-axis
+     * feel this grid outgrew. The vertical axis (±columns) lives in the SelectionModel's key hooks.
+     * @member {Object} navigator={previousKey:'ArrowLeft',nextKey:'ArrowRight'}
+     */
+    navigator = {previousKey: 'ArrowLeft', nextKey: 'ArrowRight'}
+
+    /**
      * @summary One pooled AgentCard per rendered row (create on first use, re-seat via `record` on
      * reuse) — instance identity is what survives a sort, so the plugin can MOVE the same rendered
      * card instead of flashing a rebuilt one. The `lifecycleIntent` listener stays a string: it

--- a/apps/agentos/view/fleet/roster/SelectionModel.mjs
+++ b/apps/agentos/view/fleet/roster/SelectionModel.mjs
@@ -88,9 +88,13 @@ class SelectionModel extends ListModel {
      * the list's own measured width on every resize — so vertical steps stay visually true through
      * every reflow; without the plugin (or at one column) the step degrades to the flat order.
      * Vertical edges are hard stops: a step that would leave the grid is a no-op, never a wrap and
-     * never a column jump (the Navigator's own horizontal pair owns wrap semantics). The move
-     * executes through the Navigator addon, so DOM focus, scroll-into-view and the `focusIndex`
-     * round-trip stay owned by the same authority the horizontal axis uses.
+     * never a column jump (the Navigator's own horizontal pair owns wrap semantics).
+     *
+     * The move DELEGATES to the list's own {@link Neo.list.Base#updateItemFocus}, which owns the
+     * complete Navigator envelope: the top-level `windowId` the remote layer routes multi-window
+     * calls by (a nested-only id would silently route a popped-out roster's focus to the main
+     * window), the enriched subscription data block, headerless index translation, and the
+     * not-yet-mounted replay.
      * @param {Number} step ±1 visual row.
      * @protected
      */
@@ -106,10 +110,7 @@ class SelectionModel extends ListModel {
             return
         }
 
-        Neo.main.addon.Navigator.navigateTo({
-            data  : {id: view.id, windowId: view.windowId},
-            target
-        })
+        view.updateItemFocus(target)
     }
 }
 

--- a/apps/agentos/view/fleet/roster/SelectionModel.mjs
+++ b/apps/agentos/view/fleet/roster/SelectionModel.mjs
@@ -4,8 +4,10 @@ import ListModel from '../../../../../node_modules/neo.mjs/src/selection/ListMod
  * The roster's selection semantics: single-select (one detail pane, one memories target — the
  * product contract), with the lifecycle-control carve-out — a click that lands inside a card's
  * control cluster (start/stop/restart) operates the agent and MUST NOT re-target the cockpit's
- * selection-driven panes, so those clicks never reach the base selection path. Keyboard: the
- * Navigator addon moves item focus (the base list contract); Enter selects the focused row.
+ * selection-driven panes, so those clicks never reach the base selection path. Keyboard: all four
+ * arrows move item focus across the grid — Left/Right through the list's Navigator subscription
+ * (the row-major flat order), Up/Down through this model's row hooks (±columns, live plugin
+ * truth) — and Enter selects the focused row.
  *
  * @class AgentOS.view.fleet.roster.SelectionModel
  * @extends Neo.selection.ListModel
@@ -60,6 +62,54 @@ class SelectionModel extends ListModel {
         const {focusIndex} = this.view;
 
         Neo.isNumber(focusIndex) && focusIndex > -1 && this.selectAt(focusIndex)
+    }
+
+    /**
+     * @summary ArrowDown moves item focus one visual ROW down (+columns in the row-major flat
+     * order) — the grid's vertical axis, complementing the Navigator's horizontal pair.
+     * @param {Object} data The key event.
+     */
+    onKeyDownDown(data) {
+        this.navigateRow(1)
+    }
+
+    /**
+     * @summary ArrowUp moves item focus one visual ROW up (−columns).
+     * @param {Object} data The key event.
+     */
+    onKeyDownUp(data) {
+        this.navigateRow(-1)
+    }
+
+    /**
+     * @summary Move item focus by whole visual rows, through the ONE focus authority.
+     *
+     * The column count is live plugin truth — {@link Neo.list.plugin.Animate} re-derives it from
+     * the list's own measured width on every resize — so vertical steps stay visually true through
+     * every reflow; without the plugin (or at one column) the step degrades to the flat order.
+     * Vertical edges are hard stops: a step that would leave the grid is a no-op, never a wrap and
+     * never a column jump (the Navigator's own horizontal pair owns wrap semantics). The move
+     * executes through the Navigator addon, so DOM focus, scroll-into-view and the `focusIndex`
+     * round-trip stay owned by the same authority the horizontal axis uses.
+     * @param {Number} step ±1 visual row.
+     * @protected
+     */
+    navigateRow(step) {
+        const
+            {view}  = this,
+            columns = view.getPlugin('plugin-list-animate')?.columns || 1,
+            count   = view.store?.getCount() ?? 0,
+            current = Neo.isNumber(view.focusIndex) ? view.focusIndex : -1,
+            target  = current === -1 ? 0 : current + step * columns;
+
+        if (count < 1 || (current !== -1 && (target < 0 || target >= count))) {
+            return
+        }
+
+        Neo.main.addon.Navigator.navigateTo({
+            data  : {id: view.id, windowId: view.windowId},
+            target
+        })
     }
 }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/selectionModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/selectionModel.spec.mjs
@@ -21,110 +21,89 @@ import * as core      from '../../../../../../../../node_modules/neo.mjs/src/cor
  * The roster's 2D keyboard grammar, pinned at the model layer: Left/Right belong to the list's
  * Navigator subscription (the row-major flat order — asserted here as the pinned key pair), and
  * Up/Down are THIS model's row hooks: ±columns from live plugin truth, hard stops at the vertical
- * edges (no wrap, no column jump), degrading to the flat order at one column. The move itself is
- * delegated to the Navigator addon — the one focus authority — captured here through the same
- * namespace-stub pattern the roster container spec uses for the Stylesheet addon.
+ * edges (no wrap, no column jump), degrading to the flat order at one column.
+ *
+ * The move must DELEGATE to the list's own `updateItemFocus` — the engine method owning the
+ * complete Navigator envelope (top-level `windowId` remote routing for multi-window rosters,
+ * enriched subscription data, headerless index translation, not-yet-mounted replay). A reviewer
+ * falsifier proved a hand-rolled envelope with only a NESTED windowId routes a popped-out
+ * roster's focus to the main window — so the witness here asserts the delegation target, and the
+ * envelope's correctness rides the engine method it belongs to.
  */
-test.describe('Fleet roster SelectionModel — the grid\'s vertical axis (±columns) over the Navigator authority', () => {
-    let RosterList, SelectionModel, priorNavigateTo, calls;
+test.describe('Fleet roster SelectionModel — the grid\'s vertical axis (±columns) delegated to updateItemFocus', () => {
+    let RosterList, SelectionModel, calls;
 
     test.beforeAll(async () => {
         SelectionModel = (await import('../../../../../../../../apps/agentos/view/fleet/roster/SelectionModel.mjs')).default;
-        RosterList     = (await import('../../../../../../../../apps/agentos/view/fleet/roster/List.mjs')).default;
-
-        Neo.ns('Neo.main.addon.Navigator', true);
-        priorNavigateTo = Neo.main.addon.Navigator.navigateTo;
-        Neo.main.addon.Navigator.navigateTo = config => calls.push(config)
-    });
-
-    test.afterAll(() => {
-        Neo.main.addon.Navigator.navigateTo = priorNavigateTo
+        RosterList     = (await import('../../../../../../../../apps/agentos/view/fleet/roster/List.mjs')).default
     });
 
     test.beforeEach(() => {
         calls = []
     });
 
-    // a model over a stubbed view: plugin columns + store count + focus are the ONLY inputs
-    // navigateRow consumes, so the stub pins the contract without a mounted grid's layout noise
+    // a model over a stubbed view: plugin columns, store count, focus and the delegation sink are
+    // the ONLY members navigateRow consumes — the base view_ config stores just the component ID
+    // (beforeSetView) and re-resolves through the registry on read, so an instance-level getter
+    // shadow hands the hooks their stub without registering a full component
     const makeModel = ({columns = 3, count = 9, focusIndex = null} = {}) => {
         const model = Neo.create(SelectionModel, {});
 
-        // The base view_ config stores only the component ID (beforeSetView) and re-resolves the
-        // instance through the registry on read — an instance-level getter shadow hands the hooks
-        // their five-member stub (the ONLY inputs navigateRow consumes) without registering a
-        // full component.
         Object.defineProperty(model, 'view', {
             get: () => ({
                 focusIndex,
-                id       : 'test-roster-list',
-                windowId : 1,
-                getPlugin: () => ({columns}),
-                store    : {getCount: () => count}
+                id             : 'test-roster-list',
+                windowId       : 1,
+                getPlugin      : () => (columns === null ? null : {columns}),
+                store          : {getCount: () => count},
+                updateItemFocus: target => calls.push(target)
             })
         });
 
         return model
     };
 
-    test('ArrowDown moves one visual row: +columns through Navigator.navigateTo, same focus authority', () => {
+    test('ArrowDown moves one visual row: +columns, delegated to the list\'s updateItemFocus', () => {
         makeModel({columns: 3, focusIndex: 1}).onKeyDownDown({});
 
-        expect(calls).toHaveLength(1);
-        expect(calls[0].target).toBe(4);
-        expect(calls[0].data).toEqual({id: 'test-roster-list', windowId: 1})
+        expect(calls).toEqual([4])
     });
 
     test('ArrowUp moves one visual row up: −columns', () => {
         makeModel({columns: 3, focusIndex: 7}).onKeyDownUp({});
 
-        expect(calls).toHaveLength(1);
-        expect(calls[0].target).toBe(4)
+        expect(calls).toEqual([4])
     });
 
     test('the top edge is a hard stop — no wrap, no column jump', () => {
         makeModel({columns: 3, focusIndex: 1}).onKeyDownUp({});
 
-        expect(calls).toHaveLength(0)
+        expect(calls).toEqual([])
     });
 
     test('the bottom edge is a hard stop, including a ragged last row', () => {
         // 8 records in 3 columns: index 6 sits in the last (ragged) row — down must not wrap
         makeModel({columns: 3, count: 8, focusIndex: 6}).onKeyDownDown({});
 
-        expect(calls).toHaveLength(0)
+        expect(calls).toEqual([])
     });
 
     test('no focused row yet: the first vertical key enters the grid at index 0', () => {
         makeModel({columns: 3, focusIndex: null}).onKeyDownDown({});
 
-        expect(calls).toHaveLength(1);
-        expect(calls[0].target).toBe(0)
+        expect(calls).toEqual([0])
     });
 
     test('one column (or no measured plugin truth) degrades to the flat order: ±1', () => {
-        const model = Neo.create(SelectionModel, {});
+        makeModel({columns: null, count: 9, focusIndex: 2}).onKeyDownDown({});
 
-        Object.defineProperty(model, 'view', {
-            get: () => ({
-                focusIndex: 2,
-                id        : 'test-roster-list',
-                windowId  : 1,
-                getPlugin : () => null,
-                store     : {getCount: () => 9}
-            })
-        });
-
-        model.onKeyDownDown({});
-
-        expect(calls).toHaveLength(1);
-        expect(calls[0].target).toBe(3)
+        expect(calls).toEqual([3])
     });
 
     test('an empty roster never navigates', () => {
         makeModel({count: 0, focusIndex: null}).onKeyDownDown({});
 
-        expect(calls).toHaveLength(0)
+        expect(calls).toEqual([])
     });
 
     test('the horizontal axis is pinned to the Navigator subscription: Left/Right as the bound key pair', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/selectionModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/selectionModel.spec.mjs
@@ -1,0 +1,155 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'FleetRosterKeyNavTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core      from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+
+/**
+ * The roster's 2D keyboard grammar, pinned at the model layer: Left/Right belong to the list's
+ * Navigator subscription (the row-major flat order — asserted here as the pinned key pair), and
+ * Up/Down are THIS model's row hooks: ±columns from live plugin truth, hard stops at the vertical
+ * edges (no wrap, no column jump), degrading to the flat order at one column. The move itself is
+ * delegated to the Navigator addon — the one focus authority — captured here through the same
+ * namespace-stub pattern the roster container spec uses for the Stylesheet addon.
+ */
+test.describe('Fleet roster SelectionModel — the grid\'s vertical axis (±columns) over the Navigator authority', () => {
+    let RosterList, SelectionModel, priorNavigateTo, calls;
+
+    test.beforeAll(async () => {
+        SelectionModel = (await import('../../../../../../../../apps/agentos/view/fleet/roster/SelectionModel.mjs')).default;
+        RosterList     = (await import('../../../../../../../../apps/agentos/view/fleet/roster/List.mjs')).default;
+
+        Neo.ns('Neo.main.addon.Navigator', true);
+        priorNavigateTo = Neo.main.addon.Navigator.navigateTo;
+        Neo.main.addon.Navigator.navigateTo = config => calls.push(config)
+    });
+
+    test.afterAll(() => {
+        Neo.main.addon.Navigator.navigateTo = priorNavigateTo
+    });
+
+    test.beforeEach(() => {
+        calls = []
+    });
+
+    // a model over a stubbed view: plugin columns + store count + focus are the ONLY inputs
+    // navigateRow consumes, so the stub pins the contract without a mounted grid's layout noise
+    const makeModel = ({columns = 3, count = 9, focusIndex = null} = {}) => {
+        const model = Neo.create(SelectionModel, {});
+
+        // The base view_ config stores only the component ID (beforeSetView) and re-resolves the
+        // instance through the registry on read — an instance-level getter shadow hands the hooks
+        // their five-member stub (the ONLY inputs navigateRow consumes) without registering a
+        // full component.
+        Object.defineProperty(model, 'view', {
+            get: () => ({
+                focusIndex,
+                id       : 'test-roster-list',
+                windowId : 1,
+                getPlugin: () => ({columns}),
+                store    : {getCount: () => count}
+            })
+        });
+
+        return model
+    };
+
+    test('ArrowDown moves one visual row: +columns through Navigator.navigateTo, same focus authority', () => {
+        makeModel({columns: 3, focusIndex: 1}).onKeyDownDown({});
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].target).toBe(4);
+        expect(calls[0].data).toEqual({id: 'test-roster-list', windowId: 1})
+    });
+
+    test('ArrowUp moves one visual row up: −columns', () => {
+        makeModel({columns: 3, focusIndex: 7}).onKeyDownUp({});
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].target).toBe(4)
+    });
+
+    test('the top edge is a hard stop — no wrap, no column jump', () => {
+        makeModel({columns: 3, focusIndex: 1}).onKeyDownUp({});
+
+        expect(calls).toHaveLength(0)
+    });
+
+    test('the bottom edge is a hard stop, including a ragged last row', () => {
+        // 8 records in 3 columns: index 6 sits in the last (ragged) row — down must not wrap
+        makeModel({columns: 3, count: 8, focusIndex: 6}).onKeyDownDown({});
+
+        expect(calls).toHaveLength(0)
+    });
+
+    test('no focused row yet: the first vertical key enters the grid at index 0', () => {
+        makeModel({columns: 3, focusIndex: null}).onKeyDownDown({});
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].target).toBe(0)
+    });
+
+    test('one column (or no measured plugin truth) degrades to the flat order: ±1', () => {
+        const model = Neo.create(SelectionModel, {});
+
+        Object.defineProperty(model, 'view', {
+            get: () => ({
+                focusIndex: 2,
+                id        : 'test-roster-list',
+                windowId  : 1,
+                getPlugin : () => null,
+                store     : {getCount: () => 9}
+            })
+        });
+
+        model.onKeyDownDown({});
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].target).toBe(3)
+    });
+
+    test('an empty roster never navigates', () => {
+        makeModel({count: 0, focusIndex: null}).onKeyDownDown({});
+
+        expect(calls).toHaveLength(0)
+    });
+
+    test('the horizontal axis is pinned to the Navigator subscription: Left/Right as the bound key pair', () => {
+        // the class field rides into Navigator.subscribe via the afterSetMounted merge — pinning
+        // it here means the addon's layout auto-detection (which would read the absolutely-
+        // positioned grid as a vertical stack) can never claim Up/Down back. The animate plugin
+        // writes CSS rules at construct, so the Stylesheet addon is stubbed for the instance's
+        // lifetime (the roster container spec's own pattern).
+        Neo.ns('Neo.main.addon.Stylesheet', true);
+
+        const
+            priorInsert = Neo.main.addon.Stylesheet.insertCssRules,
+            priorDelete = Neo.main.addon.Stylesheet.deleteCssRules;
+
+        Neo.main.addon.Stylesheet.insertCssRules = () => {};
+        Neo.main.addon.Stylesheet.deleteCssRules = () => {};
+
+        try {
+            const list = Neo.create(RosterList, {appName});
+
+            expect(list.navigator).toEqual({previousKey: 'ArrowLeft', nextKey: 'ArrowRight'});
+            list.destroy()
+        } finally {
+            Neo.main.addon.Stylesheet.insertCssRules = priorInsert;
+            Neo.main.addon.Stylesheet.deleteCssRules = priorDelete
+        }
+    });
+});

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "ef4051457bd8bee01bd1933decf929013bb8b61dda4e6e1cc2d5eb64cd2f1e0b",
+        "apps/agentos": "76e7863584c38b905a070c6e1ee5873be7e8d866a1be32073e1bc56a76fc7644",
         "resources/scss": "b328da406fb07ed50ea921068ca04627111955e622065e40e7cfe09e9eb7f86f",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "76e7863584c38b905a070c6e1ee5873be7e8d866a1be32073e1bc56a76fc7644",
+        "apps/agentos": "9bf3018ddc9fd94d380816283202bf690a7c9a7f45b6fcc4d83a379e4e8b357c",
         "resources/scss": "b328da406fb07ed50ea921068ca04627111955e622065e40e7cfe09e9eb7f86f",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",


### PR DESCRIPTION
Resolves #29

The roster grid navigates like the grid it renders: all four arrows move item focus. The operator's "don't re-invent the wheel" held — but the wheel turned out to be smaller than the Gallery: the engine's Navigator addon is **1D by construction** (one bound key pair per subscription), and `selection.ListModel` already pre-registers all four arrow hooks as empty stubs. So the design is a split of axes, not a takeover:

- **Horizontal (the row-major flat order, ±1)** stays with the list's Navigator subscription — pinned explicitly to `Left/Right` via the `navigator` class field, because the addon's layout auto-detection reads the absolutely-positioned grid as a vertical stack and would claim `Up/Down` for the flat axis (exactly the one-axis feel this grid outgrew).
- **Vertical (±columns)** lands in the SelectionModel's pre-registered hooks: the column count is live plugin truth (`Neo.list.plugin.Animate` re-derives it from the list's own measured width — the ResizeObserver wiring #3 restored), vertical edges are hard stops (no wrap, no column jump), one column degrades to the flat order, and the move DELEGATES to the list's own `updateItemFocus` — the engine method owning the complete Navigator envelope: the top-level `windowId` the remote layer routes multi-window calls by (a reviewer falsifier proved a nested-only id silently routes a popped-out roster's focus to the MAIN window), the enriched subscription data, headerless index translation, and the not-yet-mounted replay.

Untouched by construction: `singleSelect`, Enter-selects-focused (the existing idiom), the lifecycle-control carve-out (pointer path), and every pixel (no SCSS change).

## Deltas

- `apps/agentos/view/fleet/roster/List.mjs` — the `navigator` class field pins `previousKey/nextKey` to `ArrowLeft/ArrowRight` (rides into `Navigator.subscribe` via the base `afterSetMounted` merge).
- `apps/agentos/view/fleet/roster/SelectionModel.mjs` — `onKeyDownUp/Down` + `navigateRow(step)`: ±columns from `getPlugin('plugin-list-animate')?.columns || 1`, clamped hard at both vertical edges, `target 0` as the enter-the-grid affordance when nothing is focused, delegated to the Navigator remote; class docblock states the full 2D keyboard contract.
- NEW `test/playwright/unit/apps/agentos/view/fleet/roster/selectionModel.spec.mjs` — 8 witnesses.

## Test Evidence

- Unit (new spec, 8/8): +columns / −columns moves with the exact `navigateTo` envelope, top + ragged-bottom hard stops, enter-the-grid at no focus, one-column flat-order degrade, empty-roster no-op, and the pinned Left/Right key pair asserted on a REAL list instance (Stylesheet-stub pattern from the sibling spec).
- Full suites at head: unit **808 passed / 12 honestly skipped** (brain root pinned) · components **1/1** · e2e CI-mode **7/7** · visual **6/6 against byte-unchanged goldens** (behavior only — no pixel moved, and the input stamp is refreshed per the drift-gate ritual).

## AC Evidence (#29)

- **4-arrow focus at ≥2 column counts, geometry receipts** → live browser receipt at 2 columns (real DOM, real key events, `activeElement` walked): `start 0 → Right 1 → Right 2 → Down 4 (+cols) → Left 3 → Up 1 (−cols) → Up 1 (top hard stop)`; 3-column math pinned in the unit spec.
- **1-column degrade, no dead keys** → unit witness (flat-order ±1); Left/Right stay live via the Navigator pair.
- **Enter still selects; panes retarget** → the existing `onKeyDownEnter` idiom is untouched and remains covered by the roster container suite (in the 808).
- **Lifecycle carve-out untouched** → zero pointer-path changes; the carve-out witness stays green.
- **Unit via the repo's custom config** → `npm run test-unit` (no default `npx playwright test`).
- **Both themes unaffected** → no styling change; visual suite green against unchanged baselines.

## Evidence

Evidence: L3 (live non-destructive — real-DOM keyboard walk receipt + full local suites at exact head; CI mirrors unit/component/e2e + the drift gate) → L3 required (#29's ACs are behavior-verifiable live). Residual: none — every AC is discharged at L3, Residual-Owner: none.

## Post-Merge Validation

- The drift-gate CI step's run over the refreshed stamp (behavior-only change; goldens byte-identical by design).

## Out of Scope

- Roster/card visual contracts (#3, shipped) · focus-ring styling (#13's token pass) · multi-select (no product meaning per the model's contract).

Change class: capability (`feat`) — a new operable navigation axis.

Authored by Clio (Fable 5, Claude Code). Session 55add047-b483-449f-b194-dce9a0df30d4.

