### PR TITLE
refactor(agentos): extract the cockpit source-read family into one fenced discipline (#48)

### DIFF
--- a/apps/agentos/util/CockpitSourceReads.mjs
+++ b/apps/agentos/util/CockpitSourceReads.mjs
@@ -330,8 +330,10 @@ async function loadOperatorIdentity(owner) {
 
         // the seat-conflation honesty check rides the same resolution: a viewer claim matching a
         // registered agent identity means sends are attributed to that seat — a truth the pane
-        // must render, not swallow
-        owner.operatorIdentityPosture = deriveOperatorIdentityPosture(owner, nodeId);
+        // must render, not swallow. Dispatched THROUGH THE OWNER, never the private function:
+        // the shipped seam is the cockpit's virtual method, and an owner-side override must keep
+        // receiving the call (the delegate routes the default back here).
+        owner.operatorIdentityPosture = owner.deriveOperatorIdentityPosture(nodeId);
 
         // a materialized pane picks up the identity live and reads; a pane that projected first
         // takes the identity through this same live set — both orderings land exactly one first read

--- a/apps/agentos/util/CockpitSourceReads.mjs
+++ b/apps/agentos/util/CockpitSourceReads.mjs
@@ -1,0 +1,397 @@
+import Base from '../../../node_modules/neo.mjs/src/core/Base.mjs';
+
+/**
+ * The cockpit's source-read discipline, stated once — the first extraction cut of Epic #22 (#48).
+ *
+ * Shaped as a static util class per the view/util topology laws (view tree = class modules only;
+ * util tree = PascalCase core.Base statics, no named exports).
+ *
+ * Seven FleetCockpit bridge-read verbs repeated ONE contract per source, hand-rolled each time:
+ * resolve the authenticated registry bridge → verb-presence check → try/await → typed unavailable
+ * fallback envelope (never a fabricated success) → read-generation fence (a slow older read never
+ * overwrites a newer one) → owner-held snapshot write → WRITE-time pane resolution through the
+ * phase-blind accessor (a pane torn out or rebuilt during the await still receives the truth; a
+ * destroyed instance never swallows it). This module carries that contract as
+ * {@link #readFencedSource} + a descriptor table ({@link #SOURCE_READS}), with the measured
+ * per-source variance as explicit hooks instead of seven drifting copies:
+ *
+ * - `preAwait(owner, params)` — owner-held selection/drill state BEFORE any await (memories target,
+ *   session drill), so a pane rematerialized mid-read reopens on the PENDING truth.
+ * - `wireParams(params, owner)` — the wire payload when it differs from the intent payload
+ *   (the drill strips display-only `title`; the operator inbox derives its subject owner-side).
+ * - `inFlightField` — the liveness tick's overlap accounting (tasks): incremented before the verb
+ *   check, released in `finally` on the read's OWN settle, never on a newer read's.
+ * - `gate(owner, params, bridge)` — pre-conditions whose absence IS the honest outcome (operator
+ *   inbox: no pane / no bound subject / no verb → the pane's `unobserved` state stands).
+ * - `errorMode: 'keep'` — fail-closed variant that PRESERVES the last-known snapshot on a throwing
+ *   bridge (operator inbox) instead of writing a typed unavailable envelope.
+ * - `apply(owner, snapshot)` — the owner write + write-time pane resolve, named per source.
+ *
+ * Behavior-frozen: every path in this module is a verbatim relocation of the cockpit's shipped
+ * semantics; the cockpit keeps thin delegates with unchanged public signatures.
+ */
+
+/**
+ * @summary The cockpit-owned authenticated bridge — resolved fresh per call, never captured:
+ * custody heals swap the bridge identity, and a captured reference would outlive its authority.
+ * @returns {Object|undefined}
+ */
+function resolveFleetBridge() {
+    return globalThis.AgentOS?.fleet?.registryBridge
+}
+
+/**
+ * @summary Run one fenced source read per the discipline above.
+ *
+ * Order of laws (verbatim from the shipped verbs): fence bump first (an in-flight older read
+ * becomes unwanted the moment a newer intent exists — gate-refused intents included), then the
+ * gate, then the pre-await owner hold, then the verb/await with typed fallbacks, then — only when
+ * this read is still the newest and the owner still lives — the owner write + pane resolve.
+ * @param {Neo.container.Base} owner The cockpit instance (fence/snapshot fields + pane accessors).
+ * @param {Object} descriptor One {@link #SOURCE_READS} entry.
+ * @param {Object} [params] The caller's intent payload.
+ * @returns {Promise<Object|undefined>} The accepted-or-fallback snapshot; `undefined` on a gate
+ *     refusal or a kept error (the honest no-write outcomes).
+ */
+async function readFencedSource(owner, descriptor, params = {}) {
+    const
+        bridge     = resolveFleetBridge(),
+        generation = descriptor.fenceField ? ++owner[descriptor.fenceField] : null;
+
+    if (descriptor.gate && !descriptor.gate(owner, params, bridge)) {
+        return
+    }
+
+    descriptor.preAwait?.(owner, params);
+
+    const
+        verb       = bridge?.[descriptor.verb],
+        wireParams = descriptor.wireParams ? descriptor.wireParams(params, owner) : params,
+        fallback   = reason => descriptor.fallback(params, reason);
+
+    let snapshot;
+
+    descriptor.inFlightField && owner[descriptor.inFlightField]++;
+
+    try {
+        if (typeof verb !== 'function') {
+            snapshot = fallback(descriptor.notWiredReason)
+        } else {
+            try {
+                snapshot = await verb.call(bridge, wireParams)
+            } catch (error) {
+                if (descriptor.errorMode === 'keep') {
+                    // fail-closed: the last-known snapshot stays; the pane never renders "empty"
+                    // for a read that did not happen
+                    return
+                }
+                snapshot = fallback(descriptor.failedReason)
+            }
+        }
+    } finally {
+        descriptor.inFlightField && owner[descriptor.inFlightField]--
+    }
+
+    if ((generation === null || generation === owner[descriptor.fenceField]) && !owner.isDestroyed) {
+        descriptor.apply(owner, snapshot)
+    }
+
+    return snapshot
+}
+
+/**
+ * @summary The descriptor table: each source's full read contract in one named place.
+ * Pane accessors are called through the owner so the phase-blind resolution (projected, vesseled,
+ * parked, rebuilt) stays exactly the cockpit's.
+ */
+const SOURCE_READS = {
+    /**
+     * S3 invoked history. Typed unavailable envelope carries the requested partition so the pane's
+     * honest chrome stays addressable.
+     */
+    catchUp: {
+        verb          : 'fleetHistory',
+        fenceField    : 'catchUpReadGeneration',
+        notWiredReason: 'fleet history verb not wired',
+        failedReason  : 'fleet history read failed',
+        fallback      : (params, reason) => ({
+            capability         : {state: 'unavailable', reason},
+            needsFirstUseWindow: false,
+            partition          : params.partition || 'unified',
+            viewerState        : {lastSeen: null, lastVisitAt: null},
+            window             : null,
+            sources            : null
+        }),
+        apply(owner, snapshot) {
+            owner.catchUpSnapshot = snapshot;
+
+            const pane = owner.getCatchUpPane();
+
+            pane && (pane.snapshot = snapshot)
+        }
+    },
+
+    /**
+     * Resident per-agent session-summary recall. The requested selection is owner-held BEFORE any
+     * await: a pane removed and rematerialized while this read is in flight must reopen on the
+     * PENDING target (honest switch-pending state), not on the last accepted snapshot's target.
+     */
+    memories: {
+        verb          : 'fleetMemories',
+        fenceField    : 'memoriesReadGeneration',
+        notWiredReason: 'fleet memories verb not wired',
+        failedReason  : 'fleet memories read failed',
+        preAwait(owner, params) {
+            if (params.agentIdentity) {
+                owner.memoriesTarget = params.agentIdentity
+            }
+        },
+        fallback: (params, reason) => ({
+            capability: {state: 'unavailable', reason},
+            viewer    : null,
+            target    : params.agentIdentity || null,
+            page      : {offset: params.offset ?? 0, limit: null},
+            sessions  : [],
+            count     : 0,
+            total     : null
+        }),
+        apply(owner, snapshot) {
+            owner.memoriesSnapshot = snapshot;
+
+            const livePane = owner.getMemoriesPane();
+
+            livePane && (livePane.snapshot = snapshot)
+        }
+    },
+
+    /**
+     * The memories drill-in — the summary read's discipline one level down: the open drill is
+     * owner-held before the await, and display-only `title` never rides the wire call.
+     */
+    sessionMemories: {
+        verb          : 'fleetSessionMemories',
+        fenceField    : 'memoriesDrillReadGeneration',
+        notWiredReason: 'fleet session-memories verb not wired',
+        failedReason  : 'fleet session-memories read failed',
+        preAwait(owner, params) {
+            if (params.sessionId) {
+                owner.memoriesDrillSession = {sessionId: params.sessionId, title: params.title ?? null}
+            }
+        },
+        wireParams(params) {
+            const {title, ...wireParams} = params;
+
+            return wireParams
+        },
+        fallback: (params, reason) => ({
+            capability: {state: 'unavailable', reason},
+            viewer    : null,
+            sessionId : params.sessionId || null,
+            page      : {offset: params.offset ?? 0, limit: null},
+            turns     : [],
+            count     : 0,
+            total     : null
+        }),
+        apply(owner, snapshot) {
+            owner.memoriesDrillSnapshot = snapshot;
+
+            const livePane = owner.getMemoriesPane();
+
+            livePane && (livePane.drillSnapshot = snapshot)
+        }
+    },
+
+    /** The decomposed per-seat wake-route envelope — the memories sibling, no variance. */
+    wakeRoutes: {
+        verb          : 'fleetWakeRoutes',
+        fenceField    : 'wakeRoutesReadGeneration',
+        notWiredReason: 'fleet wake-routes verb not wired',
+        failedReason  : 'fleet wake-routes read failed',
+        fallback      : (params, reason) => ({
+            capability: {state: 'unavailable', reason},
+            viewer    : null,
+            count     : 0,
+            seats     : []
+        }),
+        apply(owner, snapshot) {
+            owner.wakeRoutesSnapshot = snapshot;
+
+            const livePane = owner.getWakeRoutesPane();
+
+            livePane && (livePane.snapshot = snapshot)
+        }
+    },
+
+    /**
+     * The deployment's task picture — plus the liveness tick's in-flight accounting: incremented
+     * before the verb check, released in `finally` on this read's OWN settle, never a newer one's.
+     */
+    tasks: {
+        verb          : 'fleetTasks',
+        fenceField    : 'tasksReadGeneration',
+        inFlightField : 'tasksReadInFlight',
+        notWiredReason: 'fleet tasks verb not wired',
+        failedReason  : 'fleet tasks read failed',
+        fallback      : (params, reason) => ({
+            capability: {state: 'unavailable', reason},
+            viewer    : null,
+            sources   : {},
+            running   : [],
+            queued    : [],
+            recent    : [],
+            counts    : {running: 0, queued: 0, recent: 0}
+        }),
+        apply(owner, snapshot) {
+            owner.tasksSnapshot = snapshot;
+
+            const livePane = owner.getTasksPane();
+
+            livePane && (livePane.snapshot = snapshot)
+        }
+    },
+
+    /**
+     * The OPERATOR's own mailbox mirror. The gate is the honest outcome, not an error: no pane /
+     * no bound subject / no verb → the pane's `unobserved` state stands (nothing is fabricated);
+     * a throwing bridge KEEPS the last-known snapshot (`errorMode: 'keep'`). The viewer is
+     * server-resolved at the ingress; the subject is the operator's own identity, held owner-side.
+     */
+    operatorInbox: {
+        verb      : 'fleetMailboxMirror',
+        fenceField: 'operatorInboxReadGeneration',
+        errorMode : 'keep',
+        gate(owner, params, bridge) {
+            return Boolean(
+                owner.getOperatorMailboxPane() &&
+                owner.operatorRecord?.agentIdentityNodeId &&
+                typeof bridge?.fleetMailboxMirror === 'function'
+            )
+        },
+        wireParams(params, owner) {
+            return {subjectAgentId: owner.operatorRecord?.agentIdentityNodeId, offset: params.offset ?? 0}
+        },
+        apply(owner, snapshot) {
+            owner.operatorSnapshot = snapshot;
+
+            // resolve at WRITE time (phase-blind): the admission read still gates the request,
+            // but a pane torn out or returning during the await gets the fresh truth
+            const livePane = owner.getOperatorMailboxPane();
+
+            livePane && (livePane.snapshot = snapshot)
+        }
+    }
+};
+
+/**
+ * @summary Clear the owner-held memories drill-in — the pane's close intent. The generation bump
+ * makes the close TERMINAL for in-flight reads: the counter is the change-proxy for "is this read
+ * still wanted", and close is a second way to make a read unwanted — without the bump, a read
+ * landing after close would repopulate the owner state (and the pane) for exactly the drill the
+ * operator left.
+ * @param {Neo.container.Base} owner
+ */
+function clearSessionMemoriesDrill(owner) {
+    owner.memoriesDrillReadGeneration++;
+    owner.memoriesDrillSession  = null;
+    owner.memoriesDrillSnapshot = null
+}
+
+/**
+ * @summary BOOT: resolve the operator's OWN identity from the authenticated bridge (whoami) and
+ * hold it owner-side — the bootstrap leg of "the client SAYS self, the admission stamp proves it".
+ * The mirror read requires an EXPLICIT subject (a self-default at a trust boundary is
+ * spoof-adjacent), so the cockpit first learns its own @-id, then the pane passes it and the
+ * mirror's admission re-stamps + proves it. Fail-closed: an unwired source / unbound context /
+ * absent bridge leaves `operatorRecord` null and the pane honestly unobserved — never a fabricated
+ * identity. Deliberately OUTSIDE {@link #readFencedSource}: no fence (identity is not racing
+ * pagination), no fallback envelope (absence IS the state), and a bridge throw propagates.
+ * @param {Neo.container.Base} owner
+ * @returns {Promise<void>}
+ */
+async function loadOperatorIdentity(owner) {
+    const bridge = resolveFleetBridge();
+
+    if (typeof bridge?.resolveViewerIdentity !== 'function') {
+        return
+    }
+
+    const outcome = await bridge.resolveViewerIdentity();
+
+    // {ok:true, agentIdentityNodeId} | {ok:false, error}. Only a proven identity seeds the
+    // subject; a refusal never reads a wrong inbox.
+    if (outcome?.ok && outcome.agentIdentityNodeId && !owner.isDestroyed) {
+        const nodeId = outcome.agentIdentityNodeId;
+
+        // the reused MailboxPane proves possession from `record.githubUsername` (canonicalized to
+        // `@<username>` against the mirror admission's subject); the node id IS that @-form
+        // authority, so carry both: the username for the possession match, the node id as the
+        // explicit read subject
+        owner.operatorRecord = {agentIdentityNodeId: nodeId, githubUsername: nodeId.replace(/^@/, '')};
+
+        // the seat-conflation honesty check rides the same resolution: a viewer claim matching a
+        // registered agent identity means sends are attributed to that seat — a truth the pane
+        // must render, not swallow
+        owner.operatorIdentityPosture = deriveOperatorIdentityPosture(owner, nodeId);
+
+        // a materialized pane picks up the identity live and reads; a pane that projected first
+        // takes the identity through this same live set — both orderings land exactly one first read
+        owner.getOperatorMailboxPane()?.set({record: owner.operatorRecord, identityPosture: owner.operatorIdentityPosture})
+    }
+}
+
+/**
+ * @summary Compare the resolved viewer identity against the provider-owned roster's agent
+ * identities — the cockpit half of the seat-conflation honesty contract (the fleet server runs
+ * the same decision server-side; the check is trivial enough that duplicating it beats an
+ * app→Brain import across the parity boundary).
+ *
+ * An empty roster answers `null` (cannot judge) rather than `{conflated: false}` — absence of
+ * roster truth is not a clean bill, and the pane renders unknown as unknown.
+ * @param {Neo.container.Base} owner
+ * @param {String} viewerIdentity The resolved `@`-form viewer identity.
+ * @returns {{conflated: Boolean, seatIdentity: String}|null}
+ */
+function deriveOperatorIdentityPosture(owner, viewerIdentity) {
+    const rows = owner.resolveFleetRosterStore()?.items ?? [];
+
+    if (typeof viewerIdentity !== 'string' || !viewerIdentity.trim() || rows.length < 1) {
+        return null
+    }
+
+    const
+        bare      = id => String(id).trim().replace(/^@/, ''),
+        viewer    = bare(viewerIdentity),
+        conflated = rows.some(row => bare(row.agentId ?? '') === viewer);
+
+    return {conflated, seatIdentity: `@${viewer}`}
+}
+
+/**
+ * Static carrier for the fenced source-read discipline — see the module header above.
+ * @class AgentOS.util.CockpitSourceReads
+ * @extends Neo.core.Base
+ */
+class CockpitSourceReads extends Base {
+    static SOURCE_READS = SOURCE_READS
+
+    static config = {
+        /**
+         * @member {String} className='AgentOS.util.CockpitSourceReads'
+         * @protected
+         */
+        className: 'AgentOS.util.CockpitSourceReads'
+    }
+
+    /** @see the module-scope docblock */
+    static clearSessionMemoriesDrill = clearSessionMemoriesDrill
+    /** @see the module-scope docblock */
+    static deriveOperatorIdentityPosture = deriveOperatorIdentityPosture
+    /** @see the module-scope docblock */
+    static loadOperatorIdentity = loadOperatorIdentity
+    /** @see the module-scope docblock */
+    static readFencedSource = readFencedSource
+    /** @see the module-scope docblock */
+    static resolveFleetBridge = resolveFleetBridge
+}
+
+export default Neo.setupClass(CockpitSourceReads);

--- a/apps/agentos/view/fleet/cockpit/Container.mjs
+++ b/apps/agentos/view/fleet/cockpit/Container.mjs
@@ -18,6 +18,7 @@ import ViewerWakeFeed         from '../../../store/ViewerWakeFeed.mjs';
 import WakeRoutePane          from '../wake/Container.mjs';
 import StateProvider          from '../../../../../node_modules/neo.mjs/src/state/Provider.mjs';
 import CockpitDockDocument    from '../../../util/CockpitDockDocument.mjs';
+import CockpitSourceReads     from '../../../util/CockpitSourceReads.mjs';
 import CockpitPresets         from '../../../util/CockpitPresets.mjs';
 import SourceHealth           from '../../../util/SourceHealth.mjs';
 import SpineBanner            from '../../../util/SpineBanner.mjs';
@@ -2531,54 +2532,13 @@ class FleetCockpit extends DockWorkspace {
     }
 
     /**
-     * @summary READ-OBSERVE: route one pane history intent through the authenticated Fleet verb and
-     * write the returned source envelopes back as owner state. Fail-closed: absence/throw becomes an
-     * explicit unavailable snapshot, never an empty historical claim.
+     * @summary READ-OBSERVE: one pane history intent through the fenced source-read discipline.
      * @param {Object} [params]
      * @returns {Promise<Object>}
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadCatchUp(params = {}) {
-        const me         = this,
-              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
-              generation = ++me.catchUpReadGeneration;
-
-        let snapshot;
-
-        if (typeof bridge?.fleetHistory !== 'function') {
-            snapshot = {
-                capability         : {state: 'unavailable', reason: 'fleet history verb not wired'},
-                needsFirstUseWindow: false,
-                partition          : params.partition || 'unified',
-                viewerState        : {lastSeen: null, lastVisitAt: null},
-                window             : null,
-                sources            : null
-            }
-        } else {
-            try {
-                snapshot = await bridge.fleetHistory(params)
-            } catch (error) {
-                snapshot = {
-                    capability         : {state: 'unavailable', reason: 'fleet history read failed'},
-                    needsFirstUseWindow: false,
-                    partition          : params.partition || 'unified',
-                    viewerState        : {lastSeen: null, lastVisitAt: null},
-                    window             : null,
-                    sources            : null
-                }
-            }
-        }
-
-        if (generation === me.catchUpReadGeneration && !me.isDestroyed) {
-            me.catchUpSnapshot = snapshot;
-
-            // resolve at WRITE time (phase-blind): a pane torn out or rebuilt during the await
-            // still receives the truth — the memories owner-seam contract
-            const pane = me.getCatchUpPane();
-
-            pane && (pane.snapshot = snapshot)
-        }
-
-        return snapshot
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.catchUp, params)
     }
 
     /**
@@ -2613,230 +2573,54 @@ class FleetCockpit extends DockWorkspace {
     }
 
     /**
-     * @summary READ-OBSERVE: route one pane memories intent through the authenticated Fleet verb
-     * and write the returned source envelope back as owner state. Fail-closed: absence/throw
-     * becomes an explicit unavailable envelope, never an empty historical claim. Generation-fenced
-     * so a slow older read never overwrites a newer target's rows.
+     * @summary READ-OBSERVE: one pane memories intent through the fenced source-read discipline
+     * (pre-await owner-held target included).
      * @param {Object} [params] `{agentIdentity, offset?, limit?}`
      * @returns {Promise<Object>}
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadMemories(params = {}) {
-        const me         = this,
-              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
-              generation = ++me.memoriesReadGeneration;
-
-        // Owner-hold the requested selection BEFORE any await: a pane removed and rematerialized
-        // while this read is in flight must reopen on the PENDING target (honest switch-pending
-        // state), not on the last accepted snapshot's target and not with a null selection.
-        if (params.agentIdentity) {
-            me.memoriesTarget = params.agentIdentity
-        }
-
-        const
-              fallback   = reason => ({
-                  capability: {state: 'unavailable', reason},
-                  viewer    : null,
-                  target    : params.agentIdentity || null,
-                  page      : {offset: params.offset ?? 0, limit: null},
-                  sessions  : [],
-                  count     : 0,
-                  total     : null
-              });
-
-        let snapshot;
-
-        if (typeof bridge?.fleetMemories !== 'function') {
-            snapshot = fallback('fleet memories verb not wired')
-        } else {
-            try {
-                snapshot = await bridge.fleetMemories(params)
-            } catch (error) {
-                snapshot = fallback('fleet memories read failed')
-            }
-        }
-
-        if (generation === me.memoriesReadGeneration && !me.isDestroyed) {
-            me.memoriesSnapshot = snapshot;
-
-            // Resolve the pane at WRITE time, not call time: the pane can be removed and
-            // rematerialized while this read was in flight — a call-time reference would write
-            // the accepted truth into the DESTROYED instance and leave the live pane pending
-            // forever. The owner state above plus this live-resolve keep both variants coherent.
-            const livePane = me.getMemoriesPane();
-
-            livePane && (livePane.snapshot = snapshot)
-        }
-
-        return snapshot
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.memories, params)
     }
 
     /**
-     * @summary Read one page of a session's turn-level memories through the cockpit-owned
-     * authenticated bridge — the memories drill-in, {@link #loadMemories}' discipline one level
-     * down: the open drill is owner-held BEFORE any await (a pane rematerialized mid-read reopens
-     * on the pending drill), the read is generation-fenced, an unwired verb or throwing bridge
-     * lands as a typed unavailable envelope, and the pane resolves at WRITE time through the
-     * phase-blind accessor so a vesseled or returning-parked pane receives the truth too.
-     * @param {Object} params `{sessionId, title?, offset?, limit?}` — `title` is owner/display
-     *     state only and never rides the wire call.
+     * @summary The memories drill-in through the fenced source-read discipline (pre-await drill
+     * hold; display-only `title` never rides the wire).
+     * @param {Object} params `{sessionId, title?, offset?, limit?}`
      * @returns {Promise<Object>}
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadSessionMemories(params = {}) {
-        const me         = this,
-              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
-              generation = ++me.memoriesDrillReadGeneration;
-
-        if (params.sessionId) {
-            me.memoriesDrillSession = {sessionId: params.sessionId, title: params.title ?? null}
-        }
-
-        const
-              {title, ...wireParams} = params,
-              fallback               = reason => ({
-                  capability: {state: 'unavailable', reason},
-                  viewer    : null,
-                  sessionId : params.sessionId || null,
-                  page      : {offset: params.offset ?? 0, limit: null},
-                  turns     : [],
-                  count     : 0,
-                  total     : null
-              });
-
-        let snapshot;
-
-        if (typeof bridge?.fleetSessionMemories !== 'function') {
-            snapshot = fallback('fleet session-memories verb not wired')
-        } else {
-            try {
-                snapshot = await bridge.fleetSessionMemories(wireParams)
-            } catch (error) {
-                snapshot = fallback('fleet session-memories read failed')
-            }
-        }
-
-        if (generation === me.memoriesDrillReadGeneration && !me.isDestroyed) {
-            me.memoriesDrillSnapshot = snapshot;
-
-            const livePane = me.getMemoriesPane();
-
-            livePane && (livePane.drillSnapshot = snapshot)
-        }
-
-        return snapshot
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.sessionMemories, params)
     }
 
     /**
-     * @summary Clear the owner-held memories drill-in — the pane's close intent lands here, so a
-     * later rematerialization reopens the summary list, never a drill the operator already left.
-     * The last accepted drill snapshot leaves with the session: holding it would rematerialize
-     * rows no open drill points at.
-     *
-     * The generation bump makes the close TERMINAL for in-flight reads: the counter is the
-     * change-proxy for "is this read still wanted", and close is a second way to make a read
-     * unwanted — without the bump, a read landing after close would repopulate the owner state
-     * (and the pane) for exactly the drill the operator left, held harmless only as long as
-     * every render stays keyed on the session rather than the snapshot.
+     * @summary Clear the owner-held memories drill-in — the close is TERMINAL for in-flight reads.
+     * @see AgentOS.util.CockpitSourceReads
      */
     clearSessionMemoriesDrill() {
-        this.memoriesDrillReadGeneration++;
-        this.memoriesDrillSession  = null;
-        this.memoriesDrillSnapshot = null
+        CockpitSourceReads.clearSessionMemoriesDrill(this)
     }
 
     /**
-     * @summary Read the decomposed per-seat wake-route envelope through the cockpit-owned
-     * authenticated bridge — the memories sibling, same discipline end to end: generation-fenced
-     * (a slow older read never overwrites a newer one), fail-honest (an unwired verb or a throwing
-     * bridge lands as a typed unavailable envelope, never fabricated seats), and the pane resolves
-     * at WRITE time so a removed-and-rematerialized pane receives the accepted truth instead of a
-     * destroyed instance swallowing it.
+     * @summary The per-seat wake-route envelope through the fenced source-read discipline.
      * @param {Object} [params]
      * @returns {Promise<Object>}
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadWakeRoutes(params = {}) {
-        const me         = this,
-              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
-              generation = ++me.wakeRoutesReadGeneration,
-              fallback   = reason => ({
-                  capability: {state: 'unavailable', reason},
-                  viewer    : null,
-                  count     : 0,
-                  seats     : []
-              });
-
-        let snapshot;
-
-        if (typeof bridge?.fleetWakeRoutes !== 'function') {
-            snapshot = fallback('fleet wake-routes verb not wired')
-        } else {
-            try {
-                snapshot = await bridge.fleetWakeRoutes(params)
-            } catch (error) {
-                snapshot = fallback('fleet wake-routes read failed')
-            }
-        }
-
-        if (generation === me.wakeRoutesReadGeneration && !me.isDestroyed) {
-            me.wakeRoutesSnapshot = snapshot;
-
-            const livePane = me.getWakeRoutesPane();
-
-            livePane && (livePane.snapshot = snapshot)
-        }
-
-        return snapshot
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.wakeRoutes, params)
     }
 
     /**
-     * @summary Read the deployment's task picture through the cockpit-owned authenticated bridge —
-     * the wake-routes loader's three laws (typed unavailable envelope for an unwired or throwing
-     * bridge, generation fence, write-time pane resolution) plus the liveness tick's in-flight
-     * accounting: the tick launches this read only while fewer than {@link #maxReadsInFlight} are
-     * unsettled, and the count is released on the read's OWN settle, never on a newer read's.
+     * @summary The deployment's task picture through the fenced source-read discipline — plus the
+     * liveness tick's in-flight accounting (released on this read's OWN settle).
      * @param {Object} [params] Reserved; the verb takes no caller input today.
      * @returns {Promise<Object>}
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadTasks(params = {}) {
-        const me         = this,
-              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
-              generation = ++me.tasksReadGeneration,
-              fallback   = reason => ({
-                  capability: {state: 'unavailable', reason},
-                  viewer    : null,
-                  sources   : {},
-                  running   : [],
-                  queued    : [],
-                  recent    : [],
-                  counts    : {running: 0, queued: 0, recent: 0}
-              });
-
-        let snapshot;
-
-        me.tasksReadInFlight++;
-
-        try {
-            if (typeof bridge?.fleetTasks !== 'function') {
-                snapshot = fallback('fleet tasks verb not wired')
-            } else {
-                try {
-                    snapshot = await bridge.fleetTasks(params)
-                } catch (error) {
-                    snapshot = fallback('fleet tasks read failed')
-                }
-            }
-        } finally {
-            me.tasksReadInFlight--
-        }
-
-        if (generation === me.tasksReadGeneration && !me.isDestroyed) {
-            me.tasksSnapshot = snapshot;
-
-            const livePane = me.getTasksPane();
-
-            livePane && (livePane.snapshot = snapshot)
-        }
-
-        return snapshot
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.tasks, params)
     }
 
     /**
@@ -2931,119 +2715,34 @@ class FleetCockpit extends DockWorkspace {
     }
 
     /**
-     * @summary BOOT: resolve the operator's OWN identity from the authenticated bridge (whoami) and hold it
-     * owner-side so the operator-mailbox pane can read its own inbox — the missing bootstrap leg of "the
-     * client SAYS self, the admission stamp proves it". The mirror read requires an EXPLICIT subjectAgentId
-     * (never a viewer-default — a self-default at a trust boundary is spoof-adjacent), so the cockpit first
-     * learns its own @-id via `resolveViewerIdentity`, then the pane passes it and the mirror's admission
-     * re-stamps + proves it. Pushing the record to a materialized pane drives its first read (the pane fires
-     * `inboxPageRequest` on a newly-bound identity); a pane a custom document dropped materializes from the
-     * held record at its next projection. Fail-closed: an unwired source / unbound context / absent bridge leaves `operatorRecord` null,
-     * so the pane stays honestly unobserved — never a fabricated or fallback identity.
+     * @summary BOOT: resolve and owner-hold the operator's own identity + seat posture.
      * @protected
+     * @see AgentOS.util.CockpitSourceReads
      */
     async loadOperatorIdentity() {
-        const
-            me     = this,
-            bridge = globalThis.AgentOS?.fleet?.registryBridge;
-
-        if (typeof bridge?.resolveViewerIdentity !== 'function') {
-            return
-        }
-
-        const outcome = await bridge.resolveViewerIdentity();
-
-        // {ok:true, agentIdentityNodeId} | {ok:false, error} (source-not-wired | unbound). Only a proven
-        // identity seeds the subject; a refusal never reads a wrong inbox.
-        if (outcome?.ok && outcome.agentIdentityNodeId && !me.isDestroyed) {
-            const nodeId = outcome.agentIdentityNodeId;
-            // the reused MailboxPane proves possession from `record.githubUsername` — it canonicalizes it
-            // to `@<username>` and matches the mirror admission's `subjectAgentId`. Seeding only the node
-            // id fails that guard closed and the own inbox NEVER renders. The resolved node id IS the
-            // `@`-form authority, so carry both: `githubUsername` for the possession match, the node id as
-            // the explicit read subject (they canonicalize to the same value).
-            me.operatorRecord = {agentIdentityNodeId: nodeId, githubUsername: nodeId.replace(/^@/, '')};
-            // the seat-conflation honesty check rides the same resolution: the roster the cockpit
-            // already holds knows every registered agent identity, and a viewer claim matching one
-            // means sends are attributed to that seat — a truth the pane must render, not swallow
-            me.operatorIdentityPosture = me.deriveOperatorIdentityPosture(nodeId);
-            // a materialized pane picks up the identity live and reads; when this resolution loses
-            // the boot race instead, the resident pane already projected without a record and takes
-            // the identity through this same live set — both orderings land exactly one first read
-            me.getOperatorMailboxPane()?.set({record: me.operatorRecord, identityPosture: me.operatorIdentityPosture})
-        }
+        return CockpitSourceReads.loadOperatorIdentity(this)
     }
 
     /**
-     * @summary Compare the resolved viewer identity against the provider-owned roster's agent
-     * identities — the cockpit half of the seat-conflation honesty contract (the fleet server
-     * runs the same decision server-side at boot over the registry; the check is trivial enough
-     * that duplicating it beats an app→Brain import across the parity boundary).
-     *
-     * An empty roster answers `null` (cannot judge) rather than `{conflated: false}` — absence of
-     * roster truth is not a clean bill, and the pane renders unknown as unknown.
+     * @summary The seat-conflation honesty check against the provider-owned roster.
      * @param {String} viewerIdentity The resolved `@`-form viewer identity.
      * @returns {{conflated: Boolean, seatIdentity: String}|null}
+     * @see AgentOS.util.CockpitSourceReads
      */
     deriveOperatorIdentityPosture(viewerIdentity) {
-        const rows = this.resolveFleetRosterStore()?.items ?? [];
-
-        if (typeof viewerIdentity !== 'string' || !viewerIdentity.trim() || rows.length < 1) {
-            return null
-        }
-
-        const
-            bare      = id => String(id).trim().replace(/^@/, ''),
-            viewer    = bare(viewerIdentity),
-            conflated = rows.some(row => bare(row.agentId ?? '') === viewer);
-
-        return {conflated, seatIdentity: `@${viewer}`}
+        return CockpitSourceReads.deriveOperatorIdentityPosture(this, viewerIdentity)
     }
 
     /**
-     * @summary READ-OBSERVE: re-read the OPERATOR's own mailbox mirror at `offset` and route the snapshot
-     * to the operator-mailbox pane — the cockpit's ONE mailbox surface (a selection-scoped per-agent
-     * subject mode re-enters here when the S5 Fleet grants/admission layer lands — viewer ingress
-     * is already live; the policy ledger holds the mirror read at awaiting-s5).
-     * Generation-fenced (older news never overwrites newer) and fail-closed (the pane stays honestly
-     * unobserved rather than inventing a snapshot). The viewer is server-resolved from the ingress request
-     * context; the subject is the operator's own identity, held owner-side.
+     * @summary READ-OBSERVE: the operator's own mailbox mirror through the fenced source-read
+     * discipline (gate = the honest unobserved outcome; a throwing bridge keeps the last truth).
      * @param {Object} [params]
      * @param {Number} [params.offset=0]
      * @protected
+     * @see AgentOS.util.CockpitSourceReads
      */
-    async loadOperatorInbox({offset = 0} = {}) {
-        const
-            me      = this,
-            pane    = me.getOperatorMailboxPane(),
-            bridge  = globalThis.AgentOS?.fleet?.registryBridge,
-            subject = me.operatorRecord?.agentIdentityNodeId;
-
-        const generation = ++me.operatorInboxReadGeneration;
-
-        if (!pane || !subject || typeof bridge?.fleetMailboxMirror !== 'function') {
-            // no bound identity / no bridge / no verb IS the honest unobserved truth — never a fabricated
-            // snapshot; the pane's own `unobserved` state stands until a real read lands
-            return
-        }
-
-        try {
-            const snapshot = await bridge.fleetMailboxMirror({subjectAgentId: subject, offset});
-
-            // the fence: an interval re-poll or a post-compose re-read can race a page-request read; the
-            // loser must not write staler news over newer, and a read outliving its owner has no pane to speak for
-            if (generation === me.operatorInboxReadGeneration && !me.isDestroyed) {
-                me.operatorSnapshot = snapshot;
-
-                // resolve at WRITE time (phase-blind): the admission read above still gates the
-                // request, but a pane torn out or returning during the await gets the fresh truth
-                const livePane = me.getOperatorMailboxPane();
-
-                livePane && (livePane.snapshot = snapshot)
-            }
-        } catch (error) {
-            // fail-closed: the last-known snapshot stays; the pane never renders "no mail" for a read that did not happen
-        }
+    async loadOperatorInbox(params = {}) {
+        return CockpitSourceReads.readFencedSource(this, CockpitSourceReads.SOURCE_READS.operatorInbox, params)
     }
 
     /**

--- a/test/playwright/unit/apps/agentos/util/cockpitSourceReads.spec.mjs
+++ b/test/playwright/unit/apps/agentos/util/cockpitSourceReads.spec.mjs
@@ -189,6 +189,33 @@ test.describe('AgentOS.util.CockpitSourceReads — the one fenced-read disciplin
         expect(owner.memoriesDrillSnapshot).toBe(null)
     });
 
+    test('loadOperatorIdentity dispatches posture through the OWNER — a custom override is invoked, never the private default', async () => {
+        const calls = [];
+        const pane  = {set(values) { calls.push(values) }};
+        const owner = {
+            isDestroyed           : false,
+            operatorRecord        : null,
+            operatorIdentityPosture: null,
+            getOperatorMailboxPane: () => pane,
+            // the sentinel override — the shipped virtual seam this witness pins (review control
+            // on the first head returned static-bypass; this test is red against that head)
+            deriveOperatorIdentityPosture(nodeId) {
+                calls.push({override: nodeId});
+                return {conflated: false, seatIdentity: nodeId, sentinel: true}
+            }
+        };
+
+        await withBridge(
+            {resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@sentinel-seat'})},
+            () => CockpitSourceReads.loadOperatorIdentity(owner)
+        );
+
+        expect(calls[0]).toEqual({override: '@sentinel-seat'});
+        expect(owner.operatorIdentityPosture).toEqual({conflated: false, seatIdentity: '@sentinel-seat', sentinel: true});
+        expect(owner.operatorRecord).toEqual({agentIdentityNodeId: '@sentinel-seat', githubUsername: 'sentinel-seat'});
+        expect(calls[1]).toEqual({record: owner.operatorRecord, identityPosture: owner.operatorIdentityPosture})
+    });
+
     test('the wire payload strips display-only title on the drill read', async () => {
         const owner = makeOwner();
         let seenWire;

--- a/test/playwright/unit/apps/agentos/util/cockpitSourceReads.spec.mjs
+++ b/test/playwright/unit/apps/agentos/util/cockpitSourceReads.spec.mjs
@@ -1,0 +1,203 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({appConfig: {name: 'CockpitSourceReadsTest'}});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from '../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core         from '../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import CockpitSourceReads from '../../../../../../apps/agentos/util/CockpitSourceReads.mjs';
+
+const {readFencedSource, SOURCE_READS} = CockpitSourceReads;
+
+/**
+ * The fenced source-read laws, pinned ONCE at the discipline (#48, first cut of Epic #22) instead
+ * of per-source stubs: generation fence, typed fallback on unwired AND throwing bridges,
+ * WRITE-time pane resolution (a destroyed-during-await owner never gets written), tasks in-flight
+ * release on the read's OWN settle, and the operator-inbox gate + keep-last-truth error mode.
+ * The cockpit's verbs are thin delegates over exactly these paths.
+ */
+test.describe('AgentOS.util.CockpitSourceReads — the one fenced-read discipline', () => {
+    /** @returns {Object} a minimal owner carrying the fields the descriptors touch */
+    function makeOwner(pane = {}) {
+        return {
+            isDestroyed: false,
+
+            catchUpReadGeneration      : 0,
+            memoriesReadGeneration     : 0,
+            memoriesDrillReadGeneration: 0,
+            wakeRoutesReadGeneration   : 0,
+            tasksReadGeneration        : 0,
+            operatorInboxReadGeneration: 0,
+            tasksReadInFlight          : 0,
+
+            catchUpSnapshot: null, memoriesSnapshot: null, memoriesDrillSnapshot: null,
+            wakeRoutesSnapshot: null, tasksSnapshot: null, operatorSnapshot: null,
+            memoriesTarget: null, memoriesDrillSession: null,
+            operatorRecord: {agentIdentityNodeId: '@e2e-operator'},
+
+            getCatchUpPane        : () => pane,
+            getMemoriesPane       : () => pane,
+            getWakeRoutesPane     : () => pane,
+            getTasksPane          : () => pane,
+            getOperatorMailboxPane: () => pane
+        }
+    }
+
+    const withBridge = async (bridge, run) => {
+        const held = globalThis.AgentOS;
+        globalThis.AgentOS = {fleet: {registryBridge: bridge}};
+        try { return await run() } finally { globalThis.AgentOS = held }
+    };
+
+    test('an unwired verb lands the typed unavailable fallback — never a fabricated success', async () => {
+        const owner = makeOwner();
+
+        const snapshot = await withBridge({}, () => readFencedSource(owner, SOURCE_READS.memories, {agentIdentity: '@x'}));
+
+        expect(snapshot.capability).toEqual({state: 'unavailable', reason: 'fleet memories verb not wired'});
+        expect(snapshot.target).toBe('@x');
+        expect(owner.memoriesSnapshot).toBe(snapshot);
+        // the pre-await hold ran even though the verb was absent — the pending truth is honest
+        expect(owner.memoriesTarget).toBe('@x')
+    });
+
+    test('a throwing bridge lands the typed failed fallback under the same envelope shape', async () => {
+        const owner = makeOwner();
+
+        const snapshot = await withBridge(
+            {fleetWakeRoutes: async () => { throw new Error('boom') }},
+            () => readFencedSource(owner, SOURCE_READS.wakeRoutes, {})
+        );
+
+        expect(snapshot.capability.reason).toBe('fleet wake-routes read failed');
+        expect(snapshot.seats).toEqual([]);
+        expect(owner.wakeRoutesSnapshot).toBe(snapshot)
+    });
+
+    test('the generation fence: a slow OLDER read never overwrites a newer one', async () => {
+        const owner = makeOwner();
+        let releaseSlow;
+
+        const slowSnapshot = {capability: {state: 'wired'}, sessions: ['old'], count: 1};
+        const fastSnapshot = {capability: {state: 'wired'}, sessions: ['new'], count: 1};
+
+        const slow = withBridge(
+            {fleetMemories: () => new Promise(resolve => { releaseSlow = () => resolve(slowSnapshot) })},
+            () => readFencedSource(owner, SOURCE_READS.memories, {agentIdentity: '@a'})
+        );
+
+        await Promise.resolve();   // the slow read has bumped its generation and is awaiting
+
+        await withBridge(
+            {fleetMemories: async () => fastSnapshot},
+            () => readFencedSource(owner, SOURCE_READS.memories, {agentIdentity: '@b'})
+        );
+
+        expect(owner.memoriesSnapshot).toBe(fastSnapshot);
+
+        releaseSlow();
+        await slow;
+
+        // the loser returned its payload but wrote NOTHING
+        expect(owner.memoriesSnapshot).toBe(fastSnapshot);
+        expect(owner.memoriesTarget).toBe('@b')
+    });
+
+    test('WRITE-time resolution: an owner destroyed during the await is never written', async () => {
+        const owner = makeOwner();
+        let release;
+
+        const pending = withBridge(
+            {fleetTasks: () => new Promise(resolve => { release = () => resolve({capability: {state: 'wired'}}) })},
+            () => readFencedSource(owner, SOURCE_READS.tasks, {})
+        );
+
+        await Promise.resolve();
+        owner.isDestroyed = true;
+        release();
+        await pending;
+
+        expect(owner.tasksSnapshot).toBe(null)
+    });
+
+    test('tasks in-flight accounting releases on the read\'s OWN settle — throw included', async () => {
+        const owner = makeOwner();
+
+        expect(owner.tasksReadInFlight).toBe(0);
+
+        let observedDuring;
+
+        await withBridge(
+            {fleetTasks: async () => { observedDuring = owner.tasksReadInFlight; throw new Error('down') }},
+            () => readFencedSource(owner, SOURCE_READS.tasks, {})
+        );
+
+        expect(observedDuring).toBe(1);
+        expect(owner.tasksReadInFlight).toBe(0)
+    });
+
+    test('the operator-inbox gate refuses honestly (no write) and a throwing bridge KEEPS the last truth', async () => {
+        const owner = makeOwner();
+
+        // gate: no bound subject → silent honest return, nothing written, nothing thrown
+        owner.operatorRecord = null;
+        const refused = await withBridge(
+            {fleetMailboxMirror: async () => ({rows: ['never']})},
+            () => readFencedSource(owner, SOURCE_READS.operatorInbox, {})
+        );
+        expect(refused).toBe(undefined);
+        expect(owner.operatorSnapshot).toBe(null);
+
+        // keep-last-truth: an accepted snapshot survives a later throwing read
+        owner.operatorRecord = {agentIdentityNodeId: '@e2e-operator'};
+        const accepted = {rows: ['truth'], page: {offset: 0}};
+
+        await withBridge(
+            {fleetMailboxMirror: async wire => {
+                expect(wire).toEqual({subjectAgentId: '@e2e-operator', offset: 0});
+                return accepted
+            }},
+            () => readFencedSource(owner, SOURCE_READS.operatorInbox, {})
+        );
+        expect(owner.operatorSnapshot).toBe(accepted);
+
+        await withBridge(
+            {fleetMailboxMirror: async () => { throw new Error('wire down') }},
+            () => readFencedSource(owner, SOURCE_READS.operatorInbox, {offset: 50})
+        );
+        expect(owner.operatorSnapshot).toBe(accepted)
+    });
+
+    test('the drill close is TERMINAL for in-flight reads (the clear bumps the fence)', async () => {
+        const owner = makeOwner();
+        let release;
+
+        const pending = withBridge(
+            {fleetSessionMemories: () => new Promise(resolve => { release = () => resolve({capability: {state: 'wired'}, turns: ['late']}) })},
+            () => readFencedSource(owner, SOURCE_READS.sessionMemories, {sessionId: 'S1', title: 'T'})
+        );
+
+        await Promise.resolve();
+        expect(owner.memoriesDrillSession).toEqual({sessionId: 'S1', title: 'T'});
+
+        CockpitSourceReads.clearSessionMemoriesDrill(owner);
+        release();
+        await pending;
+
+        // the read landed after close: owner state stays cleared, nothing repopulates
+        expect(owner.memoriesDrillSession).toBe(null);
+        expect(owner.memoriesDrillSnapshot).toBe(null)
+    });
+
+    test('the wire payload strips display-only title on the drill read', async () => {
+        const owner = makeOwner();
+        let seenWire;
+
+        await withBridge(
+            {fleetSessionMemories: async wire => { seenWire = wire; return {capability: {state: 'wired'}} }},
+            () => readFencedSource(owner, SOURCE_READS.sessionMemories, {sessionId: 'S1', title: 'display only', offset: 5})
+        );
+
+        expect(seenWire).toEqual({sessionId: 'S1', offset: 5})
+    });
+});

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "763c5cfe0239acabe5b01f9306cc07595ae68b14acce49d5636b05b4f5093c4b",
+        "apps/agentos": "cd1659d90012b7db966d74458f0b853249dd526ea9f452c01951d180500f3b5e",
         "resources/scss": "a30e79a8d88accc613584c4cd76f684a3df118d518fe83ca2e7e90a0e53592de",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "e340453f41a96e570d2ade86f4cc993251bf24c89b57580e2fa2b23b4cab3ef9",
+        "apps/agentos": "763c5cfe0239acabe5b01f9306cc07595ae68b14acce49d5636b05b4f5093c4b",
         "resources/scss": "a30e79a8d88accc613584c4cd76f684a3df118d518fe83ca2e7e90a0e53592de",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",


### PR DESCRIPTION
Resolves #48
Related: #22 (parent epic)

The first extraction cut of Epic #22: the cockpit's seven bridge-read verbs — one discipline, hand-rolled per source — now state that discipline ONCE. `FleetCockpit` Container.mjs: **3,640 → 3,339 (−301, +34/−335)**.

Evidence: L2 (full agentos unit tree **732 passed / 0 failed** — the pre-cut 723 pass IDENTICALLY plus 9 new law witnesses (the owner-dispatch sentinel joined per review RA-1); component battery 3/3 consecutive; visual 6/6 against untouched goldens) → L2 required. Residual: none — behavior frozen by construction and witnessed by the unchanged pass set.

## What

**`AgentOS.util.CockpitSourceReads`** (a static `core.Base` util — the view/util topology laws put class modules in the view tree and PascalCase statics in util): `readFencedSource(owner, descriptor, params)` carries the shared laws exactly as shipped — verb-presence check, typed unavailable fallback envelope, read-generation fence with the original bump-first order (a gate-refused intent still invalidates older in-flight reads), owner-held snapshot write, WRITE-time pane resolution through the phase-blind accessors. The measured per-source variance is explicit descriptor hooks in the `SOURCE_READS` table:

| Source | Variance captured |
|---|---|
| `catchUp` | partition-carrying fallback |
| `memories` | `preAwait` owner-held target (pending-truth reopen) |
| `sessionMemories` | `preAwait` drill hold · `wireParams` strips display-only `title` |
| `wakeRoutes` | none — the uniform base case |
| `tasks` | `inFlightField` accounting, released in `finally` on the read's OWN settle |
| `operatorInbox` | `gate` (pane + bound subject + verb = the honest unobserved refusal) · `errorMode: 'keep'` (a throwing bridge preserves the last truth) · owner-derived wire subject |

`loadOperatorIdentity` + `deriveOperatorIdentityPosture` move as named statics — deliberately OUTSIDE the template (no fence, absence IS the state, a bridge throw propagates); `clearSessionMemoriesDrill` keeps its terminal-fence semantics. The cockpit keeps thin delegates with unchanged public signatures; the full behavioral docblocks moved WITH the substance.

## AC Evidence

- Generic core + descriptor table, unchanged delegate signatures — [L1] the diff; [L2] every existing cockpit/owner-seam spec (memories `ownerSeam.spec` included) passes untouched.
- ≥ 250 net lines out of the class — [L1] 3,640 → 3,339 (−301).
- Identical pass set before/after — [L2] 723 → 723 + 8; zero modified existing specs.
- The law witnesses — [L2] `cockpitSourceReads.spec.mjs`: fence loser writes nothing; typed fallback on unwired AND throwing bridges; destroyed-during-await owner never written; tasks in-flight observed at 1 during the read and released on its own settle (throw path); operator-inbox gate short-circuit + keep-last-truth; terminal drill close (late read repopulates nothing); wire-title strip asserted on the actual wire payload.
- AC-7 — [L2] visual 6/6, stamp per commit.

## RA Disposition (Round 1, @neo-gpt)

- **RA-1 (virtual posture seam)** — fixed at `ddd4813`: `loadOperatorIdentity` now dispatches `owner.deriveOperatorIdentityPosture(nodeId)` (the delegate routes the default back into the module; owner-side overrides seat again), witnessed by a sentinel-override test that is red against the prior head (`b7ad375`, the reviewer's `static-bypass` control).
- **RA-2 (exact LOC)** — corrected in the body AND in the rewritten history: the first commit's message was reworded in place (amend + cherry-pick; trees byte-identical to the reviewed head — `git diff` empty), so no public commit carries the stale −295. True measure everywhere: 3,640 → 3,339 (−301, +34/−335); the −295 was a pre-reshape intermediate.

## Deltas

One declared: the ticket sketched the module as a `view/fleet/cockpit` sibling; the repo's topology laws (view tree = class modules only; util tree = PascalCase `core.Base` statics) place it as `AgentOS.util.CockpitSourceReads` instead — caught by the topology conformance specs during the cut, which is exactly what they are for.

## Post-Merge Validation

None deferred. Next cuts under #22 (their own PRs): the routing-matrix read class (`loadRoster`/`loadActivity`/`loadBrainHealth`), the write verbs (`markCatchUp`, `composeOperatorMessage`), the vessel + chrome families, the file-size guard.

Authored by Clio (Fable 5, Claude Code). Session 41859592-b7ee-4bce-bee3-f25644d9003b.
