### PR TITLE
feat(build): mechanical 1k-LOC app-file guard closes the #22 epic (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
             - name: Check visual baseline freshness
               run: npm run check-visual-baselines
 
+            # The #22 epic's closing clause: the 1k-LOC app-file bar with teeth — a file past the
+            # bar fails here with the offender list instead of regrowing the monolith silently.
+            - name: Check app file sizes
+              run: npm run check-app-file-sizes
+
             - name: Run isolated unit tests
               run: npm run test-unit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
             - name: Check visual baseline freshness
               run: npm run check-visual-baselines
 
-            # The #22 epic's closing clause: the 1k-LOC app-file bar with teeth — a file past the
-            # bar fails here with the offender list instead of regrowing the monolith silently.
+            # The app-file size bar with teeth — a tracked apps/** module past the 1k-line bar
+            # fails here with the offender list instead of regrowing a monolith silently.
             - name: Check app file sizes
               run: npm run check-app-file-sizes
 

--- a/buildScripts/checkAppFileSizes.mjs
+++ b/buildScripts/checkAppFileSizes.mjs
@@ -1,0 +1,95 @@
+import {execSync} from 'node:child_process';
+import fs         from 'node:fs';
+
+/**
+ * @summary The 1k-LOC bar with teeth: a mechanical size gate over the `apps/**` product surface.
+ *
+ * The #22 epic decomposed the 3.3k-LOC FleetCockpit god object into responsibility-seam leaves —
+ * and its measurements show WHY a gate must outlive the cleanup: the debt class regressed once
+ * before (3,327 → 3,487 LOC across a single feature PR) precisely because no gate watched it.
+ * This script is the epic's closing clause: every tracked `apps/**` `.mjs` file is measured, and
+ * a file past the bar fails CI with the offender list instead of merging silently.
+ *
+ * One budget, no exemptions — decided at #55 with the childapps question settled by measurement:
+ * the demo monolith the epic exempted-in-principle (dockdemo / DemoBWorkspace) had already been
+ * relocated out of the product app by the time this guard was born (neomjs/neo#16322 /
+ * neomjs/neo#15614), so a childapps carve would exempt nothing today and would HIDE a returning
+ * demo monolith tomorrow — the exact debt shape the relocation removed.
+ *
+ * The ladder: warn ≥ 900 lines (headroom is shrinking — plan the next seam), error > 1,000 lines
+ * (the bar itself; the line count of `wc -l`, matching the epic's measurements). The bar is the
+ * SYMPTOM threshold — the fix is extraction along responsibility seams, never line golf; #22
+ * records the proven seam families.
+ *
+ * Check: npm run check-app-file-sizes   (CI + local; exits 1 with offenders past the bar)
+ */
+
+/**
+ * Warn threshold, in `wc -l` lines: at or above, the file is named as approaching the bar.
+ * @type {Number}
+ */
+export const WARN_LOC = 900;
+
+/**
+ * Error threshold, in `wc -l` lines: strictly above, the check fails.
+ * @type {Number}
+ */
+export const ERROR_LOC = 1000;
+
+/**
+ * The git pathspec defining the guarded surface: every tracked module of the product apps.
+ * @type {String}
+ */
+export const guardPathspec = 'apps/**/*.mjs';
+
+/**
+ * @summary The pure verdict half: classify measured entries against the warn/error ladder.
+ *
+ * Exported for the unit witness — the boundary semantics (1,000 warns, 1,001 errors) are part of
+ * the guard's contract, not an accident of the comparison operators.
+ * @param {Object[]} entries `{path, lines}` per measured file.
+ * @returns {{errors: Object[], warnings: Object[]}} Both lists sorted largest-first.
+ */
+export function classifyEntries(entries) {
+    const
+        bySize   = [...entries].sort((a, b) => b.lines - a.lines),
+        errors   = bySize.filter(entry => entry.lines > ERROR_LOC),
+        warnings = bySize.filter(entry => entry.lines <= ERROR_LOC && entry.lines >= WARN_LOC);
+
+    return {errors, warnings}
+}
+
+/**
+ * @summary The measurement half: line counts for every tracked file the pathspec matches.
+ *
+ * `git ls-files` keeps the inventory index-true (untracked scratch files cannot fail CI), and the
+ * count matches `wc -l` — the unit the epic's own measurements use.
+ * @param {String} cwd Repository root to measure from.
+ * @returns {Object[]} `{path, lines}` per tracked file.
+ */
+export function collectAppFileSizes(cwd) {
+    return execSync(`git ls-files -z '${guardPathspec}'`, {cwd, encoding: 'utf8'})
+        .split('\0')
+        .filter(Boolean)
+        .map(file => {
+            const content = fs.readFileSync(`${cwd}/${file}`, 'utf8');
+
+            return {path: file, lines: content.split('\n').length - (content.endsWith('\n') ? 1 : 0)}
+        })
+}
+
+const invokedAsScript = process.argv[1]?.endsWith('checkAppFileSizes.mjs');
+
+if (invokedAsScript) {
+    const {errors, warnings} = classifyEntries(collectAppFileSizes(process.cwd()));
+
+    warnings.forEach(({path, lines}) => console.warn(`⚠ ${path} (${lines} lines, warn ≥ ${WARN_LOC}) — headroom is shrinking; plan the next responsibility-seam cut (#22)`));
+
+    if (errors.length > 0) {
+        errors.forEach(({path, lines}) => console.error(`✗ ${path} (${lines} lines > ${ERROR_LOC})`));
+        console.error(`\nThe 1k-LOC app-file bar failed. The fix is extraction along responsibility seams (see #22's seam families), never line golf.`);
+        process.exit(1)
+    }
+
+    console.log(`✓ app file sizes: ${errors.length} over the ${ERROR_LOC}-line bar, ${warnings.length} in the warn band (≥ ${WARN_LOC})`)
+}

