### PR TITLE
feat(agentos): the presence band projects provider validation provenance (#2)

### DIFF
--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -84,10 +84,13 @@ class FleetAgent extends Model {
             defaultValue: null
         }, {
             // The presence axis, same passthrough contract as `wake`/`throttle`: the
-            // roster row's `{source, state, confidence, lastSeenAt, reason?}` observation, where
-            // `state` is the plane's who_is_online band embryo (`online | idle | dark | benched |
-            // neverConnected | unknown`). The THIRD independent signal — presence-fresh ≠
-            // wake-route-healthy ≠ identity-bound — and the view never re-derives or fuses it.
+            // roster row's `{source, state, confidence, lastSeenAt, reason?, validationState?,
+            // since?}` observation, where `state` is the plane's who_is_online band embryo
+            // (`online | idle | dark | benched | neverConnected | unknown`). The THIRD independent
+            // signal — presence-fresh ≠ wake-route-healthy ≠ identity-bound — and the view never
+            // re-derives or fuses it. `validationState`/`since` are the provider's validation
+            // provenance (`stale-validated` + its onset): passed through verbatim for the card to
+            // PROJECT — never inferred, latched, or mutated downstream (#2).
             name        : 'presence',
             defaultValue: null
         }, {

--- a/apps/agentos/view/fleet/roster/card/Container.mjs
+++ b/apps/agentos/view/fleet/roster/card/Container.mjs
@@ -377,12 +377,26 @@ class AgentCard extends Container {
         const
             presence         = record.presence ?? null,
             presenceObserved = presence?.confidence === 'observed' &&
-                Object.hasOwn(PRESENCE_BAND_LABEL, presence?.state);
+                Object.hasOwn(PRESENCE_BAND_LABEL, presence?.state),
+            // the provider-owned validation provenance, projected verbatim (#2): the card renders
+            // the exception, never infers, latches, or mutates it
+            staleValidation  = presenceObserved && presence.validationState === 'stale-validated',
+            bandLabel        = presenceObserved ? PRESENCE_BAND_LABEL[presence.state] : '',
+            presenceBand     = me.getReference('card-presence');
 
-        me.getReference('card-presence').set({
+        presenceBand.set({
             hidden: !presenceObserved,
-            text  : presenceObserved ? `◉ ${PRESENCE_BAND_LABEL[presence.state]}` : ''
+            text  : presenceObserved ? `◉ ${bandLabel}${staleValidation ? ' · validation stale' : ''}` : ''
         });
+
+        // colour alone cannot carry the exception (WCAG 1.4.1): the words render it, the aria pair
+        // speaks it, and a fresh observation without the provenance clears every residue — class,
+        // text, aria-label, title — in the same pass. `since` is optional provenance: absent means
+        // no title, never a fabricated timestamp.
+        presenceBand[staleValidation ? 'addCls' : 'removeCls']('fm-card-presence-stale');
+        presenceBand.changeVdomRootKey('aria-label', staleValidation ? `Presence: ${bandLabel}. Provider validation stale.` : null);
+        presenceBand.changeVdomRootKey('title', staleValidation && presence.since != null ?
+            `Provider validation stale since ${new Date(presence.since).toISOString()}` : null);
 
         // the name slot: the folded display name as MUTABLE DISPLAY STATE over the durable id
         const

--- a/resources/scss/src/apps/agentos/fleet/roster/card/Container.scss
+++ b/resources/scss/src/apps/agentos/fleet/roster/card/Container.scss
@@ -139,6 +139,14 @@
         line-height: 1;
         white-space: nowrap;
         color      : var(--fm-ink-dim);
+
+        /* the provider-validation exception (#2): the WORDS carry it ("validation stale" in the
+           band text) — this modifier only adds the fm-state-hot emphasis pair (weight + full ink,
+           never a hue on text), so geometry and the ordinary band stay untouched */
+        &.fm-card-presence-stale {
+            color      : var(--fm-ink);
+            font-weight: 600;
+        }
     }
 
     /* the open-lane count badge — right-pinned; openLaneCount ONLY, never the engine */

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/card/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/card/container.spec.mjs
@@ -115,8 +115,9 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
-    // Expected red after the custody move; neo-agent-institution#2 owns the view/SCSS repair.
-    test.fail('stale validation is a visible presence exception and clears without residue', () => {
+    // the provider-owned validation provenance, projected on the band: words + aria pair, and a
+    // fresh observation clears class, text, aria-label AND title in one pass (#2)
+    test('stale validation is a visible presence exception and clears without residue', () => {
         const since = Date.parse('2026-08-09T10:55:00.000Z'),
               card  = createCard({
                   agentId : 'clio',

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "5e3677aea7e916db7ee86c11b0fd67a2882f5d1b09a6e8ca3296ffba8bac00e0",
-        "resources/scss": "b328da406fb07ed50ea921068ca04627111955e622065e40e7cfe09e9eb7f86f",
+        "apps/agentos": "9815feeed5eec336e625da26c59e1d79b564bde76bc20f636bcd8d64e22d907b",
+        "resources/scss": "27c3783411c27315fa23e694bb9a96f624f03df67e2fd977553dcf52706f7849",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "b740b2536f9994ab4346e0ee02db6400bd4ecb784e4345b3ff3ffb8b751e7adf",


### PR DESCRIPTION
Resolves #2

The last open ticket of the extraction-debt trio: the receiver's deliberately-red Fleet card witness turns green under Institution authority.

Evidence: L2 (exact-head CI 2/2 green, full unit battery 710 passed, local visual 6/6 against untouched goldens after fresh theme build) → L2 required (all five ACs are repository-local and unit/visual-verifiable). Residual: none.

## What

The provider owns validation provenance; the card now **projects** it, exactly as the ticket's architectural line demands (project, never infer/latch/mutate):

- `FleetAgent` presence passthrough doc extended for `validationState?` / `since?` (verbatim passthrough, provider-owned).
- `AgentCard.syncRecord()` renders `stale-validated` as the explicit words `· validation stale` in the band text, adds `fm-card-presence-stale`, and speaks the aria pair (`aria-label` + `since`-derived ISO `title` via `changeVdomRootKey` — the card's existing vdom-attribute pattern). A fresh observation without the provenance clears class, text, aria-label and title in the same pass. `since` is optional: absent means no title, never a fabricated timestamp.
- SCSS modifier follows the card's own `fm-state-hot` precedent — weight + full ink, never a hue on text, zero geometry change.
- The expected-red witness (`test.fail`) converts to an ordinary passing test.

## AC Evidence

- [x] Explicit words `validation stale` — Evidence: [L1] `Container.mjs` band text `` `◉ ${bandLabel}${staleValidation ? ' · validation stale' : ''}` ``; [L2] witness asserts `'◉ fresh · validation stale'`.
- [x] Accessible, not color-alone — Evidence: [L2] witness asserts `aria-label` `'Presence: fresh. Provider validation stale.'` + ISO `title`; the words carry the exception, the modifier only adds the `fm-state-hot` emphasis pair.
- [x] Fresh observation clears every residue — Evidence: [L2] witness re-applies a provenance-free observation and asserts text `'◉ fresh'`, no modifier cls, falsy `aria-label`/`title`.
- [x] Witness passes as an ordinary test — Evidence: [L2] `test.fail` → `test`; full unit battery **710 passed**.
- [x] No unrelated visual baseline refreshed — Evidence: [L2] goldens untouched (`git status` clean of `__screenshots__` images); local `test-visual` **6/6 passed** against the existing goldens after a fresh `-n -e dev` theme build (the stale modifier is referenced by no fixture — `validationState` appears only in the witness spec).

## Test Evidence

- `npm run test-unit`: **710 passed** (full battery, includes the converted witness).
- `npm run test-visual`: **6/6 passed** against untouched goldens (fresh theme build, 485 files).
- AC-7 drift gate: index-exact restamp in the same commit; `checkVisualBaselines.mjs` reports input identity matches.

## Deltas

None — the diff implements the ticket as written.

## Post-Merge Validation

Roster cards with provider-supplied `validationState: 'stale-validated'` render the visible + accessible exception; ordinary cards are byte-identical in behavior (modifier class absent, no vdom attributes added).

Residual-Owner: none — the trio (#2/#3/#4-packaging) leaves no open extraction-debt residue on the card surface.

Authored by Clio (Fable 5, Claude Code). Session 41859592-b7ee-4bce-bee3-f25644d9003b.
