### PR TITLE
fix(agentos): the define-agent zone stays lazy — the engine loads it on reveal (#74)

### DIFF
--- a/apps/agentos/view/fleet/cockpit/Container.mjs
+++ b/apps/agentos/view/fleet/cockpit/Container.mjs
@@ -1,5 +1,4 @@
 import ActivityStream         from '../activity/Container.mjs';
-import AddAgentForm           from '../instances/AddAgentForm.mjs';
 import AgentDetail            from '../detail/Container.mjs';
 import Button                 from '../../../../../node_modules/neo.mjs/src/button/Base.mjs';
 // NAMED registration import: the engine's dock LayoutAdapter emits `ntype: 'tab-container'` for tab
@@ -755,13 +754,12 @@ class FleetCockpit extends VesselContainer {
                 // `agentDefinitionAccepted` walks up the component chain to the Viewport's roster
                 // seam — the same consumer Accounts feeds, so both entry points write one truth.
                 //
-                // A STATIC module, on purpose: the zone still opens on explicit intent only (it is
-                // an auto-hidden rail tool), but a lazy `module: () => import(...)` is loaded by the
-                // card layout on tab activation — and a rail item never takes that path. The reveal
-                // overlay's pane slot is a plain container, which keeps a lazy item as an unrendered
-                // object, so the zone revealed EMPTY from the rail and from the bootstrap CTA (#74).
+                // LAZY, like the wake-routes sibling: the zone is an auto-hidden rail tool, so its
+                // module loads on the first reveal — the engine's rail resolves a loader function on
+                // reveal exactly as a card layout does on tab activation, and an eager import would
+                // pay the form's class load, construction and initAsync at app boot.
                 return {
-                    module   : AddAgentForm,
+                    module   : () => import('../instances/AddAgentForm.mjs'),
                     cls      : [marker],
                     listeners: {agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'},
                     reference: 'add-agent-form'

--- a/apps/agentos/view/fleet/cockpit/Container.mjs
+++ b/apps/agentos/view/fleet/cockpit/Container.mjs
@@ -1,4 +1,5 @@
 import ActivityStream         from '../activity/Container.mjs';
+import AddAgentForm           from '../instances/AddAgentForm.mjs';
 import AgentDetail            from '../detail/Container.mjs';
 import Button                 from '../../../../../node_modules/neo.mjs/src/button/Base.mjs';
 // NAMED registration import: the engine's dock LayoutAdapter emits `ntype: 'tab-container'` for tab
@@ -753,9 +754,14 @@ class FleetCockpit extends VesselContainer {
                 // the S5 add-agent flow (rail tool, invoked-not-ambient per the design ruling).
                 // `agentDefinitionAccepted` walks up the component chain to the Viewport's roster
                 // seam — the same consumer Accounts feeds, so both entry points write one truth.
+                //
+                // A STATIC module, on purpose: the zone still opens on explicit intent only (it is
+                // an auto-hidden rail tool), but a lazy `module: () => import(...)` is loaded by the
+                // card layout on tab activation — and a rail item never takes that path. The reveal
+                // overlay's pane slot is a plain container, which keeps a lazy item as an unrendered
+                // object, so the zone revealed EMPTY from the rail and from the bootstrap CTA (#74).
                 return {
-                    // LAZY: the define-agent zone opens on explicit intent only
-                    module   : () => import('../instances/AddAgentForm.mjs'),
+                    module   : AddAgentForm,
                     cls      : [marker],
                     listeners: {agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'},
                     reference: 'add-agent-form'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "hasInstallScript": true,
             "dependencies": {
-                "neo.mjs": "github:neomjs/neo#961ac9cd117ebce481f77dd6f0c07520edf9e87a"
+                "neo.mjs": "github:neomjs/neo#fabb61f0011ec2aa56bcf810f5af78aad706629a"
             },
             "devDependencies": {
                 "@fortawesome/fontawesome-free": "^7.3.0",
@@ -6562,8 +6562,8 @@
         },
         "node_modules/neo.mjs": {
             "version": "13.1.0",
-            "resolved": "git+ssh://git@github.com/neomjs/neo.git#961ac9cd117ebce481f77dd6f0c07520edf9e87a",
-            "integrity": "sha512-JZsTqvdNGyDHcvYl0lDkksmksUnINqrb9LyIdXryethV/w8oshZihTMXerja8ebjDrUQ8iYb1YZ4q3o5Cmts1g==",
+            "resolved": "git+ssh://git@github.com/neomjs/neo.git#fabb61f0011ec2aa56bcf810f5af78aad706629a",
+            "integrity": "sha512-iuUcf0xJl/sXcmlGz08WlG66Xn2UD8azc+ARUo3RqGhoiEYcnj+UkZHIAJVE3wkqnTfsN2xc/ZHZhHzC9XqQlQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "hasInstallScript": true,
             "dependencies": {
-                "neo.mjs": "github:neomjs/neo#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6"
+                "neo.mjs": "github:neomjs/neo#961ac9cd117ebce481f77dd6f0c07520edf9e87a"
             },
             "devDependencies": {
                 "@fortawesome/fontawesome-free": "^7.3.0",
@@ -6562,8 +6562,8 @@
         },
         "node_modules/neo.mjs": {
             "version": "13.1.0",
-            "resolved": "git+ssh://git@github.com/neomjs/neo.git#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6",
-            "integrity": "sha512-9t5WkQu0F71oHGmABwgs07tvrDk02bweQgrwywSKmm1RvPUucanp3x2+BEMCo/73FSQgjxEhEfbiTVw7ajtJ8w==",
+            "resolved": "git+ssh://git@github.com/neomjs/neo.git#961ac9cd117ebce481f77dd6f0c07520edf9e87a",
+            "integrity": "sha512-JZsTqvdNGyDHcvYl0lDkksmksUnINqrb9LyIdXryethV/w8oshZihTMXerja8ebjDrUQ8iYb1YZ4q3o5Cmts1g==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "watch-themes": "node ./node_modules/neo.mjs/buildScripts/helpers/watchThemes.mjs"
     },
     "dependencies": {
-        "neo.mjs": "github:neomjs/neo#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6"
+        "neo.mjs": "github:neomjs/neo#961ac9cd117ebce481f77dd6f0c07520edf9e87a"
     },
     "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "watch-themes": "node ./node_modules/neo.mjs/buildScripts/helpers/watchThemes.mjs"
     },
     "dependencies": {
-        "neo.mjs": "github:neomjs/neo#961ac9cd117ebce481f77dd6f0c07520edf9e87a"
+        "neo.mjs": "github:neomjs/neo#fabb61f0011ec2aa56bcf810f5af78aad706629a"
     },
     "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/test/playwright/e2e/agentos/AddAgentJourneyNL.spec.mjs
+++ b/test/playwright/e2e/agentos/AddAgentJourneyNL.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect, loadAgentOsModule, loadNeuralLinkModules} from '../../fixtures.mjs';
+import {createFleetWireOffer}                                    from '../../../../apps/agentos/config/fleetWireMethods.mjs';
 import {
     authenticatedFleetOptions,
     fleetE2EFailure,
@@ -167,7 +168,10 @@ test.describe('AgentOS S5 add-agent journey (Neural Link)', () => {
 
             const starts = fleet.requests.filter(request => request.method === 'startAgent');
             expect(starts).toHaveLength(1);
-            expect(starts[0]).toEqual({method: 'startAgent', params: TEST_AGENT_ID});
+            // minimal payload — one agent id — plus this realm's versioned protocol offer, asserted
+            // through the exported builder so exact equality keeps rejecting stray keys (the
+            // keyboard witness's shape)
+            expect(starts[0]).toEqual({method: 'startAgent', params: TEST_AGENT_ID, protocol: createFleetWireOffer()});
 
             // ── wire discipline: exactly one defineAgent carried the payload — and the credential
             // exists NOWHERE else: not in another request, not in any readback we injected

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "2f51872caacfc0e6ea6d435b48711542a6db3efcc8ee5f26ce3b4ca8a31d554f",
     "inputs": {
-        "apps/agentos": "6d22d28c775e342023499586cb2c794095f253c93dbf7bc15a0235a11ac8600f",
+        "apps/agentos": "f924ffacf4d9d90e0afbefc9ff82edf637ab5e9aa27b62df572e734c2ab68d40",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "f16c6d5aa5ddef658ef7b239b599ae78d0ba09a68db9d1d67291f882f46960d5",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4c807baa20ec37ff96080624f72577b2e6a0f6f381c947368fb85c26c7a15826",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -1,6 +1,6 @@
 {
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
-    "engine": "2f51872caacfc0e6ea6d435b48711542a6db3efcc8ee5f26ce3b4ca8a31d554f",
+    "engine": "e3686d29ee84ede9077928f3f2533f180489ef18ba82652f734240799b33911a",
     "inputs": {
         "apps/agentos": "f924ffacf4d9d90e0afbefc9ff82edf637ab5e9aa27b62df572e734c2ab68d40",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -1,6 +1,6 @@
 {
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
-    "engine": "e3686d29ee84ede9077928f3f2533f180489ef18ba82652f734240799b33911a",
+    "engine": "b0cd8d5a2941bbb23e3cf63b786bc8f99aaec6c2b3c81abb4c2ad5c45a467712",
     "inputs": {
         "apps/agentos": "f924ffacf4d9d90e0afbefc9ff82edf637ab5e9aa27b62df572e734c2ab68d40",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "2f51872caacfc0e6ea6d435b48711542a6db3efcc8ee5f26ce3b4ca8a31d554f",
     "inputs": {
-        "apps/agentos": "506233bcd5d27f865db608a8f0e4c16de98e89904df59f4d27b8e041f993104a",
+        "apps/agentos": "6d22d28c775e342023499586cb2c794095f253c93dbf7bc15a0235a11ac8600f",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "f16c6d5aa5ddef658ef7b239b599ae78d0ba09a68db9d1d67291f882f46960d5",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4c807baa20ec37ff96080624f72577b2e6a0f6f381c947368fb85c26c7a15826",


### PR DESCRIPTION
Resolves #74

Related: neomjs/neo#18062 / neomjs/neo PR #18063 (the engine's rail half: a rail loads a lazy module item on reveal), neomjs/neo#18084 / neomjs/neo PR #18086 (the engine's tab-flow half: `container.Base#insert` parks a lazy config — the bootstrap CTA's path), #76 / PR #79 (the first pin bump), #73 / PR #75 (the widened battery this is measured with), #10 (parent)

The define-agent zone stays lazy — `module: () => import('../instances/AddAgentForm.mjs')` — and materializes on its first reveal. Two engine halves make that true, one per path the zone opens through, and both are on the `dev` this PR pins (`fabb61f001`):

- **the rail tab** (the operator's explicit-intent path): the rail loads a lazy module item on reveal exactly as a card layout loads a lazy card on activation — neomjs/neo PR #18063.
- **the bootstrap CTA** (the empty-fleet path, `onAddAgentRequest` → `setItemAutoHidden(defineAgent, false)`): the item leaves the rail and the projection places it into its tabs node through `container.Base#insert`, which now parks a lazy config and loads it at the active card index — neomjs/neo PR #18086, found by this PR's own journey witness on the second pin and reproduced live before the fix (the `Add agent` tab active with a bare, invisible placeholder as its card).

The first cut of this PR had made the pane a static import; the operator's read retired that shape (a rail inside a dock layout must lazy-load like a tab container, and a reveal-only pane that pays class load, construction, `initAsync` and any store autoLoad at boot is the startup cost the lazy shape exists to avoid). What the institution carries is the lazy module line, three engine pin bumps, the journey witness back on its feet, and the visual-baseline stamps.

Evidence: L3 (`AddAgentJourneyNL` under the Brain root on the third pin; the define-agent reveal read from the rail tab and the CTA path on the live cockpit through the Neural Link) → L3 required (the zone's materialization is a rendered contract). Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — the define-agent zone renders its form from the rail tab and from the bootstrap CTA | Live on this checkout's cockpit (`localhost:8091`, Neural Link, pin `fabb61f001`, 2026-09-02 14:0xZ). **Rail tab:** the `Add agent` click reveals the overlay with the S5 form (GitHub username, PAT, the harness chips, the `Add agent` verb) — read on pin `961ac9cd11` and unchanged. **Bootstrap CTA path:** calling the controller's `onAddAgentRequest` (what the CTA fires) un-hides the zone; the DOM then holds `.fm-add-agent-form` visible (128×552) as the active card of the projected tabs node (header `Add agent` pressed), NOT inside a reveal overlay, with its text and password inputs; the rail lists `Agent detail`, `Perspectives`, `Wake routes` — `Add agent` left it. On pin `961ac9cd11` the same call projected the tab with a bare invisible placeholder card and no form. | |
| AC-2 — `AddAgentJourneyNL` green end to end under the Brain root | **Green on pin `fabb61f001`** under the Brain root (2026-09-02 14:00Z): `bootstrap CTA → S5 zone → readback-confirmed → roster graduation + CTA retirement → Start`, 1 passed in 25.4s. Red on pin `961ac9cd11` at the CTA step (30s, `.fm-add-agent-form` never appears) and on `0659b0e4` earlier (the rail half missing too) — the same locator, one engine half per pin. |
| AC-3 — the pane loads lazily: absent at boot, loaded on the first reveal, one instance across dismiss / re-reveal | Engine-side, both halves witnessed on the `dock-lazy-rail` fixture: absent from the namespace at boot, loaded on the rail click (#18063), parked in the tab flow and loaded on activation or at once when it is the node's only visible item (#18086). Consumer-side: the zone's resolver returns the loader function (`fleet/cockpit/Container.mjs`, the `define-agent` case). |
| AC-4 — the widened battery keeps its stated reds only | The widened battery (34 witnesses, `test-e2e:nl` as #75 defines it) under the Brain root on pin `fabb61f001`, 2026-09-02 14:03Z: **32 passed / 2 failed** (2.2m) — the two stated reds and nothing else: `FleetGridScaleNL` (#78) and `FleetCockpitDockNL`'s presets arm (the documented headless FLIP-settle hold, institution#66, A/B'd on PR #79 as pin-independent). `AddAgentJourneyNL`, the third red of PR #79's run, is green here. | |

## Deltas from ticket

- **The static import is gone** (the first cut's shape, withdrawn on the operator's read on 2026-09-02): the zone keeps `module: () => import(...)`; the engine grew both capabilities instead (neomjs/neo#18062, #18084).
- **Three engine pin bumps, not one:** #76 (PR #79) carried `dev@5ae9358063` for the pooled-child unmount; this PR carried `961ac9cd11` (the rail half) and now `fabb61f001` (the tab-flow half, plus the reveal chrome floor and the reveal motion's dependencies).
- **The journey witness found the second half.** Its CTA step is the falsifier that separated the two paths; it stays exactly as written.

## Test Evidence

- Pin `fabb61f001`: unit **734 passed**; `check-visual-baselines` green after the restamp (the lock entry is a stamp input), re-run on this branch before the push; `AddAgentJourneyNL` **1 passed** (25.4s) under the Brain root; the installed tree read, not assumed (`container/Base.mjs` carries the parked branch, `dashboard/Container.scss` the reveal chrome floor).
- Pin `961ac9cd11` (the second bump, for the record): rail path green live; `AddAgentJourneyNL` red at the CTA step (`.fm-add-agent-form` never appears) — the neomjs/neo#18084 class, reproduced live (the `Add agent` tab active with a bare invisible card, the orphaned projection placeholder).

## Post-Merge Validation

- [ ] The operator's rehearsal: define an agent through the S5 form from the empty-fleet CTA; the first row graduates with its card (#76, PR #79) and the define-agent pane appears from the rail on first reveal only.

## Commits

(Rebased onto `dev` after PR #79 merged — the pin lines conflicted, resolved with this branch's side and a regenerated stamp; SHAs below are the rebased ones.)

- `89e7bb8` — the first cut (static import; superseded within this PR).
- `ce673da` — merge of `dev` + stamp refresh after the first cut.
- `d9be490` — the zone stays lazy; the engine's rail loads it on reveal.
- `5a55acd` — the visual-baseline stamp after the rebase onto `dev`.
- `5b0472b` — the engine pin to `dev@961ac9cd11` (#18063 + #18078), lock, stamp.
- `9419e97` — the engine pin to `dev@fabb61f001` (#18086 + #18085), lock, stamp.

Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session 91f83b9c-df95-4f72-a68f-d33f470792ac
