### PR TITLE
fix(agentos): retire the tracked MicroLoader fork — engine loader + canonical mainPath (#46)

### DIFF
--- a/apps/agentos/childapps/widget/neo-config.json
+++ b/apps/agentos/childapps/widget/neo-config.json
@@ -2,7 +2,7 @@
     "appPath"         : "../../apps/agentos/childapps/widget/app.mjs",
     "basePath"        : "../../../../",
     "environment"     : "development",
-    "mainPath"        : "../../../node_modules/neo.mjs/src/Main.mjs",
+    "mainPath"        : "./Main.mjs",
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"     : true,
     "useSharedWorkers": true,

--- a/apps/agentos/index.html
+++ b/apps/agentos/index.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-    <script src="../../src/MicroLoader.mjs" type="module"></script>
+    <script src="../../node_modules/neo.mjs/src/MicroLoader.mjs" type="module"></script>
 </body>
 
 </html>

--- a/apps/agentos/neo-config.json
+++ b/apps/agentos/neo-config.json
@@ -2,7 +2,7 @@
     "appPath"         : "../../apps/agentos/app.mjs",
     "basePath"        : "../../",
     "environment"     : "development",
-    "mainPath"        : "../node_modules/neo.mjs/src/Main.mjs",
+    "mainPath"        : "./Main.mjs",
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"     : true,
     "useSharedWorkers": true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,6 @@
     <title>Neo Docs</title>
 </head>
 <body>
-    <script src="../src/MicroLoader.mjs" type="module"></script>
+    <script src="../node_modules/neo.mjs/src/MicroLoader.mjs" type="module"></script>
 </body>
 </html>

--- a/docs/neo-config.json
+++ b/docs/neo-config.json
@@ -2,7 +2,7 @@
     "appPath": "../../docs/app.mjs",
     "basePath": "../",
     "environment": "development",
-    "mainPath": "../node_modules/neo.mjs/src/Main.mjs",
+    "mainPath": "./Main.mjs",
     "mainThreadAddons": [
         "DragDrop",
         "HighlightJS",

--- a/src/MicroLoader.mjs
+++ b/src/MicroLoader.mjs
@@ -1,4 +1,0 @@
-fetch('./neo-config.json').then(r => r.json()).then(d => {
-    self.Neo = {config: {...d}};
-    import(d.mainPath);
-});

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -20,7 +20,10 @@ test.describe('AgentOS packaged Fleet window routing', () => {
 
         expect(config).toMatchObject({
             appPath       : '../../apps/agentos/childapps/widget/app.mjs',
-            mainPath      : '../../../node_modules/neo.mjs/src/Main.mjs',
+            // the canonical loader-relative shape (#46): Main.mjs sits BESIDE the engine
+            // MicroLoader, and import(d.mainPath) resolves relative to the loader MODULE —
+            // the resolution witness below is the executable proof
+            mainPath      : './Main.mjs',
             workerBasePath: '../../../../node_modules/neo.mjs/src/worker/'
         });
         expect(new URL(config.mainPath, microLoaderUrl).pathname)

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "a59a1c18278c9b54c5e48bc5411e91de8f00127fca8235a1ae6da2562b9f76b4",
+        "apps/agentos": "1c35ce34e1dd8b817aa8d2321bd32e542b1b2ef47b3348d68f83d15183906b8f",
         "resources/scss": "27c3783411c27315fa23e694bb9a96f624f03df67e2fd977553dcf52706f7849",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",


### PR DESCRIPTION
Resolves #46

The tracked `src/MicroLoader.mjs` fork retires. Provenance: Grace's cross-repo finding (the copied-upstream-file-with-a-decay-clock class, sibling of neomjs/devindex#10), relayed by Ada with engine-side anchors verified; Institution-side confirmation and the fix are this PR.

Evidence: L2 (live browser boot of BOTH former fork consumers through the engine loader — the full FM cockpit and the docs app mount their viewports with zero console errors; the `app.spec.mjs` path witness proves the canonical resolution executable; unit **710 passed / 0 failed**; component battery green) → L2 required. Residual: none.

## What — and the falsified first theory

The fork was two loader generations stale (`fetch` + `self.Neo` vs the engine's JSON-module import, neomjs/neo#13909). The naive fix — repoint the HTMLs at the engine file — **failed in the browser**: `import(d.mainPath)` resolves relative to the LOADER MODULE, so the engine loader turned the repo-relative `mainPath` into `node_modules/neo.mjs/node_modules/neo.mjs/...`. That failure names the fork's real reason for existing: it anchored repo-relative `mainPath` values.

The class fix is the config, not the copy:

- `mainPath` becomes the canonical loader-relative `./Main.mjs` (Main sits beside the engine MicroLoader — the shape the engine's portal AND this repo's component testbed already use) in `apps/agentos/neo-config.json`, `childapps/widget/neo-config.json`, `docs/neo-config.json`.
- `apps/agentos/index.html` + `docs/index.html` reference `node_modules/neo.mjs/src/MicroLoader.mjs` (the widget page already did).
- `src/MicroLoader.mjs` is deleted. Zero references remain (grepped).

**Nothing is left to drift, so this repo needs no drift detector** — that is the durable answer to the class here; devindex#10 stays the devindex instance's own call.

## AC Evidence

- Three HTMLs on the engine loader, fork deleted, zero references — [L1] grep; the diff IS the list.
- Pages boot — [L2] live browser, all three mainPath consumers: FM cockpit full render (roster, activity, tabs, offline banner), docs viewport, widget childapp viewport; zero console errors.
- Batteries — [L2] 710/0 unit (the widget path witness now pins `./Main.mjs` AND proves its resolution: `new URL('./Main.mjs', microLoaderUrl)` → `/node_modules/neo.mjs/src/Main.mjs`); component battery green.

## Post-Merge Validation

Dev-mode boots ride the engine loader everywhere; the next engine loader change reaches this repo through `npm ci`, never through a copy nobody re-syncs.

Related: finding provenance Grace → Ada (A2A 2026-08-29) · engine shape neomjs/neo#13909 · sibling class instance neomjs/devindex#10.

Authored by Clio (Fable 5, Claude Code). Session 41859592-b7ee-4bce-bee3-f25644d9003b.
