### PR TITLE
feat(agentos): agent-detail rail IA — identity row, state ledger, capacity gating, tab-seam pop-out (#60)

### DIFF
--- a/apps/agentos/view/fleet/cockpit/VesselContainer.mjs
+++ b/apps/agentos/view/fleet/cockpit/VesselContainer.mjs
@@ -182,18 +182,24 @@ class VesselContainer extends DockWorkspace {
 
     /**
      * @summary SHELL-owned pop-out affordance config for the inspector — routes by the vessel
-     * state machine; {@link #syncControlBar} keeps the label naming the action it will take.
-     * Same pane-chrome placement contract as {@link #buildMemoriesWindowToggle}.
+     * state machine; {@link #syncVesselChrome} keeps title + aria naming the action it will take.
+     *
+     * Icon-only by design (#23, operator direction): the pane places this through its
+     * layout-blind `shellTools` slot onto the tab header bar's ACTION seam — one icon at the
+     * strip's trailing edge, outside the content flow (the old text button floated OVER the
+     * identity block at rail widths). `contextual: false` keeps it persistent: windowing the
+     * pane is a pane verb, not a per-tab one. The label lives on title + aria-label, byte-equal.
      * @returns {Object}
      */
     buildDetailWindowToggle() {
         return {
-            module   : Button,
-            cls      : ['fm-detail-window-toggle'],
-            handler  : this.onDetailWindowToggle.bind(this),
-            iconCls  : 'fa-solid fa-arrow-up-right-from-square',
-            reference: 'detail-window-toggle',
-            text     : 'Pop out detail'
+            module    : Button,
+            cls       : ['fm-detail-window-toggle'],
+            contextual: false,
+            handler   : this.onDetailWindowToggle.bind(this),
+            iconCls   : 'fa-solid fa-arrow-up-right-from-square',
+            reference : 'detail-window-toggle',
+            vdom      : {title: 'Pop out detail', 'aria-label': 'Pop out detail'}
         }
     }
 
@@ -841,10 +847,16 @@ class VesselContainer extends DockWorkspace {
             // toggle is inert — one vessel pathway at a time (G4 owns richer convergence)
             torn   = Boolean(me.tearOutPanes?.detail || me.tearOutPaneHandles?.detail);
 
-        toggle?.set({
-            disabled: state === 'reattaching' || torn,
-            text    : torn ? 'Detail torn out' : (out ? 'Reattach detail' : 'Pop out detail')
-        });
+        if (toggle) {
+            const label = torn ? 'Detail torn out' : (out ? 'Reattach detail' : 'Pop out detail');
+
+            toggle.set({disabled: state === 'reattaching' || torn});
+            // icon-only action (#23): the state-named label rides title + aria, byte-equal —
+            // attribute strings, inert by construction
+            toggle.vdom.title          = label;
+            toggle.vdom['aria-label']  = label;
+            toggle.mounted && toggle.update()
+        }
 
         // the exception-only recall verb: visible ONLY while the pane is away — the main view
         // must always hold a way home, and the traveling pane-side toggle cannot provide it here.

--- a/apps/agentos/view/fleet/detail/Container.mjs
+++ b/apps/agentos/view/fleet/detail/Container.mjs
@@ -228,34 +228,23 @@ class AgentDetail extends Container {
                     ntype    : 'component',
                     cls      : ['fm-detail-id'],
                     reference: 'detail-id'
-                }, {
-                    // availability (participationStatus), not a role — honest status word or nothing
-                    ntype    : 'component',
-                    cls      : ['fm-detail-participation'],
-                    reference: 'detail-participation'
-                }, {
-                    // The FULL two-axis telltale readout. The card is exception-based — nominal earns
-                    // zero pixels there, because 20 cards cannot spend a line each on "fine". This is
-                    // ONE resident, so both axes state themselves unconditionally: an operator who
-                    // drilled in cannot otherwise tell "wake is on" from "nobody looked at wake".
-                    // Lives in the identity block rather than a fifth pane — the four SSOT panes are
-                    // content surfaces with freshness TTLs, and this is resident state.
-                    ntype    : 'component',
-                    cls      : ['fm-detail-telltale'],
-                    reference: 'detail-telltale'
-                }, {
-                    // The full three-source provenance readout — the drill-in counterpart to the card's
-                    // ONE honest word-line. The card names only the abnormal source(s) (20 compact cards
-                    // cannot each spend three lines on provenance); the resident detail states all three
-                    // unconditionally, each with the producer that reported it — the evidence the summary
-                    // had no room for. Reads the SAME SourceHealth.normalizeFleetSources output as the card's strip, so
-                    // detail and card can never disagree about a source's health. Sibling to the telltale
-                    // by design: both are resident identity state, not freshness-gated pane content.
-                    ntype    : 'component',
-                    cls      : ['fm-detail-sources'],
-                    reference: 'detail-sources'
                 }]
             }]