--- a/buildScripts/checkAppFileSizes.mjs
+++ b/buildScripts/checkAppFileSizes.mjs
@@ -1,25 +1,28 @@
-import {execSync} from 'node:child_process';
-import fs         from 'node:fs';
+import {execSync}      from 'node:child_process';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 /**
  * @summary The 1k-LOC bar with teeth: a mechanical size gate over the `apps/**` product surface.
  *
- * The #22 epic decomposed the 3.3k-LOC FleetCockpit god object into responsibility-seam leaves —
- * and its measurements show WHY a gate must outlive the cleanup: the debt class regressed once
- * before (3,327 → 3,487 LOC across a single feature PR) precisely because no gate watched it.
- * This script is the epic's closing clause: every tracked `apps/**` `.mjs` file is measured, and
- * a file past the bar fails CI with the offender list instead of merging silently.
+ * The cockpit decomposition split a 3.3k-line god object into responsibility-seam leaves — and the
+ * record shows WHY a gate must outlive the cleanup: the debt class regressed once before
+ * (3,327 → 3,487 lines across a single feature PR) precisely because no gate watched it. This
+ * script is the closing clause of that decomposition: every tracked `apps/**` `.mjs` file is
+ * measured, and a file past the bar fails CI with the offender list instead of merging silently.
  *
- * One budget, no exemptions — decided at #55 with the childapps question settled by measurement:
- * the demo monolith the epic exempted-in-principle (dockdemo / DemoBWorkspace) had already been
- * relocated out of the product app by the time this guard was born (neomjs/neo#16322 /
- * neomjs/neo#15614), so a childapps carve would exempt nothing today and would HIDE a returning
- * demo monolith tomorrow — the exact debt shape the relocation removed.
+ * One budget, no exemptions — settled by measurement at adoption: the demo monolith once
+ * considered for a carve had already been relocated out of the product tree by the time this guard
+ * was born, so a childapps carve would exempt nothing and would HIDE a returning demo monolith —
+ * the exact debt shape the relocation removed. (Historical coordinates live with the guard's
+ * ticket and PR, not here: the enforcement contract must stay readable without issue archaeology.)
  *
- * The ladder: warn ≥ 900 lines (headroom is shrinking — plan the next seam), error > 1,000 lines
- * (the bar itself; the line count of `wc -l`, matching the epic's measurements). The bar is the
- * SYMPTOM threshold — the fix is extraction along responsibility seams, never line golf; #22
- * records the proven seam families.
+ * The ladder: warn at 900 lines (headroom is shrinking — plan the next responsibility-seam cut),
+ * error above 1,000 lines (the bar itself). Lines are NEWLINE COUNTS, exactly `wc -l`: an empty
+ * file and a file without a final newline measure 0 and n respectively, matching the units the
+ * decomposition record was measured in. The bar is the SYMPTOM threshold — the fix is extraction
+ * along responsibility seams, never line golf.
  *
  * Check: npm run check-app-file-sizes   (CI + local; exits 1 with offenders past the bar)
  */
