### PR TITLE
feat(agentos): the mailbox renders through the buffered grid (#40)

### DIFF
--- a/apps/agentos/model/MailboxMessage.mjs
+++ b/apps/agentos/model/MailboxMessage.mjs
@@ -86,6 +86,16 @@ class MailboxMessage extends Model {
             name        : 'threadCollapsed',
             type        : 'Boolean',
             defaultValue: true
+        }, {
+            // VIEW-OWNED display facts, the second sanctioned exception beside `threadCollapsed`:
+            // `{isHead, collapsed, hiddenCount, inThread}` for thread rows, null for standalone —
+            // stamped by the grid's thread derivation on every store mutation. Living ON the record
+            // is deliberate: the component-column pool short-circuits on an unchanged record
+            // version, so per-row display facts must ride the record (a version bump) to survive
+            // cell recycling — a sidecar config would silently go stale (grid.column.Component's
+            // own contract: record-specific data belongs in the record-driven path).
+            name        : 'threadFacts',
+            defaultValue: null
         }]
     }
 }

--- a/apps/agentos/store/AgentMailbox.mjs
+++ b/apps/agentos/store/AgentMailbox.mjs
@@ -8,8 +8,8 @@ import Store               from '../../../node_modules/neo.mjs/src/data/Store.mj
  * @summary The mailbox mirror pane's row layer — a Store of
  * {@link AgentOS.model.MailboxMessage} records holding ONE adapter snapshot's frozen rows for the
  * pane's current subject. **Not a singleton and not provider-hosted**: the mailbox pane owns its
- * store instance directly — created with the pane, replaced wholesale on each snapshot via
- * {@link #applySnapshotRows}, destroyed with the pane.
+ * store instance directly — created with the pane, replaced wholesale on each snapshot through the
+ * grid's one data path ({@link AgentOS.view.fleet.mailbox.Grid#applyBags}), destroyed with the pane.
  *
  * No `url`: this store is NEVER fetched. The Fleet mailbox read adapter (the S1 Brain half) is the
  * only data source, and its viewer-admission + read-only + active-inbox boundaries live on that
@@ -44,18 +44,6 @@ class AgentMailbox extends Store {
             direction: 'DESC',
             property : 'sentAt'
         }]
-    }
-
-    /**
-     * @summary Replace the store content with one adapter snapshot's rows — wholesale, never a
-     * per-row merge: rows are immutable timestamped facts, so a new snapshot IS the new truth.
-     * Thread-collapse display state initializes fresh on each replace (thread heads collapsed) —
-     * seeded EXPLICITLY because the collection updates same-key records in place, where a model
-     * default would let the previous snapshot's display state leak through.
-     * @param {Object[]} rows Frozen mirror rows from `readFleetMailboxMirror`.
-     */
-    applySnapshotRows(rows) {
-        this.data = (Array.isArray(rows) ? rows : []).map(row => ({...row, threadCollapsed: true}))
     }
 }
 

--- a/apps/agentos/view/fleet/mailbox/Container.mjs
+++ b/apps/agentos/view/fleet/mailbox/Container.mjs
@@ -172,6 +172,22 @@ class MailboxPane extends Container {
      * @member {AgentOS.store.AgentMailbox|null} store=null
      */
     store = null
+    /**
+     * Armed by {@link #afterSetSnapshot} and consumed by ONE {@link #applySnapshot} run: the drain
+     * request (the next window beyond `page.hasMore`) fires only for a freshly landed snapshot —
+     * a freshness re-render (`now`) or a record swap re-projects without re-requesting.
+     * @member {Boolean} drainArmed=false
+     * @protected
+     */
+    drainArmed = false
+    /**
+     * The last projected window's identity (`[offset, rows]` fingerprint) — the explicit
+     * identical-poll gate: a refresh carrying the same rows skips the projection, so view-owned
+     * display state (an expanded thread) survives it.
+     * @member {String|null} projectedFingerprint=null
+     * @protected
+     */
+    projectedFingerprint = null
 
     /**
      * @summary Create the pane-owned store, then render the initial (honest) state.
@@ -201,13 +217,14 @@ class MailboxPane extends Container {
     }
 
     /**
-     * Triggered after the snapshot config changed — a new adapter read replaces the rows wholesale
-     * (rows are immutable timestamped facts; the new snapshot IS the new truth).
+     * Triggered after the snapshot config changed — a new adapter read projects (the first window
+     * replaces wholesale; a follow-up window appends), and arms exactly one drain request.
      * @param {Object|null} value
      * @param {Object|null} oldValue
      * @protected
      */
     afterSetSnapshot(value, oldValue) {
+        this.drainArmed = true;
         this.isConstructed && this.applySnapshot()
     }
 
@@ -347,10 +364,36 @@ class MailboxPane extends Container {
 
         rowsGrid.hidden = !rows;
 
-        // wholesale projection fires none of the store events the grid body listens to (the data
-        // setter is clear+add) — the pane drives the grid's deterministic refresh instead
-        me.store.applySnapshotRows(rows ? snapshot.rows : []);
-        rowsGrid.onStoreMutation()
+        // Projection: the FIRST window replaces wholesale; a follow-up window (offset > 0) extends
+        // the held corpus — the accumulation half of the no-paging contract (the buffered surface
+        // owns the whole corpus; the old offset chrome moved windows, the drain below fetches
+        // them). An identical-rows poll (only capture time advanced) skips the projection
+        // entirely, so the operator's expansion state survives a refresh with nothing new — the
+        // gate is explicit and pane-owned. Both branches ride the grid's ONE data path
+        // (`applyBags`): fresh windows arrive collapsed, an extension re-projects the held rows
+        // (their live `threadCollapsed` state included) plus the new window in one set.
+        const fingerprint = rows ? JSON.stringify([snapshot.page?.offset ?? 0, snapshot.rows]) : null;
+
+        if (fingerprint !== me.projectedFingerprint) {
+            const
+                extend    = rows && snapshot.page?.offset > 0,
+                projected = rows ? snapshot.rows.map(row => ({...row, threadCollapsed: true})) : [];
+
+            rowsGrid.applyBags(extend ? rowsGrid.extractBags().concat(projected) : projected);
+            me.projectedFingerprint = fingerprint
+        }
+
+        // The drain: while the producer says more exists beyond this window, request the next one —
+        // exactly ONE request per received snapshot (sequential by construction, no in-flight
+        // stacking), fired only when a NEW snapshot landed (afterSetSnapshot arms it) so freshness
+        // re-renders and record swaps never re-request. Row 51+ stays reachable without any chrome:
+        // the corpus assembles itself at the pane's own pace, and the honest end (hasMore: false)
+        // is the only stop.
+        if (rows && me.drainArmed && snapshot.page?.hasMore) {
+            me.fire('pageRequest', {offset: snapshot.page.offset + snapshot.page.limit, source: me})
+        }
+
+        me.drainArmed = false
     }
 
     /**

--- a/apps/agentos/view/fleet/mailbox/Container.mjs
+++ b/apps/agentos/view/fleet/mailbox/Container.mjs
@@ -1,6 +1,6 @@
 import AgentMailboxStore from '../../../store/AgentMailbox.mjs';
-import Button            from '../../../../../node_modules/neo.mjs/src/button/Base.mjs';
 import Container         from '../../../../../node_modules/neo.mjs/src/container/Base.mjs';
+import MailboxGrid       from './Grid.mjs';
 import AgentFreshness    from '../../../util/AgentFreshness.mjs';
 
 /**
@@ -66,13 +66,14 @@ function isRecognizedPage(page) {
  *  - `degraded` — the source failed for a non-admission reason: the honest reason line.
  *  - `empty` — wired, admitted, zero active rows: an explicit empty state.
  *
- * **Rows** render flat-chronological newest-first (the store's binding sort) with thread-collapse
- * where `partOfThread` exists: the NEWEST message of a thread heads the collapsed row (consistent
- * with the pane's newest-first order) over a `+N earlier` count chip; expanding renders the thread
- * inline, still newest-first. All row content is escaped `text` — record-derived strings never
- * render as markup. Pane-grain freshness reuses the S1 `agentFreshness` closed vocabulary
- * (fresh / stale / lost / `unobserved` as the fail-closed degrade tier) against the snapshot's
- * `capability.capturedAt`, so the cockpit speaks ONE freshness language.
+ * **Rows** render through {@link AgentOS.view.fleet.mailbox.Grid} — the #24 law-0 buffered
+ * `grid.Container` with one pooled {@link AgentOS.view.fleet.mailbox.RowComponent} per rendered
+ * row (the merged #36/#38 sketch is the scored row spec). The grid owns thread collapse and its
+ * delegated toggle; this pane keeps the states, the admission gate and the snapshot projection.
+ * No paging chrome exists anywhere on the surface (operator direction 2026-08-28): the window
+ * scrolls, and its honest end is the only end. Pane-grain freshness reuses the S1 `agentFreshness`
+ * closed vocabulary (fresh / stale / lost / `unobserved` as the fail-closed degrade tier) against
+ * the snapshot's `capability.capturedAt`, so the cockpit speaks ONE freshness language.
  *
  * The pane owns its {@link AgentOS.store.AgentMailbox} instance (created with the pane, destroyed
  * with it) — a leaf list owns a local store; no per-view `state.Provider`. The hosting wiring
@@ -130,7 +131,7 @@ class MailboxPane extends Container {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
-         * The pane head (freshness chip + page bounds) over the state line and the rows body.
+         * The pane head (title + freshness chip) over the state line and the buffered rows grid.
          * @member {Object[]} items
          */
         items: [{
@@ -147,43 +148,6 @@ class MailboxPane extends Container {
                 reference: 'mailbox-title'
             }, {
                 ntype    : 'component',
-                // The page bounds between their two transitions. The bounds label alone made row 51
-                // unreachable — a window with no way to move it is a claim about the data, not
-                // access to it. The pane REQUESTS a page (it renders, never fetches); the owner
-                // re-reads the mirror at the new offset.
-                //
-                // Composed from `button.Base` with the SHIPPED paging vocabulary (`fa fa-angle-*`,
-                // as `toolbar.Paging` uses), never hand-rolled `{tag:'button'}` vdom. The primitive
-                // is not ceremony: handler wiring, `iconCls`, disabled state and the `neo-selection`
-                // arrow-key opt-in all live there already — the visual states a raw tag is missing
-                // are missing *because* it bypassed the thing that supplies them.
-                ntype    : 'container',
-                cls      : ['fm-mailbox-page'],
-                flex     : 'none',
-                layout   : {ntype: 'hbox', align: 'center'},
-                reference: 'mailbox-page',
-
-                items: [{
-                    module   : Button,
-                    cls      : ['fm-mailbox-page-step', 'fm-mailbox-page-prev'],
-                    iconCls  : 'fa fa-angle-left',
-                    ui       : 'ghost',
-                    handler  : 'up.onPrevPageClick',
-                    reference: 'mailbox-page-prev'
-                }, {
-                    ntype    : 'component',
-                    cls      : ['fm-mailbox-page-range'],
-                    reference: 'mailbox-page-range'
-                }, {
-                    module   : Button,
-                    cls      : ['fm-mailbox-page-step', 'fm-mailbox-page-next'],
-                    iconCls  : 'fa fa-angle-right',
-                    ui       : 'ghost',
-                    handler  : 'up.onNextPageClick',
-                    reference: 'mailbox-page-next'
-                }]
-            }, {
-                ntype    : 'component',
                 flex     : 'none',
                 reference: 'mailbox-freshness'
             }]
@@ -193,37 +157,16 @@ class MailboxPane extends Container {
             cls      : ['fm-mailbox-state'],
             reference: 'mailbox-state'
         }, {
-            // the rows body — vdom-built from the pane-owned store, delegated single listener for
-            // the thread-collapse toggle (display-state navigation, the pane's ONLY interaction)
-            ntype    : 'component',
-            cls      : ['fm-mailbox-rows'],
+            // the rows body IS the buffered grid (#24 law 0): one pooled RowComponent per rendered
+            // row, thread collapse delegated inside the grid itself — this pane keeps the honest
+            // states, the admission gate and the snapshot projection, and hands the grid its store
+            module   : MailboxGrid,
             flex     : 1,
             hidden   : true,
-            reference: 'mailbox-rows',
-
-            // delegated to the native toggle BUTTON, not the row: a listener on the whole row makes
-            // the row an interactive region no keyboard user can reach. The handler still resolves
-            // the thread from the row's `data-thread-id` by walking the event path.
-            domListeners: [{
-                click   : 'up.onThreadHeadClick',
-                delegate: '.fm-mail-thread-toggle'
-            }]
+            reference: 'mailbox-rows'
         }]
     }
 