+        }, {
+            // ONE state ledger in the pane's own freshness-pill vocabulary (#23) — the identity
+            // block above stays pure identity (name is the only display-tier line). Every
+            // liveness/wiring axis renders exactly once as an `axis · pill` row: availability,
+            // the wake telltale, capacity (SOURCE-GATED: the axis renders only when a producer
+            // reported it — a permanently-unobservable row is furniture, not honesty), and the
+            // three data sources. Nominal states render too — this is ONE resident, and an
+            // operator who drilled in needs "wake on" confirmed, not omitted (the card stays
+            // exception-based). Provenance (producer literal, consumer reason) rides each pill's
+            // title attribute — inert by construction, like every text node here.
+            ntype    : 'component',
+            cls      : ['fm-detail-ledger'],
+            flex     : 'none',
+            hidden   : true,
+            reference: 'detail-ledger'
         }, {
             // the drill-in's tabbed body: Status panes + the Configuration card — the a11y region
             // + identity header stay above. Mail is NOT a detail concern: the south pane is the
@@ -300,8 +289,11 @@ class AgentDetail extends Container {
         // render flush; a later re-seat (applyRecord) keeps the root, so the region survives.
         Object.assign(this.vdom, {role: 'region', 'aria-label': 'Agent detail'});
 
-        // shell-supplied window verbs land at the identity header's trailing edge (layout-blind slot)
-        this.shellTools?.length && this.getReference('detail-header')?.add(this.shellTools);
+        // shell-supplied window verbs ride the tab header bar's ACTION seam (#23, operator
+        // direction): one icon at the trailing edge of the tab strip, outside the content flow —
+        // the old identity-header placement floated the verb OVER the identity block at rail
+        // widths. The slot stays layout-blind for the shell; this pane only picks the seam.
+        this.shellTools?.length && (this.getReference('detail-tabs').headerActions = this.shellTools);
         // the pane renders and never fetches: it fires the page intent, this view (which holds the
         // read seam and the subject) performs the bounded re-read. Wired explicitly rather than via
         // a string handler — this view carries no controller for one to resolve against.
@@ -505,10 +497,12 @@ class AgentDetail extends Container {
             record = me.record,
             empty  = me.getReference('detail-empty'),
             header = me.getReference('detail-header'),
+            ledger = me.getReference('detail-ledger'),
             tabs   = me.getReference('detail-tabs');
 
         empty.hidden  = !!record;
         header.hidden = !record;
+        ledger.hidden = !record;
         tabs.hidden   = !record;
 
         // the configuration tab joins on the Fleet Registry key; a roster resident with no stored
@@ -539,79 +533,7 @@ class AgentDetail extends Container {
         me.getReference('detail-engine').text = record.engineTag ?? '';
         me.getReference('detail-id').text     = agentId;
 
-        // availability, rendered honestly — a known status word, or hidden when unstamped (null =
-        // no identity-root fact; never guessed, never a role)
-        const participation = record.participationStatus ?? null;
-
-        me.getReference('detail-participation').set({
-            hidden: participation === null,
-            text  : participation === null ? '' : participation.replace(/_/g, ' ')
-        });
-
-        // The full two-axis readout: BOTH axes, always — the opposite of the card's exception-based
-        // chip, and deliberately so. Three renderings for three different facts: a nominal axis says
-        // so (an operator who drilled in needs "wake: on" confirmed, not omitted), an observed
-        // `unknown` carries the producer's reason, and an axis nobody reported says "not reported"
-        // rather than borrowing 'unknown' — which would claim someone looked.
-        const readout = Telltale.describeTelltaleReadout({throttle: record.throttle, wake: record.wake});
-
-        // Built as VDOM nodes carrying `text`, never an `html` string. `reason` is the PRODUCER's
-        // sentence — it crosses a process boundary before it reaches here — and Neo routes `html` to
-        // innerHTML (src/vdom/Helper.mjs), so interpolating it made a remote adapter's error message
-        // executable in the cockpit. A `text` node is inert by construction, which is the only version
-        // of this that cannot be got wrong again later: escaping is a thing you must remember, and a
-        // text node is a thing you cannot forget.
-        const telltale = me.getReference('detail-telltale');
-
-        telltale.vdom.cn = readout.flatMap(({axis, reason, reported, state}) => {
-            if (!reported) {
-                return [{tag: 'span', cls: ['fm-detail-telltale-axis', 'fm-detail-telltale-unreported'], text: `${axis}: not reported`}]
-            }
-
-            const nodes = [{tag: 'span', cls: ['fm-detail-telltale-axis', `fm-detail-telltale-${state}`], text: `${axis}: ${state}`}];
-
-            // the reason is the producer's evidence for what it could not see; the card has no room
-            // for it, which is what makes a degraded chip a prompt to drill in rather than a dead end
-            if (reason) {
-                nodes.push({tag: 'span', cls: ['fm-detail-telltale-reason'], text: `— ${reason}`})
-            }
-
-            return nodes
-        });
-
-        telltale.update();
-
-        // The three-source provenance readout — the drill-in counterpart to the card's one word-line.
-        // Each source states itself unconditionally (like the telltale's axes): a wired source names its
-        // confidence AND its producer; a not-wired / missing source says so plainly. State rides the TEXT
-        // ("not wired" / "missing"), never colour alone (WCAG 1.4.1). Built as `text` VDOM nodes, never an
-        // `html` string — `fact.source` is a producer literal that crossed a process boundary, and Neo
-        // routes `html` to innerHTML; a text node is inert by construction.
-        const
-            sourceLabels  = {runtime: 'Runtime', repoStatus: 'Repository', roster: 'Roster'},
-            sourceOrder   = ['runtime', 'repoStatus', 'roster'],
-            detailSources = me.getReference('detail-sources');
-
-        detailSources.vdom.cn = sourceOrder.flatMap(key => {
-            const
-                fact      = sources[key],
-                stateText = fact.state === 'wired' ? `wired · ${fact.confidence}` : fact.state.replace(/-/g, ' '),
-                nodes     = [{
-                    tag : 'span',
-                    cls : ['fm-detail-sources-axis', `fm-detail-sources-${fact.state}`],
-                    text: `${sourceLabels[key]}: ${stateText}`
-                }];
-
-            // the producer literal is the provenance evidence — which adapter reported this fact; the
-            // card's one-word summary cannot carry it, which is the point of the drill-in
-            if (fact.source) {
-                nodes.push({tag: 'span', cls: ['fm-detail-sources-producer'], text: `— ${fact.source}`})
-            }
-
-            return nodes
-        });
-
-        detailSources.update();
+        me.renderStateLedger(record, sources);
 
         me.getReference('detail-avatar').set({
             alt: record.displayName ?? agentId,
@@ -622,13 +544,86 @@ class AgentDetail extends Container {
     }
 
     /**
+     * @summary Render the ONE state ledger — every liveness/wiring axis once, as `axis · pill`
+     * rows in the pane's own freshness-pill vocabulary (#23: three vocabularies became one).
+     *
+     * Rows, in order: availability (participationStatus — a known status word or no row),
+     * the wake telltale (BOTH renderings the old readout carried: a nominal axis says so, an
+     * observed `unknown` keeps the producer's reason — on the pill title now), capacity
+     * (the throttle axis, SOURCE-GATED: it renders only when a producer actually reported it —
+     * the adapter documents that no trustworthy capacity truth source exists yet, so an
+     * unconditional row could only ever say "not reported": furniture, not honesty; the row
+     * returns with its producer, wearing a word that means what the enum measures), and the
+     * three data sources with their producer literals on the title.
+     *
+     * Tone classes reuse the freshness family deliberately (one pill language per pane):
+     * `is-fresh` = nominal, `is-stale` = deviating, `is-unobserved` = absent/unknown/not wired.
+     *
+     * Built as `text` VDOM nodes with `title` ATTRIBUTES, never an `html` string — reasons and
+     * producer literals cross a process boundary before they reach here, and Neo routes `html`
+     * to innerHTML; text nodes and attribute strings are inert by construction.
+     * @param {Object} record The drilled-in FleetAgent record (never null here).
+     * @param {Object} sources `SourceHealth.normalizeFleetSources` output — the SAME resolved
+     *     truth the card's strip reads, so detail and card can never disagree.
+     * @protected
+     */
+    renderStateLedger(record, sources) {
+        const
+            me     = this,
+            ledger = me.getReference('detail-ledger'),
+            rows   = [],
+            row    = (axis, word, tone, title) => rows.push(
+                {tag: 'span', cls: ['fm-ledger-axis'], text: axis},
+                {tag: 'span', cls: ['fm-freshness', tone], text: word, ...(title ? {title} : {})}
+            );
+
+        const participation = record.participationStatus ?? null;
+
+        participation !== null && row('status', participation.replace(/_/g, ' '),
+            participation === 'active' ? 'is-fresh' : 'is-stale');
+
+        Telltale.describeTelltaleReadout({throttle: record.throttle, wake: record.wake})
+            .forEach(({axis, reason, reported, state}) => {
+                // capacity (the renamed throttle axis) is source-gated; wake states itself always
+                if (axis === 'throttle' && !reported) {
+                    return
+                }
+
+                const
+                    label = axis === 'throttle' ? 'capacity' : axis,
+                    word  = reported ? state : 'not reported',
+                    tone  = !reported || state === 'unknown' ? 'is-unobserved'
+                          : (state === 'on' || state === 'none') ? 'is-fresh' : 'is-stale';
+
+                row(label, word, tone, reason || null)
+            });
+
+        const
+            sourceLabels = {runtime: 'runtime', repoStatus: 'repository', roster: 'roster'},
+            sourceOrder  = ['runtime', 'repoStatus', 'roster'];
+
+        sourceOrder.forEach(key => {
+            const
+                fact  = sources[key],
+                wired = fact.state === 'wired',
+                word  = wired ? `wired · ${fact.confidence}` : fact.state.replace(/-/g, ' ');
+
+            row(sourceLabels[key], word, wired ? 'is-fresh' : 'is-unobserved', fact.source || null)
+        });
+
+        ledger.vdom.cn = rows;
+        ledger.update()
+    }
+
+    /**
      * @summary Render each pane's freshness chip + known body content, honestly.
      *
      * Every pane header shows its observation freshness — timestamped `fresh`/`stale`/`lost` from a
      * wired ledger, or `unobserved` until its feed lands (never a silently-current
      * claim). The `lane` pane additionally renders the record-known lane line + open-lane count; the
-     * feed-gated panes (thought-stream / repo / prs) render an honest "awaiting …" body until their
-     * Lane-C / memory-surface leaf wires content.
+     * feed-gated panes (thought-stream / repo / prs) keep their body EMPTY until their Lane-C /
+     * memory-surface leaf wires content — the head's freshness pill carries the awaiting truth on
+     * its title (#23: the per-section boilerplate collapsed into the one provenance pill).
      * @protected
      */
     applyPaneFreshness() {
@@ -645,15 +640,24 @@ class AgentDetail extends Container {
 
             // .text (never .html): the label is ours but the pane body is record-derived
             // (laneLine), so it must be escaped text, never interpreted markup — no injection surface
-            me.getReference(`pane-${pane.key}-freshness`).set({cls, text: label});
+            const freshnessChip = me.getReference(`pane-${pane.key}-freshness`);
+
+            freshnessChip.set({cls, text: label});
+            // the awaiting truth rides the pill's title (one provenance pill per section — #23);
+            // an attribute string is inert, like every text node here
+            freshnessChip.vdom.title = ledger ? null : 'awaiting live feed — no source wired for this pane yet';
+            freshnessChip.update();
+
             me.getReference(`pane-${pane.key}-body`).text = me.renderPaneBody(pane.key, record)
         })
     }
 
     /**
      * @summary The honest body content for one pane from the record's known facts. The `lane` pane
-     * renders the real lane line + open-lane count; the feed-gated panes render an "awaiting" line
-     * until their source leaf lands (degrade honestly, never a fabricated stream).
+     * renders the real lane line + open-lane count; the feed-gated panes render NO body until
+     * their source leaf lands — the head's freshness pill already states "not observed — source
+     * not wired" and carries the awaiting detail on its title, so a body line repeating it was
+     * the same fact told twice per section (#23).
      * @param {String} key Pane key.
      * @param {Object} record The drilled-in FleetAgent record (never null here).
      * @returns {String}
@@ -669,7 +673,7 @@ class AgentDetail extends Container {
             return `${laneLine}${countText}`
         }
 
-        return 'awaiting live feed'
+        return ''
     }
 }
 

--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -61,6 +61,58 @@
        fact, and the animation exists only under no-preference (the StateDot inclusion-gate). */
     --fm-motion-pulse: 2400ms;
 
+    /* TAB HEADER ACTIONS — the app-wide contract for EVERY tab container (operator direction,
+       2026-08-30: one rule for all tab bars, never per-pane styling). The engine's header
+       toolbar stamps each action with `neo-toolbar-action`, so this targets the seam itself:
+       any pane placing a verb through `headerActions` inherits the same quiet icon form.
+
+       Geometry: a 24px square HIT AREA (an 11px glyph alone is a stray pixel to click), the
+       glyph in the chrome register (12px — one step above the 11px labels, an icon needs the
+       extra optical weight), centered on the toolbar's own axis (height:auto collapses the
+       theme button's 48px default, which floated the old box 9px above the label midline).
+       Quiet at rest, a soft field on hover — body without box weight. */
+    .neo-tab-header-toolbar .neo-button.neo-toolbar-action {
+        display        : inline-flex;
+        align-items    : center;
+        justify-content: center;
+        gap            : 0;
+        width          : 24px;
+        height         : 24px;
+        /* both minimums: the theme pins .neo-button to min-width var(--cmp-button-height) (48px)
+           with a :root prefix — width alone loses to it, and the glyph centers in the phantom */
+        min-height     : 0;
+        min-width      : 0;
+        padding        : 0;
+        background     : transparent;
+        border         : none;
+        border-radius  : 5px;
+        box-shadow     : none;
+        color          : var(--fm-ink-dim);
+        /* the hit field overhangs the content edge by its own half-padding so the icon INK sits
+           on the flush line the pane boxes and ledger pills end on — fields align by ink, boxes
+           by border (measured: without this the glyph reads ~6px shy of the content edge) */
+        margin-right   : -6px;
+        transition     : background var(--fm-motion-fast) var(--ease-out-soft), color var(--fm-motion-fast) var(--ease-out-soft);
+
+        &:hover {
+            border-color: transparent;
+            background  : color-mix(in srgb, var(--fm-ink-dim) 14%, transparent);
+            color       : var(--fm-ink);
+        }
+
+        .neo-button-glyph {
+            color      : inherit;
+            font-size  : 12px;
+            line-height: 1;
+        }
+
+        /* an icon-only action renders an EMPTY text span; any width it takes shoves the glyph
+           off the field's center (measured: 16px of phantom right-side space) */
+        .neo-button-text:empty {
+            display: none;
+        }
+    }
+
     /* The window-verb pair — quiet secondary, owned HERE because the skin must travel with the
        pane: the verbs render in pane chrome (which reparents into the widget vessel, where no
        FleetCockpit sheet ever loads) and as the cockpit bar's exception-only recall pair. This

--- a/resources/scss/src/apps/agentos/fleet/detail/Container.scss
+++ b/resources/scss/src/apps/agentos/fleet/detail/Container.scss
@@ -34,29 +34,27 @@
         border-bottom : 1px solid var(--fm-line-soft);
     }
 
+    /* 64px, grid-locked: size encodes drill depth — the roster card wears 40px, and the detail
+       is ONE resident's profile surface, so its portrait reads clearly ABOVE the card tier
+       (operator call, 2026-08-30: a detail avatar at-or-below card size inverts the hierarchy).
+       Grid-locked means it can never squeeze the identity text below readability — the text
+       column owns the remaining width, and the NAME is the only ellipsizing line in the pane. */
     .fm-detail-avatar {
-        width        : 48px;
-        height       : 48px;
+        width        : 64px;
+        height       : 64px;
         flex         : none;
         border-radius: 50%;
         object-fit   : cover;
         background   : color-mix(in srgb, var(--fm-ink-dim) 20%, transparent);
     }
 
-    /* the shell-supplied window verb docks at the header's trailing edge — layout owned here,
-       never as an inline style on the shell's config */
-    .fm-detail-header .fm-detail-window-toggle {
-        flex       : none;
-        margin-left: auto;
-    }
-
     .fm-detail-identity {
         gap      : 2px;
         overflow : hidden;
-        /* a flex child's automatic minimum is its content size: without a floor the identity
-           column refuses to shrink and the header's trailing shell tool pays with a clipped
-           label. The ch-floor makes the squeeze SHARED: the name ellipsizes down to a readable
-           stub, and only past that does the trailing verb start giving way. */
+        /* a flex child's automatic minimum is its content size: the floor keeps the name
+           ellipsizing to a readable stub instead of the column collapsing under rail pressure.
+           (The window verb left the header for the tab bar's action seam — #23 — so the column
+           no longer shares its width with a trailing control.) */
         min-width: 12ch;
     }
 
@@ -81,18 +79,38 @@
         color: var(--fm-ink-dim);
     }
 
-    /* the durable anchor — always shown, smallest + faintest: the name is display state OVER it */
+    /* the durable anchor — always shown, smallest + faintest: the name is display state OVER it.
+       Aligned with the NAME's text edge, not the row edge (operator call, 2026-08-30): the handle
+       is the durable form of the same identity, so name + handle read as ONE text column; the
+       state dot is a marker ON the name, never a column anchor. Indent = dot 8px + row gap 7px. */
     .fm-detail-id {
-        font : var(--fm-text-micro);
-        color: var(--fm-ink-dim);
+        font        : var(--fm-text-micro);
+        color       : var(--fm-ink-dim);
+        padding-left: 15px;
     }
 
-    /* availability (participationStatus), not a role */
-    .fm-detail-participation {
-        font          : var(--fm-text-detail);   /* 11px meta → detail: availability is session-metadata, the mono meta voice */
-        color         : var(--fm-ink-dim);
-        text-transform: capitalize;
+    /* THE ONE STATE LEDGER (#23): every liveness/wiring axis once, `axis · pill` per row, in the
+       pane's own freshness-pill vocabulary — the three prior languages (italic telltale prose,
+       coloured source lines, a dangling producer suffix) collapsed into it. Grid-locked columns:
+       axis words never wrap, the pill column owns the rest; NO row exceeds one line-height at
+       rail widths (the #23 falsifier). Tone mapping documented at the renderer: is-fresh =
+       nominal, is-stale = deviating, is-unobserved = absent/unknown/not wired. */
+    .fm-detail-ledger {
+        display              : grid;
+        grid-template-columns: max-content 1fr;
+        gap                  : 5px 12px;
+        align-items          : center;
+        justify-items        : start;
+        padding-bottom       : 10px;
+        border-bottom        : 1px solid var(--fm-line-soft);
     }
+
+    .fm-ledger-axis {
+        font       : var(--fm-text-detail);
+        color      : var(--fm-ink-dim);
+        white-space: nowrap;
+    }
+
 
     .fm-detail-panes {
         gap     : var(--fm-space-2);
@@ -228,68 +246,6 @@
     }
 }
 
-.fm-agent-detail {
-    // The FULL two-axis readout — both axes always, unlike the card's exception chip.
-    .fm-detail-telltale {
-        display  : flex;
-        flex-wrap: wrap;
-        gap      : 6px 10px;
-        font     : var(--fm-text-detail);
-    }
-
-    .fm-detail-telltale-axis {
-        color: var(--fm-ink-dim);
-    }
-
-    // A deviating axis earns the state color; nominal stays dim, because in the detail "wake: on" is
-    // information the operator asked for, not an alert.
-    .fm-detail-telltale-off,
-    .fm-detail-telltale-suppressed,
-    .fm-detail-telltale-overage,
-    .fm-detail-telltale-rate-limited {
-        color: var(--fm-state-limited);
-    }
-
-    // "we looked and could not see" reads as absent-information, never as an alert and never as health
-    .fm-detail-telltale-unknown {
-        color: var(--fm-ink-dim);
-    }
-
-    // "nobody reported this axis" — the absence of an observation, which is less than an unknown one.
-    // That gradient rides the ITALIC channel rather than a fainter ink: the faint tier measures below
-    // the 4.5:1 text floor on every surface in both skins, and carrying the distinction in colour alone
-    // would make colour the sole bearer of the meaning. Italic separates it while the text stays legible.
-    .fm-detail-telltale-unreported {
-        color     : var(--fm-ink-dim);
-        font-style: italic;
-    }
-
-    .fm-detail-telltale-reason {
-        color: var(--fm-ink-dim);
-    }
-
-    // The three-source provenance readout — the drill-in counterpart to the card's one word-line.
-    .fm-detail-sources {
-        display  : flex;
-        flex-wrap: wrap;
-        gap      : 6px 10px;
-        font     : var(--fm-text-detail);
-    }
-
-    .fm-detail-sources-axis {
-        display: block; // one line per source — a run-together can never read as one broken sentence
-        color  : var(--fm-ink-dim);
-    }
-
-    // A source that is not wired (or missing) earns the state colour; a wired one stays dim, because in
-    // the detail a healthy source is information the operator asked for, not an alert. The state also
-    // rides the TEXT ("not wired" / "missing"), so colour is never the sole bearer of meaning (WCAG 1.4.1).
-    .fm-detail-sources-not-wired,
-    .fm-detail-sources-missing {
-        color: var(--fm-state-limited);
-    }
-
-    .fm-detail-sources-producer {
-        color: var(--fm-ink-dim);
-    }
-}
+/* The telltale/sources prose stacks retired into the state ledger (#23) — one pill vocabulary
+   per pane. State rides the pill TEXT plus its tone class, never colour alone (WCAG 1.4.1); the
+   producer literal and the consumer's reason ride each pill's title attribute. */

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/popOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/popOut.spec.mjs
@@ -178,7 +178,7 @@ test.describe.serial('AgentOS.view.fleet.cockpit.Container — detail pop-out st
 
         // the shell affordance now names the reverse action
         // the verb lives in the pane's chrome and travels with it — resolve through the accessor
-        expect(cockpit.getAgentDetailPane().getReference('detail-window-toggle').text).toBe('Reattach detail')
+        expect(cockpit.getAgentDetailPane().getReference('detail-window-toggle').vdom.title).toBe('Reattach detail')
     });
 
     test('connect: the matching vessel adopts the SAME instance — opening → windowed', async () => {
@@ -239,7 +239,7 @@ test.describe.serial('AgentOS.view.fleet.cockpit.Container — detail pop-out st
         expect(vessel.closeCalls).toHaveLength(1);
         expect(vessel.closeCalls[0].names).toEqual([`fm-agent-detail-${cockpit.id}`]);
 
-        expect(cockpit.getAgentDetailPane().getReference('detail-window-toggle').text).toBe('Pop out detail')
+        expect(cockpit.getAgentDetailPane().getReference('detail-window-toggle').vdom.title).toBe('Pop out detail')
     });
 
     test('blocked popup: windowOpen=false takes the failed-blocked edge and rolls back commit-or-neither', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/tearOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/tearOut.spec.mjs
@@ -298,7 +298,7 @@ test.describe.serial('AgentOS.view.fleet.cockpit.Container — gesture tear-out 
         const toggle = cockpit.getAgentDetailPane().getReference('detail-window-toggle');
 
         expect(toggle.disabled).toBe(true);
-        expect(toggle.text).toBe('Detail torn out');
+        expect(toggle.vdom.title).toBe('Detail torn out');
 
         // the accessor still reaches the live instance (the drill stays live)
         expect(cockpit.getAgentDetailPane()).toBe(detailPane);

--- a/test/playwright/unit/apps/agentos/view/fleet/detail/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/detail/container.spec.mjs
@@ -190,13 +190,14 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
     test('participationStatus renders as availability (not a role); an unstamped status hides the line', () => {
         const detail = createDetail({agentId: 'gem', participationStatus: 'operator_benched', state: 'off'});
 
-        const line = detail.down({reference: 'detail-participation'});
-        expect(line.hidden).toBe(false);
-        expect(line.text).toBe('operator benched');
+        const rowTexts = () => (detail.down({reference: 'detail-ledger'}).vdom.cn ?? []).map(node => node.text ?? '');
 
-        // null (no identity-root fact) → hidden, never guessed
+        expect(rowTexts()).toContain('status');
+        expect(rowTexts()).toContain('operator benched');
+
+        // null (no identity-root fact) → no row, never guessed (#23 ledger: absent facts are absent)
         applySet(detail, {participationStatus: null});
-        expect(detail.down({reference: 'detail-participation'}).hidden).toBe(true);
+        expect(rowTexts()).not.toContain('status');
 
         detail.destroy()
     });
@@ -258,8 +259,11 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
         const detail = createDetail({agentId: 'vega', laneLine: 'FM cockpit agent detail view', openLaneCount: 17, state: 'ok'});
 
         expect(body(detail, 'lane').text).toBe('FM cockpit agent detail view · 17 open lanes');
-        // a feed-gated pane never fabricates a stream
-        expect(body(detail, 'thought-stream').text).toBe('awaiting live feed');
+        // a feed-gated pane never fabricates a stream — and never repeats the head's honest
+        // "not observed" as a body line either (#23): the body stays EMPTY, the awaiting truth
+        // rides the freshness pill's title
+        expect(body(detail, 'thought-stream').text).toBe('');
+        expect(chip(detail, 'thought-stream').vdom.title).toContain('awaiting live feed');
 
         // no lane reported → honest fallback, no fabricated count
         applySet(detail, {laneLine: null, openLaneCount: null});
@@ -284,17 +288,16 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
                   throttle: {source: 'fleet:throttle', state: 'unknown', confidence: 'none', reason: hostile}
               });
 
-        const telltale = detail.down({reference: 'detail-telltale'});
+        const ledger = detail.down({reference: 'detail-ledger'});
 
         // the sink itself: ANY html on this node re-opens the hole regardless of today's content
-        expect(telltale.html).toBeFalsy();
+        expect(ledger.html).toBeFalsy();
 
-        const nodes = telltale.vdom.cn ?? [],
-              texts = nodes.map(node => node.text ?? '');
+        const nodes = ledger.vdom.cn ?? [];
 
-        // carried, inert, and still READABLE — an operator needs the producer's evidence, so escaping
-        // it out of existence would be its own defect
-        expect(texts.some(text => text.includes(hostile))).toBe(true);
+        // carried, inert, and still READABLE — an operator needs the producer's evidence; it rides
+        // the pill's title ATTRIBUTE now (#23), which is an attribute string: inert like a text node
+        expect(nodes.some(node => node.title === hostile)).toBe(true);
 
         // …and nowhere as markup, on any node
         nodes.forEach(node => {
@@ -316,13 +319,16 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
             throttle: {source: 'fleet:throttle', state: 'unknown', confidence: 'none', reason: 'no throttle reader injected'}
         });
 
-        const texts = (detail.down({reference: 'detail-telltale'}).vdom.cn ?? []).map(node => node.text ?? '');
+        const nodes = detail.down({reference: 'detail-ledger'}).vdom.cn ?? [],
+              texts = nodes.map(node => node.text ?? '');
 
-        // both axes always, and the reason with them: the detail is the opposite of the card's
-        // exception-based chip
-        expect(texts.some(text => text.includes('no throttle reader injected'))).toBe(true);
-        expect(texts.some(text => text.includes('throttle: unknown'))).toBe(true);
-        expect(texts.some(text => text.includes('wake: on'))).toBe(true);
+        // an OBSERVED capacity axis renders (the source gate silences only the unreported case),
+        // wearing the axis word the enum measures; the producer's reason rides the pill title
+        expect(texts).toContain('capacity');
+        expect(texts).toContain('unknown');
+        expect(nodes.some(node => node.title === 'no throttle reader injected')).toBe(true);
+        expect(texts).toContain('wake');
+        expect(texts).toContain('on');
 
         detail.destroy()
     });
@@ -331,20 +337,22 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
         // the default fixture wires all three (roster/repo/runtime observed). The detail is the opposite
         // of the card's exception-based strip: every source states itself, with its producer, always —
         // an operator who drilled in needs "runtime: wired, observed by X" confirmed, never omitted.
-        const detail  = createDetail({agentId: 'vega', state: 'ok'}),
-              sources = detail.down({reference: 'detail-sources'});
+        const detail = createDetail({agentId: 'vega', state: 'ok'}),
+              ledger = detail.down({reference: 'detail-ledger'});
 
-        // the same sink guard the telltale carries: ANY html on this node re-opens the innerHTML hole
-        expect(sources.html).toBeFalsy();
+        // the same sink guard the old stacks carried: ANY html on this node re-opens the innerHTML hole
+        expect(ledger.html).toBeFalsy();
 
-        const texts = (sources.vdom.cn ?? []).map(node => node.text ?? '');
+        const nodes = ledger.vdom.cn ?? [],
+              texts = nodes.map(node => node.text ?? '');
 
-        // all three, in full words, each with confidence AND its producer literal — the provenance the
-        // compact card had no room for, which is the entire point of the drill-in
-        expect(texts.some(text => text.includes('Runtime: wired · observed'))).toBe(true);
-        expect(texts.some(text => text.includes('Repository: wired · observed'))).toBe(true);
-        expect(texts.some(text => text.includes('Roster: wired · observed'))).toBe(true);
-        expect(texts.some(text => text.includes('fleet:runtimeStatus'))).toBe(true);
+        // all three axes state themselves, each pill carrying confidence in TEXT and the producer
+        // literal on its title — the provenance the compact card had no room for
+        expect(texts).toContain('runtime');
+        expect(texts).toContain('repository');
+        expect(texts).toContain('roster');
+        expect(texts.filter(text => text === 'wired · observed')).toHaveLength(3);
+        expect(nodes.some(node => node.title === 'fleet:runtimeStatus')).toBe(true);
 
         detail.destroy()
     });