@@ -63,7 +66,9 @@ export function classifyEntries(entries) {
  * @summary The measurement half: line counts for every tracked file the pathspec matches.
  *
  * `git ls-files` keeps the inventory index-true (untracked scratch files cannot fail CI), and the
- * count matches `wc -l` — the unit the epic's own measurements use.
+ * count is the file's NEWLINE count — exactly `wc -l`, the unit the decomposition record uses.
+ * Exported for the hermetic inventory witness: the breadth of the guarded surface is part of the
+ * contract, so narrowing the pathspec or carving a subtree out must turn a spec red.
  * @param {String} cwd Repository root to measure from.
  * @returns {Object[]} `{path, lines}` per tracked file.
  */
@@ -71,23 +76,22 @@ export function collectAppFileSizes(cwd) {
     return execSync(`git ls-files -z '${guardPathspec}'`, {cwd, encoding: 'utf8'})
         .split('\0')
         .filter(Boolean)
-        .map(file => {
-            const content = fs.readFileSync(`${cwd}/${file}`, 'utf8');
-
-            return {path: file, lines: content.split('\n').length - (content.endsWith('\n') ? 1 : 0)}
-        })
+        .map(file => ({
+            path : file,
+            lines: (fs.readFileSync(`${cwd}/${file}`, 'utf8').match(/\n/g) || []).length
+        }))
 }
 
-const invokedAsScript = process.argv[1]?.endsWith('checkAppFileSizes.mjs');
+const isEntryScript = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
-if (invokedAsScript) {
+if (isEntryScript) {
     const {errors, warnings} = classifyEntries(collectAppFileSizes(process.cwd()));
 
-    warnings.forEach(({path, lines}) => console.warn(`⚠ ${path} (${lines} lines, warn ≥ ${WARN_LOC}) — headroom is shrinking; plan the next responsibility-seam cut (#22)`));
+    warnings.forEach(({path, lines}) => console.warn(`⚠ ${path} (${lines} lines, warn ≥ ${WARN_LOC}) — headroom is shrinking; plan the next responsibility-seam cut`));
 
     if (errors.length > 0) {
         errors.forEach(({path, lines}) => console.error(`✗ ${path} (${lines} lines > ${ERROR_LOC})`));
-        console.error(`\nThe 1k-LOC app-file bar failed. The fix is extraction along responsibility seams (see #22's seam families), never line golf.`);
+        console.error(`\nThe app-file size bar failed. The fix is extraction along responsibility seams, never line golf.`);
         process.exit(1)
     }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "build-themes": "node ./node_modules/neo.mjs/buildScripts/build/themes.mjs",
         "build-threads": "node ./node_modules/neo.mjs/buildScripts/webpack/buildThreads.mjs -f",
         "bundle-parse5": "node ./node_modules/neo.mjs/buildScripts/build/parse5.mjs",
+        "check-app-file-sizes": "node ./buildScripts/checkAppFileSizes.mjs",
         "check-data-tracking": "node ./buildScripts/checkDataTracking.mjs",
         "check-visual-baselines": "node ./buildScripts/checkVisualBaselines.mjs",
         "stamp-visual-baselines": "node ./buildScripts/checkVisualBaselines.mjs --stamp",

--- a/test/playwright/unit/buildScripts/checkAppFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkAppFileSizes.spec.mjs
@@ -1,17 +1,28 @@
 import {test, expect} from '@playwright/test';
+import {execSync}     from 'node:child_process';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
 import {classifyEntries, collectAppFileSizes, ERROR_LOC, WARN_LOC} from '../../../../buildScripts/checkAppFileSizes.mjs';
 
 /**
- * The 1k-bar guard's contract witness. The pure classifier arms pin the ladder's boundary
- * semantics (1,000 warns, 1,001 errors — the bar means BELOW ~1k, so the bar line itself is the
- * last warning, not the first failure), and the live arm runs the real collector over the tracked
- * tree: the guard was born with the bar HOLDING (#22's extractions landed first), and this arm
- * keeps that adoption proof executable.
+ * The app-file size bar's contract witness, in two halves.
+ *
+ * The pure classifier arms pin the ladder's boundary semantics (1,000 warns, 1,001 errors — the
+ * bar means BELOW ~1k, so the bar line itself is the last warning, not the first failure).
+ *
+ * The hermetic inventory arms drive the REAL collector over a throwaway git repository, because
+ * the guarded breadth is itself the contract: a reviewer falsifier showed that narrowing the
+ * pathspec to one subtree left every threshold arm green while the gate silently stopped watching
+ * the rest of the surface. The temp-repo witness makes that class red — inclusion across app
+ * subtrees (childapps included: no carve exists), exclusion outside `apps/`, and `wc -l` newline
+ * counting pinned on the empty and no-final-newline edge cases.
  *
  * Import safety is witnessed implicitly: importing the module runs no git probe and no
- * process.exit (the CLI flow is entry-guarded) — this suite completing is that witness.
+ * process.exit (the CLI flow is entry-guarded on the resolved module path) — this suite completing
+ * is that witness.
  */
-test.describe('checkAppFileSizes — the 1k-LOC bar\'s ladder contract', () => {
+test.describe('checkAppFileSizes — the ladder contract', () => {
 
     test('a file past the bar is an error; the bar line itself is the last warning', () => {
         const {errors, warnings} = classifyEntries([
@@ -40,6 +51,68 @@ test.describe('checkAppFileSizes — the 1k-LOC bar\'s ladder contract', () => {
         ]);
 
         expect(errors.map(e => e.path)).toEqual(['apps/agentos/view/F.mjs', 'apps/agentos/view/E.mjs'])
+    });
+});
+
+test.describe('checkAppFileSizes — the hermetic inventory contract', () => {
+
+    /**
+     * One throwaway git repository per test run: tracked fixtures spanning the guarded surface's
+     * breadth (a plain app module, a childapps module, a second product app) plus an out-of-scope
+     * module and the two `wc -l` edge cases. `git add` is enough — `ls-files` reads the index, so
+     * no commit (and no user identity) is required.
+     */
+    function makeFixtureRepo() {
+        const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'app-size-guard-'));
+
+        const write = (relPath, content) => {
+            const abs = path.join(repo, relPath);
+
+            fs.mkdirSync(path.dirname(abs), {recursive: true});
+            fs.writeFileSync(abs, content)
+        };
+
+        write('apps/agentos/view/Normal.mjs',        'line\n'.repeat(10));
+        write('apps/agentos/childapps/demo/Big.mjs', 'line\n'.repeat(ERROR_LOC + 1));
+        write('apps/other/App.mjs',                  'line\n'.repeat(3));
+        write('docs/Outside.mjs',                    'line\n'.repeat(2000));
+        write('apps/agentos/util/Empty.mjs',         '');
+        write('apps/agentos/util/NoFinalNewline.mjs', 'one\ntwo\nthree');
+
+        execSync('git init -q && git add .', {cwd: repo});
+
+        return repo
+    }
+
+    test('inventory breadth: app subtrees are IN (childapps carve-free), outside modules are OUT, wc -l is exact', () => {
+        const repo = makeFixtureRepo();
+
+        try {
+            const
+                entries = collectAppFileSizes(repo),
+                byPath  = Object.fromEntries(entries.map(e => [e.path, e.lines]));
+
+            // inclusion across the surface's breadth — a narrowed pathspec reds here
+            expect(byPath['apps/agentos/view/Normal.mjs']).toBe(10);
+            expect(byPath['apps/other/App.mjs']).toBe(3);
+
+            // no childapps carve exists — a reintroduced exemption reds here
+            expect(byPath['apps/agentos/childapps/demo/Big.mjs']).toBe(ERROR_LOC + 1);
+
+            // exclusion: modules outside apps/ never enter the inventory
+            expect(byPath['docs/Outside.mjs']).toBeUndefined();
+
+            // wc -l edge cases: newline counts, not split-based line counts
+            expect(byPath['apps/agentos/util/Empty.mjs']).toBe(0);
+            expect(byPath['apps/agentos/util/NoFinalNewline.mjs']).toBe(2);
+
+            // and the over-budget childapps module is an ERROR through the same public ladder
+            const {errors} = classifyEntries(entries);
+
+            expect(errors.map(e => e.path)).toEqual(['apps/agentos/childapps/demo/Big.mjs'])
+        } finally {
+            fs.rmSync(repo, {recursive: true, force: true})
+        }
     });
 
     test('live tree: the tracked apps/** surface holds the bar (the adoption proof, kept executable)', () => {

--- a/test/playwright/unit/buildScripts/checkAppFileSizes.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkAppFileSizes.spec.mjs
@@ -1,0 +1,54 @@
+import {test, expect} from '@playwright/test';
+import {classifyEntries, collectAppFileSizes, ERROR_LOC, WARN_LOC} from '../../../../buildScripts/checkAppFileSizes.mjs';
+
+/**
+ * The 1k-bar guard's contract witness. The pure classifier arms pin the ladder's boundary
+ * semantics (1,000 warns, 1,001 errors — the bar means BELOW ~1k, so the bar line itself is the
+ * last warning, not the first failure), and the live arm runs the real collector over the tracked
+ * tree: the guard was born with the bar HOLDING (#22's extractions landed first), and this arm
+ * keeps that adoption proof executable.
+ *
+ * Import safety is witnessed implicitly: importing the module runs no git probe and no
+ * process.exit (the CLI flow is entry-guarded) — this suite completing is that witness.
+ */
+test.describe('checkAppFileSizes — the 1k-LOC bar\'s ladder contract', () => {
+
+    test('a file past the bar is an error; the bar line itself is the last warning', () => {
+        const {errors, warnings} = classifyEntries([
+            {path: 'apps/agentos/view/A.mjs', lines: ERROR_LOC + 1},
+            {path: 'apps/agentos/view/B.mjs', lines: ERROR_LOC}
+        ]);
+
+        expect(errors.map(e => e.path)).toEqual(['apps/agentos/view/A.mjs']);
+        expect(warnings.map(w => w.path)).toEqual(['apps/agentos/view/B.mjs'])
+    });
+
+    test('the warn band opens at WARN_LOC and everything below stays silent', () => {
+        const {errors, warnings} = classifyEntries([
+            {path: 'apps/agentos/view/C.mjs', lines: WARN_LOC},
+            {path: 'apps/agentos/view/D.mjs', lines: WARN_LOC - 1}
+        ]);
+
+        expect(errors).toEqual([]);
+        expect(warnings.map(w => w.path)).toEqual(['apps/agentos/view/C.mjs'])
+    });
+
+    test('both lists render largest-first — the worst offender leads the CI output', () => {
+        const {errors} = classifyEntries([
+            {path: 'apps/agentos/view/E.mjs', lines: ERROR_LOC + 5},
+            {path: 'apps/agentos/view/F.mjs', lines: ERROR_LOC + 500}
+        ]);
+
+        expect(errors.map(e => e.path)).toEqual(['apps/agentos/view/F.mjs', 'apps/agentos/view/E.mjs'])
+    });
+
+    test('live tree: the tracked apps/** surface holds the bar (the adoption proof, kept executable)', () => {
+        const entries = collectAppFileSizes(process.cwd());
+
+        expect(entries.length).toBeGreaterThan(0);
+
+        const {errors} = classifyEntries(entries);
+
+        expect(errors, errors.map(e => `${e.path} (${e.lines})`).join(', ')).toEqual([])
+    });
+});


### PR DESCRIPTION
Resolves #55

The last open clause of the decomposition epic #22 ("the invariant gets teeth"): a mechanical file-size guard over the `apps/**` product surface, in the existing `check-*` family shape (pure exported cores + entry-guarded CLI, mirroring `checkVisualBaselines.mjs`).

- **`buildScripts/checkAppFileSizes.mjs`** — `git ls-files`-driven (index-true inventory), exact `wc -l` newline counting (empty file = 0, no-final-newline pinned), warn ≥ 900 / error > 1,000 ladder with named-constant thresholds. Boundary semantics: the bar means BELOW ~1k, so 1,000 is the last warning and 1,001 the first failure. Entry guard by resolved module-path equality, matching the sibling.
- **One budget, no exemptions** — the childapps question the epic left to this sub, settled by measurement: dockdemo/DemoBWorkspace is already relocated (tracked `childapps/**` = 39 LOC across 2 files), so a carve would exempt nothing today and would HIDE a returning demo monolith tomorrow. Decision + rationale in the script header (mechanism language, no ticket archaeology); historical coordinates live here and in #55: neomjs/neo#16322 / neomjs/neo#15614.
- **CI:** `check-app-file-sizes` step beside the baseline-freshness gate in the Isolated job, before the expensive suites; npm script wired.
- **Witness, two halves:** ladder-boundary arms over the pure classifier, and a **hermetic inventory contract** over a throwaway git repo — inclusion across app subtrees (a second product app, and an over-budget `childapps/**` module that must ERROR: carve-free is asserted, not assumed), exclusion outside `apps/`, `wc -l` edge cases, plus the live adoption-proof arm. Narrowing the pathspec or reintroducing a childapps carve reds the inventory arms (reviewer falsifier class, now mutation-resistant).

Adoption truth: the guard ships green with two honest warnings (`cockpit/Controller.mjs` 928, `cockpit/VesselContainer.mjs` 902 — both mine from the #50 rebuild; the warn band is exactly the pressure the epic wants on the next seam cut).

No `apps/**` or `resources/scss` content moved — the visual-baseline stamp is untouched by scope.

Batteries: guard run green (0 errors / 2 warnings) · buildScripts suite 11/11 · full isolated unit 732 passed.

Authored by Clio (Fable 5, Claude Code). Session 729e92a3-fa8a-4c4f-bc72-6c0ad1a5e604.