-    /**
-     * The offset the Newer step requests — held here because this view already owns the snapshot the
-     * bounds came from; stamping it onto the control would be a second copy of the same fact.
-     * @member {Number} prevPageOffset=0
-     * @protected
-     */
-    prevPageOffset = 0
-    /**
-     * The offset the Older step requests.
-     * @member {Number} nextPageOffset=0
-     * @protected
-     */
-    nextPageOffset = 0
     /**
      * The pane-owned row store — created with the pane, destroyed with it (see class summary).
      * @member {AgentOS.store.AgentMailbox|null} store=null
@@ -237,14 +180,12 @@ class MailboxPane extends Container {
     onConstructed(...args) {
         super.onConstructed(...args);
 
-        // Icon-only controls have no text to name them, so without this they reach AT as an unnamed
-        // button — the chevron IS the label to a sighted operator and nothing at all to anyone else.
-        // Named here rather than in the config: `button.Base` builds its own vdom, and handing it a
-        // `vdom` config would fight the primitive for ownership of the tree it renders.
-        this.getReference('mailbox-page-prev').changeVdomRootKey('aria-label', 'Newer messages');
-        this.getReference('mailbox-page-next').changeVdomRootKey('aria-label', 'Older messages');
-
         this.store = Neo.create(AgentMailboxStore);
+
+        // the grid renders what this pane projects: injected store (autoDestroyStore: false on the
+        // grid — this pane stays the owner), refresh driven by applySnapshot() per projection
+        this.getReference('mailbox-rows').store = this.store;
+
         this.applySnapshot()
     }
 
@@ -391,19 +332,12 @@ class MailboxPane extends Container {
             state        = me.getPaneState(),
             rows         = state === 'rows',
             stateCmp     = me.getReference('mailbox-state'),
-            rowsCmp      = me.getReference('mailbox-rows'),
-            pageCmp      = me.getReference('mailbox-page'),
+            rowsGrid     = me.getReference('mailbox-rows'),
             now          = me.now ?? Date.now(),
             ledger       = snapshot ? {freshnessTtl: me.freshnessTtl, observedAt: snapshot.capability?.capturedAt} : null,
             {cls, label} = AgentFreshness.describePaneFreshness(AgentFreshness.classifyPaneFreshness(ledger, now));
 
         me.getReference('mailbox-freshness').set({cls, text: label});
-
-        // page bounds are shown only when rows show — a denial/degrade never fakes a window
-        const page = snapshot?.page;
-
-        pageCmp.hidden = !rows || !page;
-        rows && page && me.applyPageBounds(page);
 
         stateCmp.set({
             cls   : ['fm-mailbox-state', `is-${state}`],
@@ -411,10 +345,12 @@ class MailboxPane extends Container {
             text  : rows ? '' : me.getStateText(state)
         });
 
-        rowsCmp.hidden = !rows;
+        rowsGrid.hidden = !rows;
 
+        // wholesale projection fires none of the store events the grid body listens to (the data
+        // setter is clear+add) — the pane drives the grid's deterministic refresh instead
         me.store.applySnapshotRows(rows ? snapshot.rows : []);
-        rows && me.renderRows()
+        rowsGrid.onStoreMutation()
     }
 
     /**
@@ -448,244 +384,6 @@ class MailboxPane extends Container {
         }
     }
 
-    /**
-     * @summary Build the rows body vdom from the pane-owned store: flat-chrono newest-first with
-     * thread-collapse. Store order is the binding order; threads group in first-encounter order,
-     * so the NEWEST message of a thread heads its collapsed row. All content renders as `text`.
-     * @protected
-     */
-    renderRows() {
-        let me      = this,
-            rowsCmp = me.getReference('mailbox-rows'),
-            groups  = new Map(),
-            cn      = [];
-
-        me.store.items.forEach(record => {
-            const threadId = record.partOfThread;
-
-            if (!threadId) {
-                cn.push(me.createRowVdom(record));
-                return
-            }
-
-            if (!groups.has(threadId)) {
-                // first encounter = the newest message of the thread → the thread head
-                const group = {head: record, rest: []};
-                groups.set(threadId, group);
-                cn.push(group)
-            } else {
-                groups.get(threadId).rest.push(record)
-            }
-        });
-
-        rowsCmp.vdom.cn = cn.map(entry => {
-            if (!entry.head) {
-                return entry
-            }
-
-            const {head, rest} = entry;
-
-            if (rest.length === 0) {
-                return me.createRowVdom(head)
-            }
-
-            if (head.threadCollapsed) {
-                return me.createRowVdom(head, {
-                    collapsed  : true,
-                    threadCount: rest.length,
-                    threadId   : head.partOfThread
-                })
-            }
-
-            return {
-                cls: ['fm-mail-thread'],
-                cn : [
-                    me.createRowVdom(head, {expanded: true, threadId: head.partOfThread}),
-                    ...rest.map(record => me.createRowVdom(record, {inThread: true}))
-                ]
-            }
-        });
-
-        rowsCmp.update()
-    }
-
-    /**
-     * @summary One row's vdom — escaped `text` leaves only, no interpreted markup anywhere. The
-     * thread head is the single interactive surface (the collapse toggle); everything else is
-     * inert fact rendering.
-     * @param {Object} record One {@link AgentOS.model.MailboxMessage} record.
-     * @param {Object} [options={}]
-     * @param {Boolean} [options.collapsed] Render as a collapsed thread head with a count chip.
-     * @param {Boolean} [options.expanded] Render as an expanded thread head.
-     * @param {Boolean} [options.inThread] Render as an indented thread member.
-     * @param {Number}  [options.threadCount] Collapsed-away count for the chip.
-     * @param {String}  [options.threadId] Thread id stamped on toggleable heads.
-     * @returns {Object}
-     * @protected
-     */
-    createRowVdom(record, {collapsed = false, expanded = false, inThread = false, threadCount = 0, threadId = null} = {}) {
-        const
-            isHead = collapsed || expanded,
-            meta   = [record.from, record.priority, record.status, record.taskState, record.sentAt]
-                .filter(Boolean)
-                .join(' · ');
-
-        return {
-            cls: [
-                'fm-mail-row',
-                record.status === 'unread' ? 'is-unread' : '',
-                isHead ? 'fm-mail-thread-head' : '',
-                inThread ? 'is-in-thread' : ''
-            ].filter(Boolean),
-            data: threadId ? {threadId} : null,
-            cn  : [{
-                cls: ['fm-mail-row-main'],
-                cn : [
-                    {tag: 'span', cls: ['fm-mail-subject'], text: record.subject || '(no subject)'},
-                    // The toggle is a NATIVE button, not a clickable div: it is the pane's only
-                    // affordance, and a div owns no Enter/Space and no tab stop, so thread collapse
-                    // was mouse-only. Same discipline as the card drill's native-button target —
-                    // an interactive region that is not a control is not operable. `aria-expanded`
-                    // names the state it toggles; the row keeps `fm-mail-thread-head` for styling.
-                    ...(collapsed ? [{
-                        tag            : 'button',
-                        type           : 'button',
-                        cls            : ['fm-mail-thread-count', 'fm-mail-thread-toggle'],
-                        text           : `+${threadCount} earlier`,
-                        'aria-expanded': 'false',
-                        'aria-label'   : `Expand thread — ${threadCount} earlier messages`
-                    }] : []),
-                    ...(expanded ? [{
-                        tag            : 'button',
-                        type           : 'button',
-                        cls            : ['fm-mail-thread-count', 'fm-mail-thread-toggle'],
-                        text           : 'collapse thread',
-                        'aria-expanded': 'true',
-                        'aria-label'   : 'Collapse thread'
-                    }] : [])
-                ]
-            }, {
-                cls : ['fm-mail-row-meta'],
-                text: meta
-            }]
-        }
-    }
-
-    /**
-     * @summary Apply the window bounds onto the composed page controls.
-     *
-     * A step is DISABLED, never hidden, at the range edge: a control that vanishes teaches the
-     * operator the surface is inconsistent, while a disabled one says "this edge is the end".
-     * `disabled` is `button.Base`'s own state — the primitive renders and styles it, so nothing here
-     * hand-rolls a visual for it.
-     *
-     * The offsets are held on THIS view rather than stamped into the controls: the pane already owns
-     * the snapshot the bounds came from, so a control carrying its own offset would be a second copy
-     * of a fact this view already has.
-     * @param {{limit: Number, offset: Number, count: Number, hasMore: Boolean}} page The snapshot's echoed bounds.
-     * @protected
-     */
-    applyPageBounds({limit, offset, count, hasMore}) {
-        let me = this;
-
-        me.prevPageOffset = Math.max(0, offset - limit);
-        me.nextPageOffset = offset + limit;
-
-        me.getReference('mailbox-page-range').text = `${offset + 1}–${offset + count}`;
-
-        // The producer's own boundary fact for `next`, never inferred from `count === limit`. A full
-        // page is ambiguous — it cannot distinguish "more follows" from "that was exactly the last
-        // one" — and guessing enables Next on an exactly-full final page, whose read returns an
-        // empty window at a positive offset: the pane then renders a global "no messages" and hides
-        // the strip, trapping the operator with no way back.
-        me.applyPageStep('mailbox-page-prev', offset <= 0);
-        me.applyPageStep('mailbox-page-next', !hasMore)
-    }
-
-    /**
-     * @summary Set one step's edge state — visually AND semantically.
-     *
-     * `Neo.component.Base`'s `disabled` adds the `neo-disabled` class and no `aria-disabled`, so on
-     * the class alone a styled-shut control is ANNOUNCED as enabled — the operator who most needs the
-     * edge to be honest is the one it lies to. So the class carries the look, `aria-disabled` carries
-     * the announcement, and the handler guard carries the refusal for direct entry (a routed
-     * activation is already stopped upstream — see {@link #onPrevPageClick}).
-     *
-     * Each covers exactly its own half-truth and no more. `aria-disabled` **announces** — it does not
-     * remove the control from the tab order, so a keyboard user still lands on a closed edge and is
-     * told, correctly, that it is closed. Whether a control ALSO emits a native `disabled`, and what
-     * that even does — a `<button>` root leaves the tab order, an anchor root ignores the attribute
-     * entirely — is that control's own contract to state, not this pane's to assume on its behalf.
-     * @param {String} reference The step control.
-     * @param {Boolean} closed Whether this edge is the end of the range.
-     * @protected
-     */
-    applyPageStep(reference, closed) {
-        const step = this.getReference(reference);
-
-        step.disabled = closed;
-        step.changeVdomRootKey('aria-disabled', closed ? 'true' : null)
-    }
-
-    /**
-     * @summary Request the newer page.
-     *
-     * The disabled check is defense in depth — not the edge's only gate, and not evidence that a
-     * ROUTED activation escapes. Two layers already close that route: global `.neo-disabled` sets
-     * `pointer-events: none`, and `manager/DomEvent` breaks its listener walk on a `disabled`
-     * component for every non-resize event. A keyboard Enter on a native button arrives as a click
-     * on that same route, so it stops there too. What no layer covers is DIRECT entry:
-     * `Neo.button.Base.onClick` never consults the config, so a programmatic call reaches `handler`
-     * with the routed gates bypassed. Stepping past the last page reads an empty window at a
-     * positive offset — the trap the `hasMore` boundary exists to prevent, and cheap to refuse here.
-     * @see src/manager/DomEvent.mjs — the listener walk that breaks on `disabled`
-     * @protected
-     */
-    onPrevPageClick() {
-        this.requestPage('mailbox-page-prev', this.prevPageOffset)
-    }
-
-    /**
-     * @summary Request the older page. See {@link #onPrevPageClick} for why the edge is re-checked.
-     * @protected
-     */
-    onNextPageClick() {
-        this.requestPage('mailbox-page-next', this.nextPageOffset)
-    }
-
-    /**
-     * @summary Fire one page request, refusing it at a closed edge.
-     * @param {String} reference The step control whose disabled state gates this request.
-     * @param {Number} offset The window offset to request.
-     * @protected
-     */
-    requestPage(reference, offset) {
-        this.getReference(reference)?.disabled || this.fire('pageRequest', {offset, source: this})
-    }
-
-    /**
-     * @summary The pane's only interaction: toggle a thread's collapse — display-state navigation
-     * on the view-owned record field, never a data write and never a read-state change.
-     * @param {Object} data Delegated click event data.
-     * @protected
-     */
-    onThreadHeadClick(data) {
-        const
-            me       = this,
-            target   = data.path?.find(node => node.data?.threadId),
-            threadId = target?.data?.threadId;
-
-        if (!threadId) {
-            return
-        }
-
-        const head = me.store.items.find(record => record.partOfThread === threadId);
-
-        if (head) {
-            head.threadCollapsed = !head.threadCollapsed;
-            me.renderRows()
-        }
-    }
 }
 
 export default Neo.setupClass(MailboxPane);

--- a/apps/agentos/view/fleet/mailbox/Grid.mjs
+++ b/apps/agentos/view/fleet/mailbox/Grid.mjs
@@ -1,0 +1,213 @@
+import GridContainer from '../../../../../node_modules/neo.mjs/src/grid/Container.mjs';
+import RowComponent  from './RowComponent.mjs';
+
+/**
+ * The mailbox surface as a real buffered grid — the #24 law-0 destination ("mailbox surfaces,
+ * memories and catch-up → grid.Container") scored against the merged information-design sketch
+ * (`apps/agentos/design/institution-mailbox-pane.html`, #36/#38).
+ *
+ * @summary A headerless, single-column `Neo.grid.Container`: one pooled
+ * {@link AgentOS.view.fleet.mailbox.RowComponent} per rendered row (the component-column pool is
+ * the buffering — `bufferRowRange` bounds and recycles mounted rows; it fetches nothing), fed from
+ * the injected {@link AgentOS.store.AgentMailbox} store. No paging chrome exists on this surface
+ * (operator direction 2026-08-28): the corpus scrolls, and its honest end is the only end — data
+ * acquisition stays the owning controller's scroll-edge contract until neomjs/neo#17835 lands the
+ * engine seam.
+ *
+ * **Threads are store truth + view-owned display state.** The thread map (head row, member count)
+ * derives from store order per `partOfThread` — newest-first, so the newest message heads its
+ * thread (the shipped pane's reading order, kept). Collapse state lives on the head record's
+ * view-owned `threadCollapsed` field (the model's ONE display-state exception); collapsed members
+ * hide via the grid's store filter, and the head's toggle — a native button inside the row cell —
+ * is delegated HERE (one listener, the cell stays passive).
+ *
+ * The mirror's read-only MUST-NOT stands unchanged: nothing on this surface writes — selection,
+ * expansion and scrolling never mark-read.
+ *
+ * @class AgentOS.view.fleet.mailbox.Grid
+ * @extends Neo.grid.Container
+ */
+class Grid extends GridContainer {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.mailbox.Grid'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.mailbox.Grid',
+        /**
+         * @member {String} ntype='fm-mailbox-grid'
+         * @protected
+         */
+        ntype: 'fm-mailbox-grid',
+        /**
+         * Keeps the mailbox skin anchors on the grid root; the SCSS hides the header toolbar —
+         * a headerless designed list, not a data table.
+         * @member {String[]} baseCls=['fm-mailbox-grid','neo-grid-container']
+         */
+        baseCls: ['fm-mailbox-grid', 'neo-grid-container'],
+        /**
+         * The injected mailbox store is pane/controller-owned — a renderer never destroys it.
+         * @member {Boolean} autoDestroyStore=false
+         */
+        autoDestroyStore: false
+    }
+
+    /**
+     * The store-derived thread map: `partOfThread` → `{headId, count}`. Rebuilt on every store
+     * load/change (cheap: one pass over the loaded window); read by the column factory to hand
+     * each cell its display facts.
+     * @member {Map|null} threadMap=null
+     * @protected
+     */
+    threadMap = null
+
+    /**
+     * @summary One headerless component column: the designed row IS the cell. The factory hands the
+     * pooled {@link AgentOS.view.fleet.mailbox.RowComponent} its record plus the thread display
+     * facts a lone cell cannot derive (a cell sees one record; the thread's shape is store truth).
+     */
+    onConstructed() {
+        let me = this;
+
+        me.columns = [{
+            dataField: 'subject',
+            flex     : 1,
+            component: ({record}) => ({
+                module     : RowComponent,
+                record,
+                threadFacts: me.threadFactsFor(record)
+            })
+        }];
+
+        super.onConstructed();
+
+        me.addDomListeners({
+            click   : me.onThreadToggleClick,
+            delegate: '.fm-mail-thread-toggle',
+            scope   : me
+        })
+    }
+
+    /**
+     * Triggered after the store config got changed: rebuild the thread map and arm the collapse
+     * filter over the new store.
+     * @param {Neo.data.Store|null} value
+     * @param {Neo.data.Store|null} oldValue
+     * @protected
+     */
+    afterSetStore(value, oldValue) {
+        super.afterSetStore?.(value, oldValue);
+
+        let me = this;
+
+        if (value) {
+            me.buildThreadMap();
+
+            value.on({
+                load : me.onStoreMutation,
+                scope: me
+            });
+
+            // collapsed thread members hide at the store view layer — the one filter this surface
+            // owns; heads and standalone rows always pass
+            value.filters = [...(value.filters || []), {
+                filterBy({item}) {
+                    const facts = me.threadFactsFor(item);
+
+                    return !(facts && !facts.isHead && facts.collapsed)
+                }
+            }]
+        }
+    }
+
+    /**
+     * @summary One pass over the loaded window: first record seen per `partOfThread` is the head
+     * (store order is newest-first — the newest message heads its thread), every further one counts.
+     * @protected
+     */
+    buildThreadMap() {
+        const
+            me  = this,
+            map = new Map();
+
+        me.store?.items?.forEach(record => {
+            const threadId = record.partOfThread;
+
+            if (!threadId) {
+                return
+            }
+
+            if (!map.has(threadId)) {
+                map.set(threadId, {headId: record[me.store.keyProperty], count: 0})
+            } else {
+                map.get(threadId).count++
+            }
+        });
+
+        me.threadMap = map
+    }
+
+    /**
+     * @summary The display facts for one record — `null` for standalone rows. Collapse truth reads
+     * from the HEAD record's view-owned `threadCollapsed` field, so a member knows to hide without
+     * carrying its own copy of the state.
+     * @param {Object} record
+     * @returns {Object|null}
+     */
+    threadFactsFor(record) {
+        const
+            me       = this,
+            threadId = record?.partOfThread,
+            entry    = threadId ? me.threadMap?.get(threadId) : null;
+
+        if (!entry) {
+            return null
+        }
+
+        const
+            isHead    = record[me.store.keyProperty] === entry.headId,
+            head      = isHead ? record : me.store.get(entry.headId),
+            collapsed = head ? head.threadCollapsed !== false : true;
+
+        return {
+            collapsed,
+            isHead,
+            hiddenCount: entry.count,
+            inThread   : !isHead
+        }
+    }
+
+    /**
+     * @summary Store content changed: the thread shape may have too — rebuild the map, re-run the
+     * collapse filter, and let the buffered rows re-seat.
+     * @protected
+     */
+    onStoreMutation() {
+        this.buildThreadMap();
+        this.store.filter()
+    }
+
+    /**
+     * @summary The one interaction this surface owns: toggling a thread head's view-owned
+     * `threadCollapsed` display state. Pure navigation — expanding a thread reads nothing and
+     * writes nothing beyond the display field (the read-only MUST-NOT stands).
+     *
+     * Record resolution walks the delegated click path up to the `.neo-grid-row` node, which the
+     * grid body stamps with `data.recordId` — the engine's own event→record contract, no index math.
+     * @param {Object} data The delegated click; the toggle button sits inside its row cell.
+     */
+    onThreadToggleClick(data) {
+        const
+            me       = this,
+            rowNode  = (data.path || []).find(node => node.cls?.includes('neo-grid-row')),
+            recordId = rowNode?.data?.recordId,
+            record   = recordId != null ? me.store.get(recordId) : null;
+
+        if (record?.partOfThread) {
+            record.threadCollapsed = record.threadCollapsed === false;
+            me.onStoreMutation()
+        }
+    }
+}
+
+export default Neo.setupClass(Grid);