@@ -362,16 +370,19 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
             }
         });
 
-        const nodes       = detail.down({reference: 'detail-sources'}).vdom.cn ?? [],
-              runtimeNode = nodes.find(node => (node.text ?? '').startsWith('Runtime:'));
+        const nodes       = detail.down({reference: 'detail-ledger'}).vdom.cn ?? [],
+              runtimeIdx  = nodes.findIndex(node => node.text === 'runtime'),
+              runtimePill = nodes[runtimeIdx + 1];
 
-        expect(runtimeNode.text).toContain('not wired');
-        expect(runtimeNode.cls).toContain('fm-detail-sources-not-wired');
+        // the condition rides the TEXT plus the absence tone class — never colour alone
+        expect(runtimePill.text).toBe('not wired');
+        expect(runtimePill.cls).toContain('is-unobserved');
 
-        // the readout stays unconditional — the two wired sources still state themselves
+        // the ledger stays unconditional — the two wired sources still state themselves
         const texts = nodes.map(node => node.text ?? '');
-        expect(texts.some(text => text.includes('Repository: wired · observed'))).toBe(true);
-        expect(texts.some(text => text.includes('Roster: wired · observed'))).toBe(true);
+        expect(texts).toContain('repository');
+        expect(texts).toContain('roster');
+        expect(texts.filter(text => text === 'wired · observed')).toHaveLength(2);
 
         detail.destroy()
     });

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "93d2cc9ec69ead450587e0bbca1c89dc385eafb30e3be745257e8ea5827a5ece",
     "inputs": {
-        "apps/agentos": "d2792337e4d9d4f69eb7658cf13ed695d81c04e7c1a275c111a55e063c1709ae",
-        "resources/scss": "9f0b0ea2265fdebadcad4ab8bb1a2f4141d9d97aebf5dc58ee0b1cab4b8df7c4",
+        "apps/agentos": "588b9863deeae72da012a7ac8c39056346aa9d6ecb698ead8132dad82d1de3b7",
+        "resources/scss": "a150c525e448cd139e9963f26acb945760df24469fdc965f8727ac0099c7d0eb",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "1cb24d86fc36bddbc25ed53848977dc0462684718aaab635dc14b1b8b2ff03d4",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "076e640d42b8a201e7e3fdbcaea3f9b062252cbaa77a96e98dc42f032de21d1a",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "308c863432484fa7116728068cbdb3ea34492952d34a169558af5850c2b51386",


### PR DESCRIPTION
Resolves #60

Refs #23 (parent arc). Implementation Cut B of the merged IA sketch (PR #57): the agent-detail rail — stacked on the Cut-A branch so this diff is PURE Cut B (GitHub retargets to dev automatically when PR #58 merges and its branch deletes).

**Identity, one grid row.** 64px portrait, grid-locked — size encodes drill depth (the roster card wears 40px; a detail avatar at-or-below card size inverts the hierarchy — operator call). The NAME is the only display-tier and only ellipsizing node; the handle aligns to the NAME's text edge (dot 8px + gap 7px = 15px indent, derivation in the comment): name + handle read as one text column, the state dot is a marker, not a column anchor.

**One state ledger.** The three vocabularies (italic telltale prose, coloured source lines, dangling producer suffix) collapse into `axis · pill` rows in the pane's own freshness-pill language: status (participation), wake, and the three sources — nominal states render too (this is ONE resident; "wake on" needs confirming, not omitting). Producer literals + consumer reasons ride pill TITLES — attribute strings, inert like text nodes; the html-sink guard holds (hostile-reason witness moved to the ledger).

**`capacity`, source-gated.** The throttle axis renames to what its enum measures (seat capacity: overage / rate-limited — not a speed mode) and renders ONLY when a producer reports: the adapter documents that no truth source exists yet, so the permanently-"not reported" row was furniture, not honesty. Model field, enum and adapter seam stay as shipped; the row returns with its producer.

**Pop-out on the tab header action seam** (operator direction: tab header bar actions, one icon right). The verb leaves the content flow entirely — the old text button floated OVER the identity block at rail widths. Ships with the app-wide tab-action contract in Viewport.scss targeting the ENGINE's own seam (`.neo-tab-header-toolbar .neo-button.neo-toolbar-action`): 24×24 hit field, 12px glyph on the label midline (measured midY equal), quiet-at-rest/soft-field hover, `min-width:0 + min-height:0` (the theme pins .neo-button to 48px minimums with a :root prefix), and the field overhanging −6px so the icon INK sits on the content flush line (measured 1469 vs 1467). EVERY tab container placing `headerActions` inherits this — no per-pane styling.

**Pane boilerplate collapsed.** Feed-gated bodies render empty; the head's freshness pill carries the awaiting truth on its title — the same fact is no longer told twice per section. The lane pane keeps its real body.

Witness moves ride along: participation → ledger status row, hostile-reason sink → ledger title-attribute assertion, sources → ledger rows with producer titles, toggle label assertions → `vdom.title` (popOut/tearOut).

Batteries: unit 732 · components 3 · visual 6/6 (goldens untouched — the detail is closed in every capture; five operator-review iterations each re-verified + restamped) · baseline stamp index-true.

Authored by Clio (Fable 5, Claude Code). Session 729e92a3-fa8a-4c4f-bc72-6c0ad1a5e604.