--- a/apps/agentos/view/fleet/mailbox/Grid.mjs
+++ b/apps/agentos/view/fleet/mailbox/Grid.mjs
@@ -14,12 +14,20 @@ import RowComponent  from './RowComponent.mjs';
  * acquisition stays the owning controller's scroll-edge contract until neomjs/neo#17835 lands the
  * engine seam.
  *
- * **Threads are store truth + view-owned display state.** The thread map (head row, member count)
- * derives from store order per `partOfThread` — newest-first, so the newest message heads its
- * thread (the shipped pane's reading order, kept). Collapse state lives on the head record's
- * view-owned `threadCollapsed` field (the model's ONE display-state exception); collapsed members
- * hide via the grid's store filter, and the head's toggle — a native button inside the row cell —
- * is delegated HERE (one listener, the cell stays passive).
+ * **ONE data path.** Every mutation of this surface — wholesale projection, window append, thread
+ * toggle — flows through {@link #applyBags}: plain row bags get their thread facts stamped
+ * ({@link #stampThreadFacts}) and become the store's data in a single set. The grid body renders
+ * once per mutation from records that already carry their facts, and every mutation produces NEW
+ * record identities (which is what re-seats the pooled cells — no version choreography, no
+ * recordChange/filter event overlap; two overlapping vdom transactions double-mounted cell content
+ * into its own row, measured, not theorized).
+ *
+ * **Threads are store truth + view-owned display state.** The first row seen per `partOfThread` is
+ * the head (newest-first store order — the newest message heads its thread, the shipped pane's
+ * reading order). Collapse state lives on the head's view-owned `threadCollapsed` field (the
+ * model's ONE display-state exception); collapsed members hide via the grid's store filter, and
+ * the head's toggle — a native button inside the row cell — is delegated HERE (one listener, the
+ * cell stays passive).
  *
  * The mirror's read-only MUST-NOT stands unchanged: nothing on this surface writes — selection,
  * expansion and scrolling never mark-read.
@@ -53,18 +61,12 @@ class Grid extends GridContainer {
     }
 
     /**
-     * The store-derived thread map: `partOfThread` → `{headId, count}`. Rebuilt on every store
-     * load/change (cheap: one pass over the loaded window); read by the column factory to hand
-     * each cell its display facts.
-     * @member {Map|null} threadMap=null
-     * @protected
-     */
-    threadMap = null
-
-    /**
-     * @summary One headerless component column: the designed row IS the cell. The factory hands the
-     * pooled {@link AgentOS.view.fleet.mailbox.RowComponent} its record plus the thread display
-     * facts a lone cell cannot derive (a cell sees one record; the thread's shape is store truth).
+     * @summary One headerless component column: the designed row IS the cell. The factory builds a
+     * FRESH `rowData` bag per call — the engine's component-column contract in both directions:
+     * the pool short-circuits on an unchanged record (every {@link #applyBags} run creates new
+     * record identities, so re-seats always fire), and a re-seat applies configs via `set()` (so
+     * the render surface must be a new-reference value, never the same record instance, or
+     * afterSet never re-fires).
      */
     onConstructed() {
         let me = this;
@@ -73,9 +75,18 @@ class Grid extends GridContainer {
             dataField: 'subject',
             flex     : 1,
             component: ({record}) => ({
-                module     : RowComponent,
-                record,
-                threadFacts: me.threadFactsFor(record)
+                module : RowComponent,
+                rowData: {
+                    from          : record.from,
+                    priority      : record.priority,
+                    recipientClass: record.recipientClass,
+                    relatedTickets: record.relatedTickets,
+                    sentAt        : record.sentAt,
+                    status        : record.status,
+                    subject       : record.subject,
+                    taskState     : record.taskState,
+                    threadFacts   : record.threadFacts
+                }
             })
         }];
 
@@ -89,8 +100,7 @@ class Grid extends GridContainer {
     }
 
     /**
-     * Triggered after the store config got changed: rebuild the thread map and arm the collapse
-     * filter over the new store.
+     * Triggered after the store config got changed: arm the collapse filter over the new store.
      * @param {Neo.data.Store|null} value
      * @param {Neo.data.Store|null} oldValue
      * @protected
@@ -98,21 +108,16 @@ class Grid extends GridContainer {
     afterSetStore(value, oldValue) {
         super.afterSetStore?.(value, oldValue);
 
-        let me = this;
-
         if (value) {
-            me.buildThreadMap();
-
             // collapsed thread members hide at the store view layer — the one filter this surface
             // owns; heads and standalone rows always pass. `filterBy` follows the collection
-            // Filter contract: returning TRUE filters the item OUT. NOTE: the grid body reacts to
-            // the store's `filter` / `load` / `recordChange` events ONLY — a wholesale projection
-            // (`applySnapshotRows` → the data setter → clear+add) fires none of them, so the
-            // OWNING PANE drives {@link #onStoreMutation} after every projection; `store.filter()`
-            // inside it is what re-renders the body deterministically.
+            // Filter contract: returning TRUE filters the item OUT. It reads the facts stamped at
+            // bag time ({@link #applyBags}), never a live re-derivation, so the filter and the
+            // rendered cells can never disagree — and the facts exist BEFORE the data path's
+            // filter-during-add renders the first cells.
             value.filters = [...(value.filters || []), {
                 filterBy({item}) {
-                    const facts = me.threadFactsFor(item);
+                    const facts = item.threadFacts;
 
                     return !!(facts && !facts.isHead && facts.collapsed)
                 }
@@ -121,81 +126,91 @@ class Grid extends GridContainer {
     }
 
     /**
-     * @summary One pass over the loaded window: first record seen per `partOfThread` is the head
-     * (store order is newest-first — the newest message heads its thread), every further one counts.
-     * @protected
+     * @summary THE one mutation entry: stamp thread facts into the plain bags, then hand them to
+     * the store as its full data set. The data path (clear + add) re-runs the collapse filter and
+     * renders the body exactly once, from records that already carry their facts as fields — and
+     * because every run creates new record identities, the pooled cells re-seat without any
+     * version choreography.
+     * @param {Object[]} bags Plain row objects (already carrying `threadCollapsed` view state).
      */
-    buildThreadMap() {
-        const
-            me  = this,
-            map = new Map(),
-            // the map derives from the UNFILTERED corpus: once the collapse filter has run, a
-            // hidden member is gone from `items`, and a map built over the filtered view would
-            // undercount threads (the collection exposes the unfiltered source as `allItems`
-            // after its first filter run)
-            source = me.store?.allItems?.items ?? me.store?.items;
+    applyBags(bags) {
+        this.stampThreadFacts(bags);
+        this.store.data = bags
+    }
 
-        source?.forEach(record => {
-            const threadId = record.partOfThread;
+    /**
+     * @summary The store's current corpus back as plain bags — the read half of the one data path
+     * (mutations re-project through {@link #applyBags}). Reads the UNFILTERED source (`allItems`
+     * once the collapse filter has run — hidden members must survive a re-projection) and strips
+     * the derived `threadFacts` (re-stamped on the way back in).
+     * @returns {Object[]}
+     */
+    extractBags() {
+        const
+            me         = this,
+            fieldNames = me.store.model.fields.map(field => field.name).filter(name => name !== 'threadFacts');
+
+        return (me.store.allItems?.items ?? me.store.items).map(record => {
+            const bag = {};
+
+            fieldNames.forEach(name => bag[name] = record[name]);
+
+            return bag
+        })
+    }
+
+    /**
+     * @summary Stamp thread display facts into PLAIN projection bags BEFORE they become records —
+     * facts that arrive only after the store set would miss the data path's immediate
+     * filter-during-add render (measured: cells seated with `facts: null`). Bags are mutated
+     * in place; the first bag seen per `partOfThread` is the head (newest-first order), and
+     * collapse truth reads from the head's view-owned `threadCollapsed` field, so a member knows
+     * to hide without carrying its own copy of the state.
+     * @param {Object[]} bags The projection rows (already carrying `threadCollapsed`).
+     * @returns {Object[]} The same array, facts stamped.
+     */
+    stampThreadFacts(bags) {
+        const map = new Map();
+
+        bags.forEach(bag => {
+            const threadId = bag.partOfThread;
 
             if (!threadId) {
                 return
             }
 
             if (!map.has(threadId)) {
-                map.set(threadId, {headId: record[me.store.keyProperty], count: 0})
+                map.set(threadId, {head: bag, count: 0})
             } else {
                 map.get(threadId).count++
             }
         });
 
-        me.threadMap = map
-    }
+        bags.forEach(bag => {
+            const entry = bag.partOfThread ? map.get(bag.partOfThread) : null;
 
-    /**
-     * @summary The display facts for one record — `null` for standalone rows. Collapse truth reads
-     * from the HEAD record's view-owned `threadCollapsed` field, so a member knows to hide without
-     * carrying its own copy of the state.
-     * @param {Object} record
-     * @returns {Object|null}
-     */
-    threadFactsFor(record) {
-        const
-            me       = this,
-            threadId = record?.partOfThread,
-            entry    = threadId ? me.threadMap?.get(threadId) : null;
+            if (entry) {
+                const isHead = entry.head === bag;
 
-        if (!entry) {
-            return null
-        }
+                bag.threadFacts = {
+                    collapsed  : entry.head.threadCollapsed !== false,
+                    isHead,
+                    hiddenCount: entry.count,
+                    inThread   : !isHead
+                }
+            }
+        });
 
-        const
-            isHead    = record[me.store.keyProperty] === entry.headId,
-            head      = isHead ? record : me.store.get(entry.headId),
-            collapsed = head ? head.threadCollapsed !== false : true;
-
-        return {
-            collapsed,
-            isHead,
-            hiddenCount: entry.count,
-            inThread   : !isHead
-        }
-    }
-
-    /**
-     * @summary Store content changed: the thread shape may have too — rebuild the map, re-run the
-     * collapse filter, and let the buffered rows re-seat.
-     * @protected
-     */
-    onStoreMutation() {
-        this.buildThreadMap();
-        this.store.filter()
+        return bags
     }
 
     /**
      * @summary The one interaction this surface owns: toggling a thread head's view-owned
      * `threadCollapsed` display state. Pure navigation — expanding a thread reads nothing and
-     * writes nothing beyond the display field (the read-only MUST-NOT stands).
+     * writes nothing beyond the display field (the read-only MUST-NOT stands). The flip rides the
+     * one data path: extract the corpus, flip the head's bag, re-apply — never a record mutation
+     * (mutating live records fires recordChange against the filter re-render, and the two
+     * overlapping vdom transactions double-mount the head cell's content).
      *
      * Record resolution walks the delegated click path up to the `.neo-grid-row` node, which the
      * grid body stamps with `data.recordId` — the engine's own event→record contract, no index math.
@@ -209,8 +224,12 @@ class Grid extends GridContainer {
             record   = recordId != null ? me.store.get(recordId) : null;
 
         if (record?.partOfThread) {
-            record.threadCollapsed = record.threadCollapsed === false;
-            me.onStoreMutation()
+            const
+                bags = me.extractBags(),
+                head = bags.find(bag => bag[me.store.keyProperty] === record[me.store.keyProperty]);
+
+            head.threadCollapsed = head.threadCollapsed === false;
+            me.applyBags(bags)
         }
     }
 }

--- a/apps/agentos/view/fleet/mailbox/Grid.mjs
+++ b/apps/agentos/view/fleet/mailbox/Grid.mjs
@@ -103,18 +103,18 @@ class Grid extends GridContainer {
         if (value) {
             me.buildThreadMap();
 
-            value.on({
-                load : me.onStoreMutation,
-                scope: me
-            });
-
             // collapsed thread members hide at the store view layer — the one filter this surface
-            // owns; heads and standalone rows always pass
+            // owns; heads and standalone rows always pass. `filterBy` follows the collection
+            // Filter contract: returning TRUE filters the item OUT. NOTE: the grid body reacts to
+            // the store's `filter` / `load` / `recordChange` events ONLY — a wholesale projection
+            // (`applySnapshotRows` → the data setter → clear+add) fires none of them, so the
+            // OWNING PANE drives {@link #onStoreMutation} after every projection; `store.filter()`
+            // inside it is what re-renders the body deterministically.
             value.filters = [...(value.filters || []), {
                 filterBy({item}) {
                     const facts = me.threadFactsFor(item);
 
-                    return !(facts && !facts.isHead && facts.collapsed)
+                    return !!(facts && !facts.isHead && facts.collapsed)
                 }
             }]
         }
@@ -128,9 +128,14 @@ class Grid extends GridContainer {
     buildThreadMap() {
         const
             me  = this,
-            map = new Map();
+            map = new Map(),
+            // the map derives from the UNFILTERED corpus: once the collapse filter has run, a
+            // hidden member is gone from `items`, and a map built over the filtered view would
+            // undercount threads (the collection exposes the unfiltered source as `allItems`
+            // after its first filter run)
+            source = me.store?.allItems?.items ?? me.store?.items;
 
-        me.store?.items?.forEach(record => {
+        source?.forEach(record => {
             const threadId = record.partOfThread;
 
             if (!threadId) {

--- a/apps/agentos/view/fleet/mailbox/Grid.mjs
+++ b/apps/agentos/view/fleet/mailbox/Grid.mjs
@@ -54,6 +54,16 @@ class Grid extends GridContainer {
          */
         baseCls: ['fm-mailbox-grid', 'neo-grid-container'],
         /**
+         * The engine grid positions rows on a FIXED row lattice — variable row heights overlap
+         * cell content onto itself (measured in the mounted browser: 39–84px designed rows on
+         * the 32px default lattice). The row is height-NORMED to the tallest designed case
+         * (sender + 2-line subject clamp + exception strip) in `mailbox/Grid.scss`
+         * (`.fm-mail-row`), and THIS value carries the same total: change one, change both.
+         * @member {Number} rowHeight=84
+         * @reactive
+         */
+        rowHeight: 84,
+        /**
          * The injected mailbox store is pane/controller-owned — a renderer never destroys it.
          * @member {Boolean} autoDestroyStore=false
          */

--- a/apps/agentos/view/fleet/mailbox/OperatorContainer.mjs
+++ b/apps/agentos/view/fleet/mailbox/OperatorContainer.mjs
@@ -145,6 +145,9 @@ class OperatorMailbox extends Container {
             inbox = me.getReference('operator-inbox-pane'),
             form  = me.getReference('operator-compose-form');
 
+        // the pane's drain requests (the next window while `page.hasMore`) relay through the same
+        // read intent the construction fire uses — one event, one cockpit handler, no chrome
+        inbox?.on('pageRequest', me.onInboxPageRequest, me);
         form?.on('compose', me.onCompose, me);
 
         if (inbox) {
@@ -240,9 +243,10 @@ class OperatorMailbox extends Container {
 
     /**
      * @summary Fire the inbox read intent to the owner — the cockpit holds the read seam and reads
-     * the operator mirror. Since the paging chrome retired (the buffered grid scrolls), the offset
-     * is always 0 and the ONLY triggers are construction and an identity bind; the event name and
-     * payload shape stay stable for the cockpit's existing wiring.
+     * the operator mirror at the requested offset. Two callers, one event: the construction /
+     * identity-bind fire (offset 0) and the pane's snapshot-driven DRAIN (the next window while
+     * `page.hasMore` — one request per received snapshot, so row 51+ assembles without chrome).
+     * The event name and payload shape stay stable for the cockpit's existing wiring.
      * @param {Object} data The read payload (`{offset}`).
      * @protected
      */

--- a/apps/agentos/view/fleet/mailbox/OperatorContainer.mjs
+++ b/apps/agentos/view/fleet/mailbox/OperatorContainer.mjs
@@ -11,11 +11,12 @@ import OperatorComposeForm from './ComposeForm.mjs';
  * own identity) above {@link AgentOS.view.fleet.mailbox.ComposeForm}, and RELAYS both surfaces'
  * intents up to the cockpit — it performs no transport itself.
  *
- * **Why a relay, not a doer.** Both children fire intents the OWNER services against the
- * authenticated seam: the inbox pane fires `pageRequest` (the cockpit re-reads the operator mirror
- * at the new offset — exactly AgentDetail's read-seam split), and the compose form fires `compose`
- * (the cockpit maps it onto the compose verb). This surface holds neither the read seam nor the
- * verb, so it forwards both — keeping identity a transport fact end-to-end, never authored here.
+ * **Why a relay, not a doer.** The intents the OWNER services live against the authenticated seam:
+ * this surface fires `inboxPageRequest` itself (construction / identity bind — the cockpit reads
+ * the operator mirror; the paging chrome retired with the buffered grid, so the offset is always
+ * 0), and the compose form fires `compose` (the cockpit maps it onto the compose verb). This
+ * surface holds neither the read seam nor the verb — identity stays a transport fact end-to-end,
+ * never authored here.
  *
  * **Capability today = the shipped read-only pane.** The pane is read-only by its own MUST-NOT
  * (operator mark-read would mutate an agent's turn-start signal). The operator's OWN inbox is the
@@ -144,7 +145,6 @@ class OperatorMailbox extends Container {
             inbox = me.getReference('operator-inbox-pane'),
             form  = me.getReference('operator-compose-form');
 
-        inbox?.on('pageRequest', me.onInboxPageRequest, me);
         form?.on('compose', me.onCompose, me);
 
         if (inbox) {
@@ -239,9 +239,11 @@ class OperatorMailbox extends Container {
     }
 
     /**
-     * @summary Relay the inbox's page intent to the owner — the cockpit holds the read seam and
-     * re-reads the operator mirror at the requested offset.
-     * @param {Object} data The pane's `pageRequest` payload (`{offset, source}`).
+     * @summary Fire the inbox read intent to the owner — the cockpit holds the read seam and reads
+     * the operator mirror. Since the paging chrome retired (the buffered grid scrolls), the offset
+     * is always 0 and the ONLY triggers are construction and an identity bind; the event name and
+     * payload shape stay stable for the cockpit's existing wiring.
+     * @param {Object} data The read payload (`{offset}`).
      * @protected
      */
     onInboxPageRequest(data) {

--- a/apps/agentos/view/fleet/mailbox/RowComponent.mjs
+++ b/apps/agentos/view/fleet/mailbox/RowComponent.mjs
@@ -46,21 +46,16 @@ class RowComponent extends Component {
          */
         baseCls: ['fm-mail-row'],
         /**
-         * The row's data surface: one {@link AgentOS.model.MailboxMessage} record (or a plain field
-         * bag with the same keys). Re-assigned on every pool recycle by the column's `component`
-         * factory; `afterSetRecord` rebuilds the vdom in place.
-         * @member {Object|null} record_=null
+         * The row's render surface: a PLAIN bag of the record-derived values (subject, from,
+         * status, priority, taskState, recipientClass, relatedTickets, sentAt, threadFacts),
+         * assembled fresh by the column factory on every pool recycle. Deliberately NOT the record
+         * instance: the engine's component-column contract re-seats pooled cells via `set()`, and
+         * a same-instance record never re-fires its afterSet — a freshly built bag always does
+         * (the bigData example's `text: record.firstname` pattern, generalized to one config).
+         * @member {Object|null} rowData_=null
          * @reactive
          */
-        record_: null,
-        /**
-         * Thread display facts for THIS row, derived by the owning grid from its store-wide thread
-         * map (a cell sees one record and cannot know its thread's shape): `null` for a standalone
-         * row, else `{isHead: Boolean, collapsed: Boolean, hiddenCount: Number, inThread: Boolean}`.
-         * @member {Object|null} threadFacts_=null
-         * @reactive
-         */
-        threadFacts_: null
+        rowData_: null
     }
 
     /**
@@ -80,15 +75,7 @@ class RowComponent extends Component {
      * @param {Object|null} value
      * @param {Object|null} oldValue
      */
-    afterSetRecord(value, oldValue) {
-        this.buildRow()
-    }
-
-    /**
-     * @param {Object|null} value
-     * @param {Object|null} oldValue
-     */
-    afterSetThreadFacts(value, oldValue) {
+    afterSetRowData(value, oldValue) {
         this.buildRow()
     }
 
@@ -102,8 +89,8 @@ class RowComponent extends Component {
     buildRow() {
         const
             me           = this,
-            record       = me.record,
-            facts        = me.threadFacts,
+            record       = me.rowData,
+            facts        = record?.threadFacts,
             {cls, vdom}  = me;
 
         if (!record) {

--- a/apps/agentos/view/fleet/mailbox/RowComponent.mjs
+++ b/apps/agentos/view/fleet/mailbox/RowComponent.mjs
@@ -1,0 +1,188 @@
+import Component  from '../../../../../node_modules/neo.mjs/src/component/Base.mjs';
+import ViewerTime from '../../../util/ViewerTime.mjs';
+
+/**
+ * One designed mailbox row — the merged information-design sketch
+ * (`apps/agentos/design/institution-mailbox-pane.html`, #36/#38) rendered from one
+ * {@link AgentOS.model.MailboxMessage} record.
+ *
+ * @summary The grid cell for {@link AgentOS.view.fleet.mailbox.Grid}: a deliberately FLAT component —
+ * the whole row anatomy (unread mark · sender monogram · content column · viewer-local age) is built
+ * as plain vdom from the record, with zero child components. Flatness is the recycle-atomicity
+ * contract: `grid.column.Component` re-seats pooled cells via silent `set()`, and a child that
+ * updates itself leaves the row's scroll transaction and tears (the engine's `NestedCell` example
+ * documents the hazard; a flat cell cannot exhibit it). The one interactive element — the thread
+ * toggle — is a NATIVE button in the vdom (keyboard-operable, `aria-expanded`); its click is
+ * delegated by the owning grid, never handled here.
+ *
+ * Row grammar (the sketch's contract, all writer-guaranteed fields — no phantom states):
+ * - `status` — `unread` lifts the subject to weight + ink and fills the dot (two channels,
+ *   WCAG 1.4.1); `retracted` strikes the subject on readable ink and names itself in the strip.
+ * - `subject` — the ONE body-tier line, escaped text only (the adapter's redaction contract).
+ * - `sentAt` — T5: viewer-local text via {@link AgentOS.util.ViewerTime}, exact ISO on `title`.
+ * - exception strip — chips render ONLY for deviations (T2 exception-only): `high`/`low` priority,
+ *   an A2A `taskState` envelope, a non-direct `recipientClass`; a direct/normal/plain/read message
+ *   renders two quiet lines and zero chips.
+ * - thread — a head renders the toggle (`+N earlier` collapsed · `collapse thread` expanded);
+ *   members indent on the rail (grid-fed display facts, derived from the store's thread map).
+ *
+ * @class AgentOS.view.fleet.mailbox.RowComponent
+ * @extends Neo.component.Base
+ */
+class RowComponent extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.mailbox.RowComponent'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.mailbox.RowComponent',
+        /**
+         * @member {String} ntype='fm-mailbox-row'
+         * @protected
+         */
+        ntype: 'fm-mailbox-row',
+        /**
+         * @member {String[]} baseCls=['fm-mail-row']
+         */
+        baseCls: ['fm-mail-row'],
+        /**
+         * The row's data surface: one {@link AgentOS.model.MailboxMessage} record (or a plain field
+         * bag with the same keys). Re-assigned on every pool recycle by the column's `component`
+         * factory; `afterSetRecord` rebuilds the vdom in place.
+         * @member {Object|null} record_=null
+         * @reactive
+         */
+        record_: null,
+        /**
+         * Thread display facts for THIS row, derived by the owning grid from its store-wide thread
+         * map (a cell sees one record and cannot know its thread's shape): `null` for a standalone
+         * row, else `{isHead: Boolean, collapsed: Boolean, hiddenCount: Number, inThread: Boolean}`.
+         * @member {Object|null} threadFacts_=null
+         * @reactive
+         */
+        threadFacts_: null
+    }
+
+    /**
+     * @summary The sender monogram: the first two characters of the handle's last dash segment
+     * (`@neo-gpt-emmy` → `em`, `@tobiu` → `to`) — a deterministic, view-local derivation. Family
+     * hue joins only if the adapter ever ships a family field; never guessed from the handle.
+     * @param {String} from The canonical `@`-form sender.
+     * @returns {String}
+     */
+    static monogram(from) {
+        const segments = String(from || '').replace(/^@/, '').split('-');
+
+        return segments[segments.length - 1].slice(0, 2)
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     */
+    afterSetRecord(value, oldValue) {
+        this.buildRow()
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     */
+    afterSetThreadFacts(value, oldValue) {
+        this.buildRow()
+    }
+
+    /**
+     * @summary Rebuild the full row vdom from the record + thread facts — one atomic update.
+     *
+     * The exception strip is assembled first and only mounted when it has content: absence of
+     * deviation earns zero pixels, and an empty strip element would still cost its gap.
+     * @protected
+     */
+    buildRow() {
+        const
+            me           = this,
+            record       = me.record,
+            facts        = me.threadFacts,
+            {cls, vdom}  = me;
+
+        if (!record) {
+            vdom.cn = [];
+            me.update();
+            return
+        }
+
+        const
+            unread    = record.status === 'unread',
+            retracted = record.status === 'retracted',
+            stamp     = ViewerTime.formatViewerTime(record.sentAt),
+            strip     = [];
+
+        // the exception strip: every entry is a deviation from direct/normal/plain — T2 exception-only
+        if (record.priority === 'high' || record.priority === 'low') {
+            strip.push({tag: 'span', cls: ['fm-mail-chip', `fm-mail-prio-${record.priority}`], text: record.priority})
+        }
+
+        if (record.taskState) {
+            strip.push({tag: 'span', cls: ['fm-mail-chip', 'fm-mail-task'], text: `task · ${record.taskState}`})
+        }
+
+        if (record.recipientClass && record.recipientClass !== 'agent') {
+            strip.push({tag: 'span', cls: ['fm-mail-chip', 'fm-mail-bcast'], text: record.recipientClass})
+        }
+
+        if (facts?.isHead) {
+            strip.push({
+                tag            : 'button',
+                type           : 'button',
+                cls            : ['fm-mail-thread-toggle'],
+                'aria-expanded': String(!facts.collapsed),
+                'aria-label'   : facts.collapsed
+                    ? `Expand thread — ${facts.hiddenCount} earlier messages`
+                    : 'Collapse thread',
+                text: facts.collapsed ? `+${facts.hiddenCount} earlier` : 'collapse thread'
+            })
+        }
+
+        if (retracted) {
+            strip.push({tag: 'span', cls: ['fm-mail-tickets'], text: 'retracted'})
+        } else if (record.relatedTickets?.length) {
+            const
+                tickets  = record.relatedTickets,
+                shown    = tickets.slice(0, 2).map(id => `#${id}`).join(' · '),
+                overflow = tickets.length > 2 ? ` +${tickets.length - 2}` : '';
+
+            strip.push({tag: 'span', cls: ['fm-mail-tickets'], text: shown + overflow})
+        }
+
+        me[unread    ? 'addCls' : 'removeCls']('is-unread');
+        me[retracted ? 'addCls' : 'removeCls']('status-retracted');
+        me[facts?.inThread ? 'addCls' : 'removeCls']('is-in-thread');
+
+        vdom.cn = [{
+            tag: 'span',
+            cls: ['fm-mail-udot'],
+            ...(unread ? {title: 'unread in the subject agent\'s queue'} : {})
+        }, {
+            tag : 'span',
+            cls : ['fm-mail-smark'],
+            text: RowComponent.monogram(record.from)
+        }, {
+            cls: ['fm-mail-content'],
+            cn : [
+                {cls: ['fm-mail-sender'],  text: record.from},
+                {cls: ['fm-mail-subject'], text: record.subject || '(no subject)'},
+                ...(strip.length > 0 ? [{cls: ['fm-mail-xstrip'], cn: strip}] : [])
+            ]
+        }, {
+            tag : 'span',
+            cls : ['fm-mail-age'],
+            text: stamp?.text ?? '',
+            ...(stamp?.title ? {title: stamp.title} : {})
+        }];
+
+        me.update()
+    }
+}
+
+export default Neo.setupClass(RowComponent);

--- a/resources/scss/src/apps/agentos/fleet/mailbox/Container.scss
+++ b/resources/scss/src/apps/agentos/fleet/mailbox/Container.scss
@@ -29,37 +29,6 @@
         color      : var(--fm-ink);
     }
 
-    /* the page window (offset–count) — mono, subordinate; only rendered in rows mode */
-    .fm-mailbox-page {
-        flex       : none;
-        gap        : 2px;
-        align-items: center;
-        font       : var(--fm-text-micro);
-        color      : var(--fm-ink-dim);
-    }
-
-    /* the two page steps are quiet icon controls — never the stock primary slab; the disabled
-       edge keeps the glyph and drops the affordance (button.Base owns the semantic state) */
-    .neo-button.fm-mailbox-page-step {
-        background: transparent;
-        border    : 0;
-        box-shadow: none;
-        color     : var(--fm-ink-dim);
-        min-width : 0;
-
-        &:hover:not(.neo-disabled) {
-            color: var(--fm-ink);
-        }
-
-        &.neo-disabled {
-            opacity: 0.4;
-        }
-
-        .neo-button-glyph {
-            color: inherit;
-        }
-    }
-
     /* the freshness ledger chip — the S1 vocabulary, verbatim from the AgentDetail sibling so the
        cockpit speaks ONE freshness language in both mounts (values must not drift; see
        AgentDetail.scss for the tone rationale incl. the .is-lost AA treatment) */
@@ -111,91 +80,10 @@
         }
     }
 
-    .fm-mailbox-rows {
+    /* the rows body is the buffered mailbox grid (Grid.scss owns the designed row anatomy);
+       this skin only slots it into the pane's vertical rhythm */
+    .fm-mailbox-grid {
         overflow  : auto;
         min-height: 0;
-    }
-
-    /* one message row — an immutable timestamped fact: subject line over a mono meta line.
-       NO hover affordance beyond the thread head (the only interactive surface). */
-    .fm-mail-row {
-        padding      : 6px var(--fm-space-2);
-        border       : 1px solid var(--fm-line-soft);
-        border-radius: 6px;
-        background   : var(--fm-panel);
-
-        & + .fm-mail-row,
-        & + .fm-mail-thread {
-            margin-top: 6px;
-        }
-
-        /* unread is the SUBJECT AGENT's queue fact (never operator state) — a signal-tinted
-           left edge, no count, no badge */
-        &.is-unread {
-            border-left: 2px solid var(--fm-signal);
-        }
-
-        &.is-in-thread {
-            margin-left: 14px;
-        }
-    }
-
-    .fm-mail-row-main {
-        display    : flex;
-        gap        : var(--fm-space-2);
-        align-items: baseline;
-    }
-
-    .fm-mail-subject {
-        flex         : 1;
-        font         : var(--fm-text-body);
-        color        : var(--fm-ink);
-        overflow     : hidden;
-        white-space  : nowrap;
-        text-overflow: ellipsis;
-    }
-
-    /* the thread-collapse chip on a thread head — the pane's single affordance; a NATIVE button,
-       so the reset strips the stock button chrome down to the pill */
-    .fm-mail-thread-count {
-        flex         : none;
-        border       : 0;
-        cursor       : pointer;
-        font         : var(--fm-text-micro);   /* 9px → micro: the ruled deliberate growth */
-        line-height  : 1;
-        padding      : 2px 7px;
-        border-radius: 999px;
-        color        : var(--fm-ink-dim);
-        background   : color-mix(in srgb, currentColor 12%, transparent);
-
-        &:hover {
-            color: var(--fm-ink);
-        }
-
-        &:focus-visible {
-            outline       : 2px solid var(--fm-signal);
-            outline-offset: 1px;
-        }
-    }
-
-    .fm-mail-thread-head {
-        cursor: pointer;
-    }
-
-    .fm-mail-thread {
-        & + .fm-mail-row,
-        & + .fm-mail-thread {
-            margin-top: 6px;
-        }
-
-        > .fm-mail-row + .fm-mail-row {
-            margin-top: var(--fm-space-1);
-        }
-    }
-
-    .fm-mail-row-meta {
-        margin-top: 3px;
-        font      : var(--fm-text-micro);   /* 9px → micro: the ruled deliberate growth */
-        color     : var(--fm-ink-dim);
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
+++ b/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
@@ -25,6 +25,11 @@
         gap                  : 0 var(--fm-space-2);
         align-items          : start;
         width                : 100%;
+        /* height-NORMED to the tallest designed case for the engine's fixed row lattice —
+           = the grid's rowHeight config (mailbox/Grid.mjs); change one, change both. Quieter
+           rows keep the rhythm with whitespace; overflow clamps, never grows. */
+        height               : 84px;
+        overflow             : hidden;
         padding              : var(--fm-space-2) var(--fm-space-3);
         border-bottom        : 1px solid var(--fm-line-soft);
 

--- a/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
+++ b/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
@@ -1,0 +1,151 @@
+/* The mailbox grid — the designed row anatomy from the merged sketch
+   (apps/agentos/design/institution-mailbox-pane.html, #36/#38) over Neo.grid.Container.
+   §04 contracts: T1 role tokens only (zero font-size literals — the pass's greppable acceptance),
+   T2 chip geometry via the family tokens, information-bearing text floors at --fm-ink-dim
+   (5.90:1 on panel; --fm-ink-faint is decorative-only), no paging chrome anywhere. */
+.fm-mailbox-grid {
+
+    /* a headerless designed list, not a data table: the single component column needs no header
+       row — hidden at the skin layer (the engine offers no headerless config today; recorded) */
+    .neo-grid-header-toolbar {
+        display: none;
+    }
+
+    /* ── the designed row: [unread mark] [monogram] [content] [age] ── */
+    .fm-mail-row {
+        display              : grid;
+        grid-template-columns: 10px 24px 1fr auto;
+        gap                  : 0 var(--fm-space-2);
+        align-items          : start;
+        width                : 100%;
+        padding              : var(--fm-space-2) var(--fm-space-3);
+        border-bottom        : 1px solid var(--fm-line-soft);
+
+        /* unread: the subject agent's QUEUE FACT (never operator state) — dot + weight,
+           two channels per WCAG 1.4.1 */
+        &.is-unread {
+            .fm-mail-udot    { background: var(--fm-signal); }
+            .fm-mail-subject { font-weight: 600; color: var(--fm-ink); }
+        }
+
+        /* retracted: the strike is the state channel; the words keep readable ink */
+        &.status-retracted .fm-mail-subject {
+            text-decoration: line-through;
+        }
+
+        /* thread members indent on the rail — the rail, not repetition, says "same conversation" */
+        &.is-in-thread {
+            margin-left: calc(var(--fm-space-3) + 10px + var(--fm-space-2));
+            border-left: 2px solid var(--fm-line-soft);
+            padding-left: var(--fm-space-2);
+        }
+    }
+
+    .fm-mail-udot {
+        width        : 7px;
+        height       : 7px;
+        margin-top   : 5px;
+        border-radius: 50%;
+        background   : transparent;
+    }
+
+    /* sender monogram — deterministic view derivation from the handle; the fill may stay faint
+       (decorative), the letters ride dim */
+    .fm-mail-smark {
+        display       : grid;
+        place-items   : center;
+        width         : 24px;
+        height        : 24px;
+        border-radius : 50%;
+        background    : var(--fm-panel-2, color-mix(in srgb, var(--fm-ink-dim) 10%, transparent));
+        border        : 1px solid var(--fm-line);
+        font          : var(--fm-text-micro);
+        color         : var(--fm-ink-dim);
+        text-transform: uppercase;
+    }
+
+    .fm-mail-content {
+        min-width: 0;
+    }
+
+    .fm-mail-sender {
+        font : var(--fm-text-detail);
+        color: var(--fm-ink-dim);
+    }
+
+    /* the ONE body-tier line, 2-line clamp — escaped text only */
+    .fm-mail-subject {
+        font              : var(--fm-text-body);
+        color             : var(--fm-ink-dim);
+        margin-top        : 1px;
+        overflow          : hidden;
+        display           : -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+    }
+
+    /* the exception strip: chips render ONLY for deviations (T2 exception-only) */
+    .fm-mail-xstrip {
+        display    : flex;
+        flex-wrap  : wrap;
+        align-items: center;
+        gap        : var(--fm-space-1);
+        margin-top : 3px;
+    }
+
+    .fm-mail-chip {
+        position     : relative;
+        font         : var(--fm-text-micro);
+        color        : var(--fm-ink-dim);
+        border       : 1px solid var(--fm-line);
+        border-radius: var(--fm-chip-radius, 4px);
+        padding      : var(--fm-chip-pad-y, 2px) var(--fm-chip-pad-x, 8px);
+        padding-left : calc(var(--fm-chip-pad-x, 8px) + var(--fm-chip-mark-w, 3px) + 3px);
+
+        /* the T2 mark: severity/kind rides ONE custom property; the word carries the message */
+        &::before {
+            content      : "";
+            position     : absolute;
+            left         : 0;
+            top          : 0;
+            bottom       : 0;
+            width        : var(--fm-chip-mark-w, 3px);
+            border-radius: var(--fm-chip-radius, 4px) 0 0 var(--fm-chip-radius, 4px);
+            background   : var(--fm-mail-chip-mark, var(--fm-ink-faint));
+        }
+    }
+
+    .fm-mail-prio-high { --fm-mail-chip-mark: var(--fm-state-limited); color: var(--fm-ink); }
+    .fm-mail-task      { --fm-mail-chip-mark: var(--fm-signal); }
+    /* the broadcast/other class chip keeps the neutral decorative mark */
+
+    .fm-mail-tickets {
+        font : var(--fm-text-micro);
+        color: var(--fm-ink-dim);
+    }
+
+    /* the thread toggle — the row's ONE affordance, a native button (keyboard-operable) */
+    .fm-mail-thread-toggle {
+        font         : var(--fm-text-micro);
+        color        : var(--fm-ink-dim);
+        border       : 1px solid var(--fm-line);
+        border-radius: var(--fm-chip-radius, 4px);
+        padding      : var(--fm-chip-pad-y, 2px) var(--fm-chip-pad-x, 8px);
+        background   : transparent;
+        cursor       : pointer;
+
+        &:hover {
+            border-color: var(--fm-ink-dim);
+            color       : var(--fm-ink);
+        }
+    }
+
+    /* age: T5 viewer-local — same-day time-only, older compact date; exact ISO on title */
+    .fm-mail-age {
+        font       : var(--fm-text-micro);
+        color      : var(--fm-ink-dim);
+        margin-top : 3px;
+        white-space: nowrap;
+        text-align : right;
+    }
+}

--- a/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
+++ b/resources/scss/src/apps/agentos/fleet/mailbox/Grid.scss
@@ -6,9 +6,16 @@
 .fm-mailbox-grid {
 
     /* a headerless designed list, not a data table: the single component column needs no header
-       row — hidden at the skin layer (the engine offers no headerless config today; recorded) */
+       row — COLLAPSED at the skin layer, never display:none: the header toolbar is the engine's
+       measuring instrument for flex-sized columns ("only the DOM can answer", grid/header/Toolbar),
+       so it must keep its WIDTH in the layout while costing zero height. (No headerless grid
+       config exists engine-side today; recorded.) */
     .neo-grid-header-toolbar {
-        display: none;
+        height    : 0;
+        min-height: 0;
+        overflow  : hidden;
+        border    : 0;
+        padding   : 0;
     }
 
     /* ── the designed row: [unread mark] [monogram] [content] [age] ── */

--- a/test/playwright/component/apps/agentos/MailboxGridSeam.spec.mjs
+++ b/test/playwright/component/apps/agentos/MailboxGridSeam.spec.mjs
@@ -1,0 +1,123 @@
+import {test, expect} from '@playwright/test';
+
+let paneId;
+
+/**
+ * @summary The mounted Grid→pooled-row seam witness (#40 / PR #41 RA-3): a populated mailbox pane
+ * rendering through the REAL pipeline — `Neo.grid.Container` → `grid.column.Component` → the pooled
+ * {@link AgentOS.view.fleet.mailbox.RowComponent} — in a browser, across the worker boundary.
+ *
+ * What only this layer can prove (the Node unit specs assert instances and direct method calls):
+ * 1. the component column actually materializes pooled row cells into the DOM from store records;
+ * 2. a snapshot swap RECYCLES those cells — the same mounted surface re-seats `record` (subjects
+ *    swap in place) and `threadFacts` (a toggle appears when a thread arrives);
+ * 3. the thread toggle works through the REAL delegated event path — a genuine click on the native
+ *    button inside the grid row, resolved via the engine's `.neo-grid-row` `data.recordId` contract.
+ *
+ * All assertions are text/count checks — no fonts, no colors, no geometry.
+ */
+test.describe('AgentOS.view.fleet.mailbox — the mounted Grid → pooled RowComponent seam', () => {
+    const CAPTURED_AT = '2026-07-16T12:00:00.000Z';
+
+    const row = (id, subject, overrides = {}) => ({
+        messageId     : id,
+        subject,
+        from          : '@neo-gpt-emmy',
+        recipientClass: 'agent',
+        priority      : 'normal',
+        status        : 'read',
+        taskState     : null,
+        partOfThread  : null,
+        relatedTickets: [],
+        wakeSuppressed: false,
+        sentAt        : '2026-07-16T11:00:00.000Z',
+        readAt        : null,
+        ...overrides
+    });
+
+    const snapshot = rows => ({
+        capability: {source: 'memory-core:mailbox', state: 'wired', confidence: 'observed', capturedAt: CAPTURED_AT, reason: null},
+        admission : {state: 'granted', viewerIdentity: '@tobiu', subjectAgentId: '@neo-opus-vega', checkedAt: CAPTURED_AT, reason: null},
+        rows,
+        page      : {limit: 50, offset: 0, count: rows.length, hasMore: false}
+    });
+
+    test.beforeEach(async ({page}) => {
+        await page.goto('test/playwright/component/apps/empty-viewport/index.html');
+        await page.waitForSelector('#component-test-viewport', {state: 'attached'});
+    });
+
+    test.afterEach(async ({page}) => {
+        if (paneId) {
+            await page.evaluate(id => Neo.worker.App.destroyNeoInstance(id), paneId);
+            paneId = null;
+        }
+    });
+
+    test('pooled cells render, recycle onto new records + thread facts, and the real toggle click expands', async ({page}) => {
+        const result = await page.evaluate(config => Neo.worker.App.createNeoInstance(config), {
+            importPath: '../../../../apps/agentos/view/fleet/mailbox/Container.mjs',
+            ntype     : 'fm-mailbox-pane',
+            parentId  : 'component-test-viewport',
+            height    : 400,
+            record    : {agentId: 'vega', githubUsername: 'neo-opus-vega'},
+            snapshot  : snapshot([
+                row('MESSAGE:a', 'first window alpha'),
+                row('MESSAGE:b', 'first window beta', {sentAt: '2026-07-16T10:00:00.000Z'})
+            ])
+        });
+
+        if (!result.success) {
+            throw new Error(`Component creation failed: ${result.error.message}`);
+        }
+
+        paneId = result.id;
+
+        // 1. the REAL pipeline materialized pooled row cells into the DOM. The grid renders only
+        //    after its measurement cycle settles (the engine's own grid e2e waits up to 60s for
+        //    first rows) — wait for the first cell before asserting counts.
+        await page.waitForSelector('.fm-mail-row', {timeout: 30000});
+
+        const rows = page.locator('.fm-mail-row:visible');
+        await expect(rows).toHaveCount(2);
+        await expect(page.locator('.fm-mail-row:visible .fm-mail-subject').nth(0)).toHaveText('first window alpha');
+        await expect(page.locator('.fm-mail-row:visible .fm-mail-subject').nth(1)).toHaveText('first window beta');
+
+        // 2. RECYCLE: a new snapshot re-seats the SAME mounted surface — subjects swap in place,
+        //    and a thread head arrives carrying its toggle (threadFacts reached the pooled cell)
+        await page.evaluate(([id, snap]) => Neo.worker.App.setConfigs({id, snapshot: snap}), [paneId, snapshot([
+            row('MESSAGE:h', 'thread newest', {partOfThread: 'THREAD:x', status: 'unread'}),
+            row('MESSAGE:m', 'thread earlier', {partOfThread: 'THREAD:x', sentAt: '2026-07-16T10:30:00.000Z'}),
+            row('MESSAGE:s', 'standalone gamma', {sentAt: '2026-07-16T09:00:00.000Z'})
+        ])]);
+
+        // collapsed: head + standalone visible, the member hidden by the store filter
+        await expect(page.locator('.fm-mail-row:visible')).toHaveCount(2);
+        await expect(page.locator('.fm-mail-row:visible .fm-mail-subject').nth(0)).toHaveText('thread newest');
+
+        const toggle = page.locator('.fm-mail-thread-toggle:visible');
+        await expect(toggle).toHaveCount(1);
+        await expect(toggle).toHaveText('+1 earlier');
+        await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+        // 3. the REAL delegated event path: a genuine bubbling DOM click on the native button —
+        //    the grid's delegated listener resolves the record via `.neo-grid-row` data.recordId
+        //    and flips the view-owned collapse state; the member materializes. Dispatched rather
+        //    than pointer-synthesized: the engine's GridDragScroll layer sits over the rows and
+        //    preventDefaults every mousedown, so raw pointer clicks land on the layer, not the
+        //    button — an ENGINE seam (filed as a defect-note; bigData's cell buttons share it),
+        //    deliberately not worked around here with force-clicks that would test nothing.
+        await toggle.dispatchEvent('click');
+
+        // visible-row truth comes from the store filter, not a DOM node count — the component
+        // pool legitimately keeps recycled cells in hidden rows
+        await expect(page.locator('.fm-mail-thread-toggle:visible')).toHaveText('collapse thread');
+        await expect(page.locator('.fm-mail-thread-toggle:visible')).toHaveAttribute('aria-expanded', 'true');
+        await expect(page.locator('.fm-mail-row:visible .fm-mail-subject').nth(1)).toHaveText('thread earlier');
+
+        // and back: collapse hides the member again through the same path
+        await page.locator('.fm-mail-thread-toggle:visible').first().dispatchEvent('click');
+        await expect(page.locator('.fm-mail-thread-toggle:visible')).toHaveText('+1 earlier');
+        await expect(page.locator('.fm-mail-thread-toggle:visible')).toHaveAttribute('aria-expanded', 'false')
+    });
+});

--- a/test/playwright/unit/apps/agentos/store/agentMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/store/agentMailbox.spec.mjs
@@ -57,11 +57,13 @@ test.describe('AgentOS.store.AgentMailbox — the mailbox mirror data plane', ()
         })])
     }
 
-    test('applySnapshotRows accepts the frozen adapter rows verbatim, keyed by messageId, newest first', () => {
+    test('the data setter accepts the frozen adapter rows verbatim, keyed by messageId, newest first', () => {
         const store = Neo.create(AgentMailboxStore);
         const rows  = frozenAdapterRows();
 
-        store.applySnapshotRows(rows);
+        // the pane projects plain bags straight into the data setter (the grid's one data path);
+        // the store layer's own contract is sorter + key + model conversion
+        store.data = rows.map(row => ({...row}));
 
         expect(store.getCount()).toBe(2);
         // the sorter renders flat-chrono newest-first regardless of input order
@@ -77,7 +79,7 @@ test.describe('AgentOS.store.AgentMailbox — the mailbox mirror data plane', ()
         expect(record.status).toBe('unread');
         expect(record.taskState).toBe('Submitted');
         expect(record.readAt).toBe(null);
-        // the frozen input array was cloned, never mutated
+        // the frozen adapter rows were never mutated (the projection spreads per bag)
         expect(Object.isFrozen(rows)).toBe(true);
         expect(rows[0].threadCollapsed).toBe(undefined);
 
@@ -87,24 +89,24 @@ test.describe('AgentOS.store.AgentMailbox — the mailbox mirror data plane', ()
     test('a new snapshot replaces wholesale — rows are timestamped facts, not merge targets', () => {
         const store = Neo.create(AgentMailboxStore);
 
-        store.applySnapshotRows(frozenAdapterRows());
+        store.data = frozenAdapterRows().map(row => ({...row}));
         expect(store.getCount()).toBe(2);
 
-        store.applySnapshotRows([{
+        store.data = [{
             messageId     : 'MESSAGE:third',
             subject       : 'fresh snapshot',
             from          : '@neo-fable',
             recipientClass: 'agent',
             status        : 'unread',
             sentAt        : '2026-07-16T13:00:00.000Z'
-        }]);
+        }];
 
         expect(store.getCount()).toBe(1);
         expect(store.items[0].messageId).toBe('MESSAGE:third');
         // display state initializes fresh: thread heads start collapsed by model default
         expect(store.items[0].threadCollapsed).toBe(true);
 
-        store.applySnapshotRows(null);
+        store.data = [];
         expect(store.getCount()).toBe(0);
 
         store.destroy()
@@ -115,14 +117,14 @@ test.describe('AgentOS.store.AgentMailbox — the mailbox mirror data plane', ()
 
         const store = Neo.create(AgentMailboxStore);
 
-        store.applySnapshotRows([{
+        store.data = [{
             messageId     : 'MESSAGE:bare',
             subject       : 'minimal row',
             from          : '@neo-gpt',
             recipientClass: 'agent',
             status        : 'unread',
             sentAt        : '2026-07-16T09:00:00.000Z'
-        }]);
+        }];
 
         const record = store.get('MESSAGE:bare');
 

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/container.spec.mjs
@@ -96,8 +96,6 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         expect(stateCmp.text).toContain('@neo-observer');
         expect(stateCmp.text).toContain('@neo-opus-vega');
         expect(stateCmp.cls).toContain('is-denied');
-        // a denial NEVER shows a page window — that would fake a readable inbox
-        expect(pane.getReference('mailbox-page').hidden).toBe(true);
         expect(pane.getReference('mailbox-rows').hidden).toBe(true);
 
         pane.destroy()
@@ -161,7 +159,8 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
 
         expect(ada.getPaneState(), "vega's mail must not render on ada's pane").toBe('unobserved');
         expect(ada.getReference('mailbox-rows').hidden).toBe(true);
-        expect(JSON.stringify(ada.getReference('mailbox-rows').vdom)).not.toContain('VEGA PRIVATE MAIL');
+        // the inadmissible snapshot never reaches the grid's store — no row can materialize
+        expect(ada.store.getCount()).toBe(0);
         ada.destroy();
 
         // an EMPTY snapshot about someone else is equally inadmissible: rendering it would say
@@ -242,15 +241,14 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
             expect(pane.getPaneState()).toBe('degraded');
             expect(text, 'the owner reason is carried verbatim').toContain(reason);
             expect(text, 'no fabricated source-outage attribution').not.toContain('source degraded');
-            // a refusal shows no rows and no page window — never a half-truth
+            // a refusal shows no rows — never a half-truth
             expect(pane.getReference('mailbox-rows').hidden).toBe(true);
-            expect(pane.getReference('mailbox-page').hidden).toBe(true);
 
             pane.destroy()
         })
     });
 
-    test('rows: newest-first flat-chrono, page bounds shown, fresh chip from capturedAt', () => {
+    test('rows: the full window projects into the grid store newest-first, fresh chip from capturedAt', () => {
         const pane = createPane({
             snapshot: wiredSnapshot([
                 row({messageId: 'MESSAGE:old', subject: 'older', sentAt: '2026-07-16T10:00:00.000Z'}),
@@ -261,55 +259,77 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         expect(pane.getPaneState()).toBe('rows');
         expect(pane.getReference('mailbox-state').hidden).toBe(true);
 
-        const rowsCmp = pane.getReference('mailbox-rows');
-        expect(rowsCmp.hidden).toBe(false);
-        expect(rowsCmp.vdom.cn).toHaveLength(2);
-        expect(rowsCmp.vdom.cn[0].cn[0].cn[0].text).toBe('newer');
-        expect(rowsCmp.vdom.cn[1].cn[0].cn[0].text).toBe('older');
+        // the rows body is the buffered grid: visible, fed the FULL snapshot window through the
+        // pane-owned store (newest-first is the store's binding sort), no paging chrome anywhere
+        const rowsGrid = pane.getReference('mailbox-rows');
+        expect(rowsGrid.hidden).toBe(false);
+        expect(rowsGrid.store).toBe(pane.store);
+        expect(pane.store.getCount()).toBe(2);
+        expect(pane.store.getAt(0).subject).toBe('newer');
+        expect(pane.store.getAt(1).subject).toBe('older');
+        expect(pane.getReference('mailbox-page')).toBeNull();
 
-        // the bounds now live in the range span, between their two transition controls
-        expect(pane.getReference('mailbox-page-range').text).toBe('1–2');
         // capturedAt is 30s old vs a 60s TTL → fresh
         expect(pane.getReference('mailbox-freshness').text).toContain('updated');
 
         pane.destroy()
     });
 
-    test('thread-collapse: the NEWEST message heads the collapsed row over a +N earlier chip; toggle expands inline', () => {
+    test('thread-collapse is grid truth: the NEWEST message heads the thread, collapsed members hide via the store filter', () => {
         const pane = createPane({
             snapshot: wiredSnapshot([
-                row({messageId: 'MESSAGE:t1', subject: 'thread oldest', partOfThread: 'THREAD:x', sentAt: '2026-07-16T09:00:00.000Z'}),
                 row({messageId: 'MESSAGE:t3', subject: 'thread newest', partOfThread: 'THREAD:x', sentAt: '2026-07-16T11:00:00.000Z'}),
                 row({messageId: 'MESSAGE:t2', subject: 'thread middle', partOfThread: 'THREAD:x', sentAt: '2026-07-16T10:00:00.000Z'}),
+                row({messageId: 'MESSAGE:t1', subject: 'thread oldest', partOfThread: 'THREAD:x', sentAt: '2026-07-16T09:00:00.000Z'}),
                 row({messageId: 'MESSAGE:solo', subject: 'standalone', sentAt: '2026-07-16T11:45:00.000Z'})
             ], {limit: 50, offset: 0, count: 4})
         });
 
-        const rowsCmp = pane.getReference('mailbox-rows');
+        const
+            rowsGrid = pane.getReference('mailbox-rows'),
+            head     = pane.store.get('MESSAGE:t3');
 
-        // standalone (newest overall) first, then ONE collapsed thread row
-        expect(rowsCmp.vdom.cn).toHaveLength(2);
-        expect(rowsCmp.vdom.cn[0].cn[0].cn[0].text).toBe('standalone');
+        // the grid's thread map: store order is newest-first, so the newest message heads its
+        // thread — the shipped reading order, pinned (Grace's steer, kept)
+        const headFacts = rowsGrid.threadFactsFor(head);
+        expect(headFacts).toEqual({collapsed: true, isHead: true, hiddenCount: 2, inThread: false});
 
-        const collapsedHead = rowsCmp.vdom.cn[1];
-        // Grace's steer pinned: the NEWEST thread message heads the collapsed row
-        expect(collapsedHead.cn[0].cn[0].text).toBe('thread newest');
-        expect(collapsedHead.cn[0].cn[1].text).toBe('+2 earlier');
-        expect(collapsedHead.cls).toContain('fm-mail-thread-head');
-        expect(collapsedHead.data).toEqual({threadId: 'THREAD:x'});
+        // collapsed members hide at the store view layer: the filtered count carries head + solo only
+        expect(pane.store.getCount()).toBe(2);
+        expect(rowsGrid.threadFactsFor(pane.store.get('MESSAGE:solo'))).toBeNull();
 
-        // toggle = display-state navigation, never a data write
-        const head = pane.store.get('MESSAGE:t3');
+        // toggle = display-state navigation on the view-owned field, never a data write
         head.threadCollapsed = false;
-        pane.renderRows();
+        rowsGrid.onStoreMutation();
 
-        const thread = rowsCmp.vdom.cn[1];
-        expect(thread.cls).toContain('fm-mail-thread');
-        expect(thread.cn).toHaveLength(3);
-        expect(thread.cn[0].cn[0].cn[0].text).toBe('thread newest');
-        expect(thread.cn[1].cn[0].cn[0].text).toBe('thread middle');
-        expect(thread.cn[2].cn[0].cn[0].text).toBe('thread oldest');
-        expect(thread.cn[1].cls).toContain('is-in-thread');
+        expect(pane.store.getCount()).toBe(4);
+        expect(rowsGrid.threadFactsFor(head).collapsed).toBe(false);
+        expect(rowsGrid.threadFactsFor(pane.store.get('MESSAGE:t2'))).toEqual({collapsed: false, isHead: false, hiddenCount: 2, inThread: true});
+
+        pane.destroy()
+    });
+
+    test('the grid toggle click resolves its record through the engine row contract and flips collapse', () => {
+        const pane = createPane({
+            snapshot: wiredSnapshot([
+                row({messageId: 'MESSAGE:h', partOfThread: 'THREAD:z', sentAt: '2026-07-16T11:00:00.000Z'}),
+                row({messageId: 'MESSAGE:m', partOfThread: 'THREAD:z', sentAt: '2026-07-16T10:00:00.000Z'})
+            ], {limit: 50, offset: 0, count: 2})
+        });
+
+        const rowsGrid = pane.getReference('mailbox-rows');
+
+        expect(pane.store.getCount()).toBe(1);
+
+        // the grid body stamps `data.recordId` on every `.neo-grid-row` — the delegated toggle
+        // click walks the path to that node, no index math
+        rowsGrid.onThreadToggleClick({path: [
+            {cls: ['fm-mail-thread-toggle']},
+            {cls: ['neo-grid-row'], data: {recordId: 'MESSAGE:h'}}
+        ]});
+
+        expect(pane.store.get('MESSAGE:h').threadCollapsed).toBe(false);
+        expect(pane.store.getCount()).toBe(2);
 
         pane.destroy()
     });
@@ -340,11 +360,13 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         walk(pane.getReference('mailbox-rows').vdom);
         walk(pane.getReference('mailbox-state').vdom);
 
-        // 2. the single listener surface is the thread-collapse toggle — and it is delegated to the
-        //    BUTTON, not the row: a row-wide listener is an interactive region with no tab stop
-        const listeners = pane.getReference('mailbox-rows').domListeners;
-        expect(listeners).toHaveLength(1);
-        expect(listeners[0].delegate).toBe('.fm-mail-thread-toggle');
+        // 2. the pane's mutation-capable listener surface is exactly ONE delegated click on the
+        //    grid, and it targets the toggle BUTTON, not the row (a row-wide listener is an
+        //    interactive region with no tab stop). The grid may own further engine-internal
+        //    listeners (scroll plumbing) — none of them a mutation affordance.
+        const toggleListeners = (pane.getReference('mailbox-rows').domListeners || [])
+            .filter(listener => listener.delegate === '.fm-mail-thread-toggle');
+        expect(toggleListeners).toHaveLength(1);
 
         // 3. the pane class itself exports no mutation verb
         Object.getOwnPropertyNames(Object.getPrototypeOf(pane)).forEach(name => {
@@ -357,44 +379,22 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         pane.destroy()
     });
 
-    test('pagination TRANSITIONS: row 51 is reachable — the window can move, not just describe itself', () => {
-        const pane  = createPane({snapshot: wiredSnapshot([row({messageId: 'MESSAGE:a'})], {limit: 50, offset: 0, count: 50, hasMore: true})}),
-              fired = [];
+    test('no paging chrome exists — the buffered surface owns the whole window (operator direction 2026-08-28)', () => {
+        const pane = createPane({snapshot: wiredSnapshot(
+            Array.from({length: 50}, (v, i) => row({messageId: `MESSAGE:${i}`, sentAt: `2026-07-16T10:${String(i % 60).padStart(2, '0')}:00.000Z`})),
+            {limit: 50, offset: 0, count: 50, hasMore: true}
+        )});
 
-        pane.on('pageRequest', data => fired.push(data.offset));
+        // the offset-window controls retired with the hand-rolled rows: no references, no handlers
+        expect(pane.getReference('mailbox-page')).toBeNull();
+        expect(pane.getReference('mailbox-page-prev')).toBeNull();
+        expect(pane.getReference('mailbox-page-next')).toBeNull();
+        expect(pane.onNextPageClick).toBeUndefined();
+        expect(pane.fire).toBeDefined();
 
-        const prev  = pane.getReference('mailbox-page-prev'),
-              next  = pane.getReference('mailbox-page-next'),
-              range = pane.getReference('mailbox-page-range');
-
-        // the steps are COMPOSED controls, not hand-rolled tags: `button.Base` with the shipped
-        // paging vocabulary (`fa fa-angle-*`, as toolbar.Paging uses). A raw {tag:'button'} would
-        // reproduce the outcome and skip the primitive that owns disabled/icon/focus states.
-        expect(prev.ntype).toBe('button');
-        expect(next.ntype).toBe('button');
-        expect(prev.iconCls).toBe('fa fa-angle-left');
-        expect(next.iconCls).toBe('fa fa-angle-right');
-
-        // page 1 of a FULL window: newer is disabled (this IS the edge), older is offered
-        expect(prev.disabled).toBe(true);
-        expect(next.disabled).toBe(false);
-        expect(range.text).toBe('1–50');
-
-        // the handler is wired UP to this view (the primitive resolves the string), and the pane
-        // REQUESTS rather than fetching
-        expect(next.handler).toBe('up.onNextPageClick');
-        expect(prev.handler).toBe('up.onPrevPageClick');
-        pane.onNextPageClick();
-        expect(fired).toEqual([50]);
-
-        // page 2, short (the producer ran out): older disables, newer opens, range reflects the window
-        pane.snapshot = wiredSnapshot([row({messageId: 'MESSAGE:b'})], {limit: 50, offset: 50, count: 10, hasMore: false});
-        expect(prev.disabled).toBe(false);
-        expect(next.disabled, 'a short page is the producer saying it ran out').toBe(true);
-        expect(range.text).toBe('51–60');
-
-        pane.onPrevPageClick();
-        expect(fired).toEqual([50, 0]);
+        // the grid store carries the FULL projected window — scrolling reaches every row,
+        // and the honest end of the window is the only end
+        expect(pane.store.getCount()).toBe(50);
 
         pane.destroy()
     });
@@ -424,7 +424,6 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
 
             expect(pane.getPaneState(), JSON.stringify(snapshot)).toBe('unobserved');
             expect(pane.getReference('mailbox-rows').hidden).toBe(true);
-            expect(pane.getReference('mailbox-page').hidden).toBe(true);
 
             pane.destroy()
         })
@@ -457,134 +456,17 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         })
     });
 
-    test('a11y: the icon-only page steps carry an accessible name AND a real disabled semantic', () => {
-        const pane = createPane({snapshot: wiredSnapshot([row({messageId: 'MESSAGE:a'})], {limit: 50, offset: 0, count: 50, hasMore: true})}),
-              prev = pane.getReference('mailbox-page-prev'),
-              next = pane.getReference('mailbox-page-next');
-
-        // a chevron IS the label to a sighted operator and nothing at all to anyone else
-        expect(prev.vdom['aria-label']).toBe('Newer messages');
-        expect(next.vdom['aria-label']).toBe('Older messages');
-
-        // `component.Base.disabled` guarantees the neo-disabled CLASS and no aria-disabled. Without
-        // the explicit ARIA state the closed edge is announced as ENABLED: the operator who most
-        // needs the boundary to be honest is the one it lies to. Any native `disabled` projection
-        // belongs to the Button layer and is deliberately not assumed here.
-        expect(prev.disabled).toBe(true);
-        expect(prev.vdom['aria-disabled']).toBe('true');
-        expect(next.disabled).toBe(false);
-        expect(next.vdom['aria-disabled'] ?? null, 'an open edge must not be announced as disabled').toBe(null);
-
-        // and the semantics track the bounds, not just the first render
-        pane.snapshot = wiredSnapshot([row({messageId: 'MESSAGE:b'})], {limit: 50, offset: 50, count: 10, hasMore: false});
-        expect(prev.vdom['aria-disabled'] ?? null).toBe(null);
-        expect(next.vdom['aria-disabled']).toBe('true');
-
-        pane.destroy()
-    });
-
-    test('a DISABLED step refuses the request — the handler guard closes what the routed gates cannot', () => {
-        // A ROUTED activation never gets this far: `.neo-disabled` sets `pointer-events: none`, and
-        // `manager/DomEvent` breaks its listener walk on a disabled component for every non-resize
-        // event — a keyboard Enter arrives as a click on that same route and stops there too. This
-        // test enters the handler DIRECTLY, which is the one path those gates miss, since
-        // `button.Base.onClick` never consults the config. So what is pinned here is the guard
-        // against programmatic entry — NOT a claim that a real click or keypress reaches the
-        // handler. Unguarded, stepping past the last page reads an empty window at a positive
-        // offset. `aria-disabled` owns the announcement only; it does not remove focus or suppress
-        // activation. The routed gates plus this direct-entry guard own refusal here, while any
-        // native focus/activation behavior remains the Button layer's contract.
-        const pane  = createPane({snapshot: wiredSnapshot([row({messageId: 'MESSAGE:a'})], {limit: 50, offset: 0, count: 50, hasMore: false})}),
-              fired = [];
-
-        pane.on('pageRequest', data => fired.push(data.offset));
-
-        // page 1 AND the last page: both edges closed
-        expect(pane.getReference('mailbox-page-prev').disabled).toBe(true);
-        expect(pane.getReference('mailbox-page-next').disabled).toBe(true);
-
-        // entering the handler directly: the routed gates are BYPASSED here, not defeated
-        pane.onPrevPageClick();
-        pane.onNextPageClick();
-
-        expect(fired, 'a closed edge must refuse the request, not merely look shut').toEqual([]);
-
-        pane.destroy()
-    });
-
-    test('a denial or degrade never fakes a page window', () => {
-        const denied = createPane({snapshot: {
-            capability: {state: 'degraded', confidence: 'none', capturedAt: CAPTURED_AT, reason: 'no grant'},
-            admission : {state: 'denied', viewerIdentity: '@x', subjectAgentId: '@neo-opus-vega', checkedAt: CAPTURED_AT, reason: 'Unauthorized: no CAN_READ_INBOX_OF permission for @neo-gpt'},
-            rows      : [],
-            page      : {limit: 50, offset: 0, count: 0}
-        }});
-
-        // bounds + their transitions are hidden together: a window over data you cannot see is a lie
-        expect(denied.getReference('mailbox-page').hidden).toBe(true);
-        denied.destroy()
-    });
-
-    test('a11y: thread collapse is a NATIVE button that names its state — not a clickable div', () => {
-        const pane = createPane({
-            snapshot: wiredSnapshot([
-                row({messageId: 'MESSAGE:head', partOfThread: 'THREAD:z'}),
-                row({messageId: 'MESSAGE:old', partOfThread: 'THREAD:z', sentAt: '2026-07-16T11:10:00.000Z'})
-            ], {limit: 50, offset: 0, count: 2})
-        });
-
-        const findToggle = () => {
-            let found;
-            const walk = node => {
-                if (!node || typeof node !== 'object') return;
-                node.cls?.includes?.('fm-mail-thread-toggle') && (found = node);
-                (node.cn || []).forEach(walk)
-            };
-            walk(pane.getReference('mailbox-rows').vdom);
-            return found
-        };
-
-        const collapsed = findToggle();
-
-        // a native <button> owns Enter/Space and a tab stop; a div owns neither, so the toggle was
-        // mouse-only — the pane's ONLY affordance was unreachable by keyboard
-        expect(collapsed.tag).toBe('button');
-        expect(collapsed.type).toBe('button');
-        expect(collapsed['aria-expanded']).toBe('false');
-        expect(collapsed['aria-label']).toContain('Expand thread');
-
-        // toggling re-renders the button with the INVERTED state named — not a stale label
-        const head = pane.store.items.find(record => record.partOfThread === 'THREAD:z');
-        head.threadCollapsed = false;
-        pane.renderRows();
-
-        const expanded = findToggle();
-        expect(expanded.tag).toBe('button');
-        expect(expanded['aria-expanded']).toBe('true');
-        expect(expanded['aria-label']).toContain('Collapse thread');
-
-        pane.destroy()
-    });
-
-    test('hostile subjects are DOUBLE-defended: the String field strips markup, the vdom is text-only', () => {
+    test('hostile subjects: the record layer strips markup before any row can render it', () => {
+        // Layer 1 of the double defense (the record String convert strips tags — RecordFactory);
+        // layer 2 (text-only vdom leaves) is pinned per-row in `rowComponent.spec.mjs`, where the
+        // rendering now lives.
         const pane = createPane({
             snapshot: wiredSnapshot([
                 row({messageId: 'MESSAGE:xss', subject: 'deploy <img src=x onerror=alert(1)> done'})
             ], {limit: 50, offset: 0, count: 1})
         });
 
-        // layer 1: Neo's record layer strips tags from every String field (RecordFactory) —
-        // markup never even reaches the view
         expect(pane.store.get('MESSAGE:xss').subject).toBe('deploy  done');
-
-        // layer 2: the vdom carries text leaves only — no node anywhere renders html
-        const walk = node => {
-            if (!node || typeof node !== 'object') return;
-            expect(node.html).toBe(undefined);
-            (node.cn || []).forEach(walk)
-        };
-        walk(pane.getReference('mailbox-rows').vdom);
-        expect(pane.getReference('mailbox-rows').vdom.cn[0].cn[0].cn[0].text).toBe('deploy  done');
 
         pane.destroy()
     });
@@ -613,7 +495,9 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
             ...threadRows()
         ], {limit: 50, offset: 0, count: 3});
         expect(pane.store.get('MESSAGE:j').threadCollapsed).toBe(true);
-        expect(pane.store.get('MESSAGE:h').threadCollapsed).toBe(true);
+        // h is now a COLLAPSED MEMBER (j heads the thread) — hidden from the filtered view by
+        // design, so the assertion reads the unfiltered source
+        expect(pane.store.allItems.get('MESSAGE:h').threadCollapsed).toBe(true);
 
         const store = pane.store;
         pane.destroy();

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/container.spec.mjs
@@ -285,26 +285,32 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
             ], {limit: 50, offset: 0, count: 4})
         });
 
-        const
-            rowsGrid = pane.getReference('mailbox-rows'),
-            head     = pane.store.get('MESSAGE:t3');
+        const rowsGrid = pane.getReference('mailbox-rows');
 
-        // the grid's thread map: store order is newest-first, so the newest message heads its
-        // thread — the shipped reading order, pinned (Grace's steer, kept)
-        const headFacts = rowsGrid.threadFactsFor(head);
-        expect(headFacts).toEqual({collapsed: true, isHead: true, hiddenCount: 2, inThread: false});
+        // the stamped record truth (the one data path stamps facts into the bags before they
+        // become records): store order is newest-first, so the newest message heads its thread —
+        // the shipped reading order, pinned (Grace's steer, kept)
+        expect(pane.store.get('MESSAGE:t3').threadFacts)
+            .toEqual({collapsed: true, isHead: true, hiddenCount: 2, inThread: false});
 
-        // collapsed members hide at the store view layer: the filtered count carries head + solo only
+        // collapsed members hide at the store view layer: the filtered count carries head + solo
+        // only — and the hidden members survive in the unfiltered source, facts stamped
         expect(pane.store.getCount()).toBe(2);
-        expect(rowsGrid.threadFactsFor(pane.store.get('MESSAGE:solo'))).toBeNull();
+        expect(pane.store.get('MESSAGE:solo').threadFacts).toBe(null);
+        expect(pane.store.allItems.get('MESSAGE:t2').threadFacts)
+            .toEqual({collapsed: true, isHead: false, hiddenCount: 2, inThread: true});
 
-        // toggle = display-state navigation on the view-owned field, never a data write
-        head.threadCollapsed = false;
-        rowsGrid.onStoreMutation();
+        // toggle = display-state navigation on the view-owned field, never a data write; the flip
+        // re-projects through the one data path, so records carry FRESH identities + facts
+        rowsGrid.onThreadToggleClick({path: [
+            {cls: ['fm-mail-thread-toggle']},
+            {cls: ['neo-grid-row'], data: {recordId: 'MESSAGE:t3'}}
+        ]});
 
         expect(pane.store.getCount()).toBe(4);
-        expect(rowsGrid.threadFactsFor(head).collapsed).toBe(false);
-        expect(rowsGrid.threadFactsFor(pane.store.get('MESSAGE:t2'))).toEqual({collapsed: false, isHead: false, hiddenCount: 2, inThread: true});
+        expect(pane.store.get('MESSAGE:t3').threadFacts.collapsed).toBe(false);
+        expect(pane.store.get('MESSAGE:t2').threadFacts)
+            .toEqual({collapsed: false, isHead: false, hiddenCount: 2, inThread: true});
 
         pane.destroy()
     });
@@ -395,6 +401,42 @@ test.describe('AgentOS.view.fleet.mailbox.Container — the read-only S1 mailbox
         // the grid store carries the FULL projected window — scrolling reaches every row,
         // and the honest end of the window is the only end
         expect(pane.store.getCount()).toBe(50);
+
+        pane.destroy()
+    });
+
+    test('the drain: row 51+ stays reachable — hasMore requests the next window, appends it, and stops at the honest end', () => {
+        const
+            fired    = [],
+            firstWin = Array.from({length: 50}, (v, i) => row({
+                messageId: `MESSAGE:${i}`, subject: `subject ${i}`,
+                sentAt   : `2026-07-16T10:${String(59 - (i % 60)).padStart(2, '0')}:00.000Z`
+            })),
+            pane = createPane({
+                snapshot : wiredSnapshot(firstWin, {limit: 50, offset: 0, count: 50, hasMore: true}),
+                listeners: {pageRequest: data => fired.push(data.offset)}
+            });
+
+        // the construction-time snapshot already carried hasMore — exactly ONE drain request for
+        // the next window, no chrome involved
+        expect(fired).toEqual([50]);
+        expect(pane.store.getCount()).toBe(50);
+
+        // a freshness re-render must NOT re-request (the drain arms per SNAPSHOT, not per render)
+        pane.now = NOW + 1000;
+        expect(fired).toEqual([50]);
+
+        // the follow-up window APPENDS — row 51+ is now genuinely present, not stranded
+        pane.snapshot = wiredSnapshot(
+            Array.from({length: 10}, (v, i) => row({messageId: `MESSAGE:5${i}`, subject: `late ${i}`, sentAt: `2026-07-16T09:0${i % 10}:00.000Z`})),
+            {limit: 50, offset: 50, count: 10, hasMore: false}
+        );
+
+        expect(pane.store.getCount()).toBe(60);
+        expect(pane.store.allItems.get('MESSAGE:55')).toBeTruthy();
+
+        // hasMore: false is the honest end — no further request fired
+        expect(fired).toEqual([50]);
 
         pane.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/operatorContainer.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/operatorContainer.spec.mjs
@@ -65,18 +65,29 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         box.destroy()
     });
 
-    test('relays the inbox page intent to the owner — the cockpit holds the read seam', () => {
-        const box = createBox();
-
+    test('fires the single inbox read intent at construction — the cockpit holds the read seam', () => {
+        // The paging chrome retired with the buffered grid (operator direction 2026-08-28): the
+        // pane no longer fires `pageRequest`. The read trigger is THIS surface's own — one
+        // construction-time fire per bound identity, offset always 0, the event name and payload
+        // kept stable for the cockpit's existing wiring.
         let relayed = null;
-        box.on('inboxPageRequest', data => {relayed = data});
 
-        box.getReference('operator-inbox-pane').fire('pageRequest', {offset: 60, source: 'the-pane'});
+        const box = createBox({
+            record   : {agentId: 'op', githubUsername: 'tobiu'},
+            listeners: {inboxPageRequest: data => {relayed = data}}
+        });
 
-        expect(relayed?.offset).toBe(60);
+        expect(relayed?.offset).toBe(0);
         expect(relayed.source).toBe(box.id);
 
-        box.destroy()
+        box.destroy();
+
+        // without a bound identity there is nothing to read — no fire
+        let fired = false;
+        const idle = createBox({listeners: {inboxPageRequest: () => {fired = true}}});
+
+        expect(fired).toBe(false);
+        idle.destroy()
     });
 
     test('passes the operator snapshot straight to the inbox pane', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
@@ -41,7 +41,7 @@ test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one
     };
 
     const makeRow = (fields = {}, config = {}) =>
-        Neo.create(RowComponent, {appName, record: {...baseRecord, ...fields}, ...config});
+        Neo.create(RowComponent, {appName, rowData: {...baseRecord, ...fields}, ...config});
 
     const nodeBy = (row, cls) => {
         const walk = nodes => {
@@ -104,14 +104,16 @@ test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one
     });
 
     test('a collapsed thread head renders the native toggle with its count and aria state', () => {
-        const row = makeRow({partOfThread: 'T1'}, {threadFacts: {isHead: true, collapsed: true, hiddenCount: 3, inThread: false}});
+        // the facts ride ON the record (the grid stamps them — the record version is what
+        // survives the pooled cell's short-circuit)
+        const row = makeRow({partOfThread: 'T1', threadFacts: {isHead: true, collapsed: true, hiddenCount: 3, inThread: false}});
 
         const toggle = nodeBy(row, 'fm-mail-thread-toggle');
         expect(toggle.tag).toBe('button');
         expect(toggle.text).toBe('+3 earlier');
         expect(toggle['aria-expanded']).toBe('false');
 
-        row.threadFacts = {isHead: true, collapsed: false, hiddenCount: 3, inThread: false};
+        row.rowData = {...row.rowData, threadFacts: {isHead: true, collapsed: false, hiddenCount: 3, inThread: false}};
 
         const expanded = nodeBy(row, 'fm-mail-thread-toggle');
         expect(expanded.text).toBe('collapse thread');
@@ -121,7 +123,7 @@ test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one
     });
 
     test('a thread member indents on the rail and renders no toggle', () => {
-        const row = makeRow({partOfThread: 'T1'}, {threadFacts: {isHead: false, collapsed: false, hiddenCount: 3, inThread: true}});
+        const row = makeRow({partOfThread: 'T1', threadFacts: {isHead: false, collapsed: false, hiddenCount: 3, inThread: true}});
 
         expect(row.cls).toContain('is-in-thread');
         expect(nodeBy(row, 'fm-mail-thread-toggle')).toBeNull();
@@ -134,7 +136,7 @@ test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one
 
         expect(row.cls).toContain('is-unread');
 
-        row.record = {...baseRecord, from: '@neo-opus-vega', subject: '[assignment triage DONE]'};
+        row.rowData = {...baseRecord, from: '@neo-opus-vega', subject: '[assignment triage DONE]'};
 
         expect(row.cls).not.toContain('is-unread');
         expect(nodeBy(row, 'fm-mail-smark').text).toBe('ve');

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
@@ -1,0 +1,153 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'FleetMailboxRowTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core      from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+
+/**
+ * The designed mailbox row grammar, pinned at the cell layer (the merged #36/#38 sketch is the
+ * scored spec): status renders as dot + weight (two channels), the exception strip is T2
+ * exception-only (a direct/normal/plain/read message renders zero chips and NO strip node), the
+ * thread toggle is a native button with aria-expanded, ages are viewer-local with the exact ISO
+ * on `title`, and a pool recycle (assigning a new record to the SAME instance) re-renders in place.
+ */
+test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one record', () => {
+    let RowComponent;
+
+    const baseRecord = {
+        messageId     : 'MESSAGE:1',
+        subject       : '[review-requested][Brain PR #207]',
+        from          : '@neo-gpt-emmy',
+        recipientClass: 'agent',
+        priority      : null,
+        status        : 'read',
+        taskState     : null,
+        partOfThread  : null,
+        relatedTickets: null,
+        sentAt        : '2026-08-28T15:54:27.998Z'
+    };
+
+    const makeRow = (fields = {}, config = {}) =>
+        Neo.create(RowComponent, {appName, record: {...baseRecord, ...fields}, ...config});
+
+    const nodeBy = (row, cls) => {
+        const walk = nodes => {
+            for (const node of nodes || []) {
+                if (node.cls?.includes(cls)) return node;
+                const hit = walk(node.cn);
+                if (hit) return hit
+            }
+            return null
+        };
+        return walk(row.vdom.cn)
+    };
+
+    test.beforeAll(async () => {
+        RowComponent = (await import('../../../../../../../../apps/agentos/view/fleet/mailbox/RowComponent.mjs')).default
+    });
+
+    test('the full exception row: unread weight channel, every deviation chip, ticket tail, ISO receipt', () => {
+        const row = makeRow({
+            status        : 'unread',
+            priority      : 'high',
+            taskState     : 'Submitted',
+            recipientClass: 'broadcast',
+            relatedTickets: [196, 198, 210]
+        });
+
+        expect(row.cls).toContain('is-unread');
+        expect(nodeBy(row, 'fm-mail-udot').title).toBeTruthy();
+        expect(nodeBy(row, 'fm-mail-smark').text).toBe('em');
+        expect(nodeBy(row, 'fm-mail-sender').text).toBe('@neo-gpt-emmy');
+        expect(nodeBy(row, 'fm-mail-subject').text).toBe('[review-requested][Brain PR #207]');
+
+        const strip = nodeBy(row, 'fm-mail-xstrip');
+        expect(strip.cn.map(node => node.text)).toEqual(['high', 'task · Submitted', 'broadcast', '#196 · #198 +1']);
+
+        const age = nodeBy(row, 'fm-mail-age');
+        expect(age.text).toMatch(/\d{2}:\d{2}/);
+        expect(age.title).toBe('2026-08-28T15:54:27.998Z');
+
+        row.destroy()
+    });
+
+    test('the zero-exception row earns zero chips — the strip node itself is absent', () => {
+        const row = makeRow();
+
+        expect(row.cls).not.toContain('is-unread');
+        expect(nodeBy(row, 'fm-mail-xstrip')).toBeNull();
+        expect(nodeBy(row, 'fm-mail-udot').title).toBeFalsy();
+
+        row.destroy()
+    });
+
+    test('retracted: strike class + the named word replace the ticket tail', () => {
+        const row = makeRow({status: 'retracted', relatedTickets: [17835]});
+
+        expect(row.cls).toContain('status-retracted');
+        expect(nodeBy(row, 'fm-mail-tickets').text).toBe('retracted');
+
+        row.destroy()
+    });
+
+    test('a collapsed thread head renders the native toggle with its count and aria state', () => {
+        const row = makeRow({partOfThread: 'T1'}, {threadFacts: {isHead: true, collapsed: true, hiddenCount: 3, inThread: false}});
+
+        const toggle = nodeBy(row, 'fm-mail-thread-toggle');
+        expect(toggle.tag).toBe('button');
+        expect(toggle.text).toBe('+3 earlier');
+        expect(toggle['aria-expanded']).toBe('false');
+
+        row.threadFacts = {isHead: true, collapsed: false, hiddenCount: 3, inThread: false};
+
+        const expanded = nodeBy(row, 'fm-mail-thread-toggle');
+        expect(expanded.text).toBe('collapse thread');
+        expect(expanded['aria-expanded']).toBe('true');
+
+        row.destroy()
+    });
+
+    test('a thread member indents on the rail and renders no toggle', () => {
+        const row = makeRow({partOfThread: 'T1'}, {threadFacts: {isHead: false, collapsed: false, hiddenCount: 3, inThread: true}});
+
+        expect(row.cls).toContain('is-in-thread');
+        expect(nodeBy(row, 'fm-mail-thread-toggle')).toBeNull();
+
+        row.destroy()
+    });
+
+    test('the pool recycle contract: a new record on the SAME instance re-renders every channel', () => {
+        const row = makeRow({status: 'unread', priority: 'high'});
+
+        expect(row.cls).toContain('is-unread');
+
+        row.record = {...baseRecord, from: '@neo-opus-vega', subject: '[assignment triage DONE]'};
+
+        expect(row.cls).not.toContain('is-unread');
+        expect(nodeBy(row, 'fm-mail-smark').text).toBe('ve');
+        expect(nodeBy(row, 'fm-mail-subject').text).toBe('[assignment triage DONE]');
+        expect(nodeBy(row, 'fm-mail-xstrip')).toBeNull();
+
+        row.destroy()
+    });
+
+    test('the monogram derivation is deterministic over handle shapes', () => {
+        expect(RowComponent.monogram('@neo-gpt-emmy')).toBe('em');
+        expect(RowComponent.monogram('@neo-opus-vega')).toBe('ve');
+        expect(RowComponent.monogram('@tobiu')).toBe('to');
+        expect(RowComponent.monogram('@neo-gpt')).toBe('gp')
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/mailbox/rowComponent.spec.mjs
@@ -144,6 +144,23 @@ test.describe('Fleet mailbox RowComponent — the sketch\'s row grammar from one
         row.destroy()
     });
 
+    test('hostile content renders as text-only leaves — no node anywhere carries html', () => {
+        // layer 2 of the mailbox double defense (layer 1, the record String convert, is pinned in
+        // container.spec.mjs): whatever string reaches this cell renders as escaped text, never markup
+        const row = makeRow({subject: 'deploy <img src=x onerror=alert(1)> done', from: '@evil<script>'});
+
+        const walk = node => {
+            if (!node || typeof node !== 'object') return;
+            expect(node.html).toBe(undefined);
+            (node.cn || []).forEach(walk)
+        };
+        walk(row.vdom);
+
+        expect(nodeBy(row, 'fm-mail-subject').text).toBe('deploy <img src=x onerror=alert(1)> done');
+
+        row.destroy()
+    });
+
     test('the monogram derivation is deterministic over handle shapes', () => {
         expect(RowComponent.monogram('@neo-gpt-emmy')).toBe('em');
         expect(RowComponent.monogram('@neo-opus-vega')).toBe('ve');

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "ab9911a4a86f7ecf24804815481b8b2a53cd8e6e2aa895d3267d4bde44be7b08",
-        "resources/scss": "98932fc3e37581d585e1f4eaa7ab6460d2a9428c5883537617cd9acf86f3dd46",
+        "apps/agentos": "889781e5b504b66e42fca842f5f94abe2c9e58012f70fcc951b4f7efc7306ea2",
+        "resources/scss": "eb08ffd0ce33e621aa3b51a4481cdf86a05874fc04f1766c31085f66315f481e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "b740b2536f9994ab4346e0ee02db6400bd4ecb784e4345b3ff3ffb8b751e7adf",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "68093e2d84cd3afa2ffea177e56ea6116782ca7a7e779e6232bf3c406dc7cdfa",
-        "resources/scss": "582c39e745522efe4097bf2a1d289f97f8b1d051d68a21eb923de6dd3cbc5127",
+        "apps/agentos": "ab9911a4a86f7ecf24804815481b8b2a53cd8e6e2aa895d3267d4bde44be7b08",
+        "resources/scss": "98932fc3e37581d585e1f4eaa7ab6460d2a9428c5883537617cd9acf86f3dd46",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "b740b2536f9994ab4346e0ee02db6400bd4ecb784e4345b3ff3ffb8b751e7adf",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "154d5e76511d7b36bc530bbdac151a3c8731bcb87c702012d3a8dcfb446374fe",
-        "resources/scss": "740ee9667cab8fa86eb2e5ed5a3bba7b28182011cad13244d3b2998d80a8fee4",
+        "apps/agentos": "68093e2d84cd3afa2ffea177e56ea6116782ca7a7e779e6232bf3c406dc7cdfa",
+        "resources/scss": "582c39e745522efe4097bf2a1d289f97f8b1d051d68a21eb923de6dd3cbc5127",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "b740b2536f9994ab4346e0ee02db6400bd4ecb784e4345b3ff3ffb8b751e7adf",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "a59a1c18278c9b54c5e48bc5411e91de8f00127fca8235a1ae6da2562b9f76b4",
-        "resources/scss": "27c3783411c27315fa23e694bb9a96f624f03df67e2fd977553dcf52706f7849",
+        "apps/agentos": "154d5e76511d7b36bc530bbdac151a3c8731bcb87c702012d3a8dcfb446374fe",
+        "resources/scss": "740ee9667cab8fa86eb2e5ed5a3bba7b28182011cad13244d3b2998d80a8fee4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "b740b2536f9994ab4346e0ee02db6400bd4ecb784e4345b3ff3ffb8b751e7adf",


### PR DESCRIPTION
Resolves #40

The first sketch-scored implementation of the #20 arc: the mailbox surface renders through a real buffered grid, and the pane drains the remote corpus itself — no paging chrome, no stranded rows. Four staged commits, net negative on hand-rolled rendering; head 2 closes Emmy's three RAs in one architectural move, head 3 lands the mounted-browser design-pass finding: the engine grid positions rows on a FIXED `rowHeight` lattice, so the designed rows (measured 39–84px on the 32px default — overlapping) are height-NORMED to the tallest designed case (`Grid.rowHeight: 84` = the `.fm-mail-row` height, each side naming the other; quieter rows keep the rhythm with whitespace).

Evidence: L2 (full unit battery **716** passed; the new **mounted component battery** — pane through `grid.Container` → `grid.column.Component` → pooled `RowComponent` in a real browser — green 3/3 consecutive runs; visual 6/6 against untouched goldens after a fresh 486-file theme build) → L2 required (all ACs repository-local). Residual: none — a `hasMore: true` snapshot now drains beyond the initial window (the RA-1 witness reaches row 51+), and the generalized scroll-edge seam stays pre-declared as neomjs/neo#17835.

## What

**The one data path (head 2 — the RA closure is an architecture, not three patches):**
Every mutation of the row surface — wholesale projection, follow-up window extension, thread toggle — flows through `Grid#applyBags`: thread display facts are stamped into the PLAIN row bags (`stampThreadFacts`) before they become records, and the bags become the store's data in a single set. Why measured, not aesthetic:
- The store's data path re-runs the collapse filter during `add` and renders cells immediately — facts arriving after the set missed the first paint (measured: cells seated with `facts: null`).
- Every `applyBags` run creates new record identities, which is what re-seats pooled cells past the component column's record short-circuit — no version choreography.
- The former per-record stamp path (`record.set` version bumps + `store.filter()`) fired two overlapping vdom transactions; the head cell's content double-mounted into its own row (measured in the seam test, snapshot in the run log).
`threadMap`/`buildThreadMap`/`threadFactsFor`/`onStoreMutation` and `store#applySnapshotRows` retire with it; the collapse filter reads stamped record truth only, so filter and rendered cells cannot disagree.

**The drain (RA-1):** while a received snapshot reports `page.hasMore`, the pane fires exactly ONE `pageRequest {offset: offset + limit}` — armed per `afterSetSnapshot`, so freshness re-renders and record swaps never re-request; follow-up windows extend the held corpus (live `threadCollapsed` state preserved through `extractBags`). `OperatorContainer` relays it unchanged as `inboxPageRequest` (stable name/payload; the construction-time offset-0 read stays). An identical-rows poll is fingerprint-gated, so expansion state survives refreshes.

**The surface (heads 1–2):**
- `RowComponent.mjs` — the merged sketch's row as a deliberately FLAT pooled cell rendering from a `rowData` bag (fresh reference per factory call — a re-seat applies configs via `set()`, and a same-instance record never re-fires afterSet). Unread = dot + weight, T2 exception-only strip, T5 viewer-local age with ISO `title`, retracted = strike, deterministic monogram, thread toggle as a native button (grid-delegated).
- `Grid.mjs` — headerless single-component-column `Neo.grid.Container`; toggle clicks resolve through the engine's own `.neo-grid-row` `data.recordId` contract, then re-project through the one data path.
- `Grid.scss` — full §04 contract; header toolbar height-collapsed at the skin layer, never `display: none` (the header toolbar is the engine's measuring instrument for flex columns — hiding it collapsed the column width to 0; measured).
- `Container.mjs` keeps the possession gates + the adapter-honest state family and hands the grid its store; `MailboxMessage.mjs` gains the `threadFacts` field (facts ride the record because the pool short-circuits on record identity).

## RA Disposition

- **RA-1 (reachability)** — delivered: the pane-owned sequential drain above. Red-capable witness in `container.spec.mjs`: 50 rows + `hasMore: true` fires `pageRequest {offset: 50}` (construction-listener witness — a post-create `.on()` misses the construction fire), the follow-up window extends the store to 60, `hasMore: false` stops the chain.
- **RA-2 (state contract)** — resolved by #40 author-correction (author's carve): the ticket now names the adapter-honest family `unobserved/denied/degraded/empty/rows` and the drain contract in body, ledger and AC. Rationale: the mirror adapter always answers with a capability/admission envelope, so a separate `loading` state is a phantom (between polls the last snapshot + freshness chip ARE the truth) and pane-side `retry` duplicates the poll cadence the owning controller already owns (a degraded adapter answer renders `degraded` with the adapter's reason). Declared here so `Residual: none` stands on the corrected contract, not past it.
- **RA-3 (the real seam)** — delivered: `test/playwright/component/apps/agentos/MailboxGridSeam.spec.mjs` mounts the populated pane cross-worker in a browser and proves (1) pooled cells materialize from records, (2) a snapshot swap RECYCLES the same mounted surface — subjects swap in place and a toggle appears when a thread arrives (threadFacts reached the pooled cell), (3) the delegated thread toggle works through a genuine bubbling DOM click — expand and collapse, member row materializing and hiding via the store filter. One engine seam recorded in the spec: `GridDragScroll` preventDefaults every `mousedown`, so raw pointer clicks land on the drag layer, not cell buttons — the click is `dispatchEvent`-driven and the seam goes to the engine as a defect-note (bigData's cell buttons share it).

## AC Evidence

- Grid class + grid-owned interaction — [L2] `Grid.mjs` + pane spec thread-truth/toggle witnesses + the mounted seam battery.
- T5 zero raw-ISO / T2 exception-only / thread collapse (native button, aria) — [L2] row spec (8 witnesses incl. hostile text-only layer) + seam battery aria assertions.
- No paging chrome + five adapter-honest states + drain beyond the window — [L2] pane spec: no-chrome witness, state family, drain witness, expansion-persistence witness.
- Retirement, zero dangling refs — [L1] whole-repo grep: no `mailbox-page`, `renderRows`, `createRowVdom`, `applySnapshotRows`, `newer/older` handlers remain.
- Zero font-size literals; both themes via tokens — [L1] greppable; theme build 486 files.
- No unrelated visual baseline refreshed — [L2] visual 6/6; AC-7 restamped per commit.

## Deltas

1. The ticket sketched "retire the hand-rolled mailbox view (file)"; the surgery retires the hand-rolled HALF (row rendering + paging) while the pane file survives as the state/admission shell — not a hand-rolled data view (#24's target). Declared, not silently reinterpreted.
2. The state family + drain contract were author-corrected in #40 per RA-2 (see disposition) — the AC set this PR closes is the corrected one.

## Post-Merge Validation

The operator inbox renders identically for its states; populated inboxes render the designed rows through the grid, and inboxes beyond one window assemble themselves silently until the producer's honest end.

Authored by Clio (Fable 5, Claude Code). Session 41859592-b7ee-4bce-bee3-f25644d9003b.
