### PR TITLE
chore(deps): bump the engine pin to dev@5ae9358063 — pooled children unmount, frame-origin window geometry (#76)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "hasInstallScript": true,
             "dependencies": {
-                "neo.mjs": "github:neomjs/neo#0659b0e42d65f67f0ec0cbd568ed32c5b2c1bc14"
+                "neo.mjs": "github:neomjs/neo#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6"
             },
             "devDependencies": {
                 "@fortawesome/fontawesome-free": "^7.3.0",
@@ -6562,8 +6562,8 @@
         },
         "node_modules/neo.mjs": {
             "version": "13.1.0",
-            "resolved": "git+ssh://git@github.com/neomjs/neo.git#0659b0e42d65f67f0ec0cbd568ed32c5b2c1bc14",
-            "integrity": "sha512-XkAv814GSN+54BwbwXjviNDzPxr4Qpy481vu9xWtHwhfAGRav7LmSqNQPCcmtw/NoQIgx08DNLODTAoClBEC4Q==",
+            "resolved": "git+ssh://git@github.com/neomjs/neo.git#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6",
+            "integrity": "sha512-9t5WkQu0F71oHGmABwgs07tvrDk02bweQgrwywSKmm1RvPUucanp3x2+BEMCo/73FSQgjxEhEfbiTVw7ajtJ8w==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "watch-themes": "node ./node_modules/neo.mjs/buildScripts/helpers/watchThemes.mjs"
     },
     "dependencies": {
-        "neo.mjs": "github:neomjs/neo#0659b0e42d65f67f0ec0cbd568ed32c5b2c1bc14"
+        "neo.mjs": "github:neomjs/neo#5ae9358063c35bb4e0c88f2dedd4f4284d8394d6"
     },
     "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -1,6 +1,6 @@
 {
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
-    "engine": "02596ca85a59aa9592d96b9d6035df51ddd59ddf047e127306b38409e8a1d2c5",
+    "engine": "2f51872caacfc0e6ea6d435b48711542a6db3efcc8ee5f26ce3b4ca8a31d554f",
     "inputs": {
         "apps/agentos": "3f5f6bb8fe568c5485f0227acacece2d992be41fd82f2fced5ae053aef7ffe93",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",


### PR DESCRIPTION
Resolves #76

Related: neomjs/neo#18060 / neomjs/neo PR #18061 (the engine cause and its fix), neomjs/neo PR #18068 (frame-origin window geometry, in the same range), #74 / PR #77 (the define-agent zone — the second bump, once neomjs/neo PR #18063 lands), #75 (the widened battery this bump was measured with), #10 (parent)

The engine pin moves from `0659b0e4` to `dev@5ae9358063`. The row this ticket describes — a fleet that rendered empty, then the first graduate shows as `Fleet · 1 agents` with an empty `li` — was the engine's: nothing unmounted a pooled `AgentCard` whose DOM left inside the list's own delta, so its next reference became a placeholder pointing at a node that no longer existed. neomjs/neo PR #18061 makes the vdom lifecycle mark the whole removed subtree unmounted at every depth a synced vnode carries, and the roster needs no override: `list.Component` pooling across an empty state works as designed once the engine tells the pooled child it left. Nothing in the institution changes but the pin, its lock entry and the visual-baseline stamp (the lock entry is a stamp input).

Evidence: L3 (the live cockpit on this checkout's `node_modules` after the bump, driven through the Neural Link; the institution unit suite; the widened Neural Link battery on a scratch merge with #75, headless under the Brain root) → L3 required (the ticket's AC are rendered-DOM contracts). Residual: AC-3, Residual-Owner: PR #77.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 (after a settled empty roster, the first added row renders its card with avatar, name and verbs) | Live cockpit on the bumped install (Neural Link session on `localhost:8091`, 2026-09-02 11:3xZ): `FleetRoster#clear` → the empty render left to settle (several seconds, well past the fade) → `add([one row with a data-URI avatar])` → DOM read: one `li` (`neo-fm-fleet-roster-list-1__0`, not empty), the card `…__0__component` visible, name `First Graduate`, the avatar `<img>` with `src` set and `naturalWidth > 0`, the verbs `Stop First Graduate` / `Restart First Graduate`, title `Fleet · 1 agents`. The same probe on the previous pin (earlier this session, same seat) left three `mounted: true` placeholders and zero rendered cards. |
| AC-2 (the roster reload still renders exactly one card per row; the AgentCard witness's clear → add renders every card with its avatar) | The widened battery of #75 on a scratch merge (`a5caf54` = this branch + `origin/agent/73-battery-out-of-glob`, this checkout's bumped `node_modules`), headless under the Brain root, 2026-09-02 11:31Z: `FleetGridKeyboardA11y` **green** (the clear-then-add reload, one card per row) and `AgentCardSynthesisRenderNL` **green** in 3.8s — the witness that was red at the avatar-keeper poll on the old pin this morning in both modes and on the untouched `013caf3` (its four-card `clear` → `add(4)` lost the avatar `Image` child: the same engine class, now closed). |
| AC-3 (`AddAgentJourneyNL` green end to end, the cause named at the seam) | Residual, owner PR #77: the journey reaches the define-agent zone only once the rail loads a lazy module item (neomjs/neo PR #18063, approved, merge pending) and the second bump carries it. The cause is named here: the engine seam (`src/mixin/VdomLifecycle.mjs`, `unmountRemovedChildren`), not the roster. |

Also read on the live cockpit, the operator's sighting class: `clear` → `add(3)` renders three cards (`Amadeus`, `Clementina`, `Dionysius`), all visible, the "Add first agent" CTA not visible — no CTA-beside-cards conflict on the bumped install.

## What the bump carries

Twelve engine commits, `0659b0e4..5ae9358063` on `dev`:

| commit | what |
| --- | --- |
| `630f95d27e` | fix(vdom): unmount the whole removed subtree, at every depth a synced vnode carries (#18060 / PR #18061) — **this ticket's cause** |
| `5ae9358063` | fix(manager): the window manager reads screenLeft/Top as the frame origin (#18058 / PR #18068) |
| `dbad38c6b9` | fix(grid): a grid click keeps its mousedown default so focus reaches the View (#18065 / PR #18066) |
| `474d07ba7d` | fix(manager): a refused native park retries until the OS releases the popup (#18054 / PR #18055) |
| `46c441eaba` | feat(dock): lock content presentation delegates to the pane, like reload (#18044 / PR #18057) |
| `74732d9ef4` | feat(tab): own the title weight and trim the inline header (#18043 / PR #18048) |
| `c5aa0d2c11` | fix(dock): a pane returns from the rail with its reload action (#18039 / PR #18041) |
| `ff4ccd512b` | feat(main): WindowPosition observeMovement owns the movement poll (#18029 / PR #18040) |
| `2da8389d4c` | test(workstation): the native titlebar drag of a popup onto another popup (#18047 / PR #18051) |
| `8c86f4478f` | test(build): the workflow scope classifier's unit coverage (#17922 / PR #18053) |
| `9dcafc5fa2` | fix(build): the sync guard recognises repo-qualified corpus paths (#18049 / PR #18050) |
| `40edf8abfa` | chore(deps): consume neo-agent-skills 0.1.3 (#18045 / PR #18046) |

The installed tree was read, not assumed: `src/mixin/VdomLifecycle.mjs` carries `unmountRemovedChildren`, `src/manager/Window.mjs` carries the `mozInnerScreenX` branch and no `isSafari`, `src/dashboard/dock/interaction/Rail.mjs` does not yet carry `loadRevealPane` (that is the second bump).

## Deltas from ticket

- **Nothing roster-side changed.** The ticket's fallback (stop pooling across an empty state by construction) is not needed; the three shapes the ticket records as failed stay retired.
- **Seen, not this diff:** a roster record without `avatarUrl` renders the card's `<img>` with no `src`, so Chrome's broken-image glyph sits over the initials fallback (read on the three fixture rows). Production rows carry the GitHub face; a first-run agent without one would show it. One line here so nobody re-derives it; not filed.

## Test Evidence

- Unit on the bumped engine: **734 passed** (`npm run test-unit`).
- `npm run --silent check-visual-baselines`: green after `stamp-visual-baselines`, re-run on this branch immediately before the push.
- The widened Neural Link battery (34 witnesses, `test-e2e:nl` as #75 defines it) on the scratch merge, headless under the Brain root: **31 passed / 3 failed** (2.3m). The three: `AddAgentJourneyNL` (`.fm-add-agent-form` never appears — #74, AC-3's residual), `FleetGridScaleNL` (`inspectStore` reads 0 of 20 — #78), and `FleetCockpitDockNL`'s presets arm (`.fm-agent-detail` resolved but `hidden` for 10s after `activatePerspective('Review')`).
- The presets red is the documented Engine hold, not this bump — measured A/B on the same specs, same seat: old pin `0659b0e4` **0/2** green, new pin `5ae9358063` **1/2** green (10.1s pass, then the same `hidden` timeout). The spec's own comment names the mechanism (tab chrome staged with `hideMode: 'visibility'`, un-hidden on the FLIP settle that headless Chromium does not always land; ledger institution#66). On the live cockpit with the bumped engine, one real click on `Review` materializes the detail pane visibly (avatar, status chips, the STATUS / CONF tabs) — read on this seat at 11:37Z.

## Post-Merge Validation

- [ ] PR #77 (the second bump, once neomjs/neo PR #18063 is on `dev`): `AddAgentJourneyNL` under the Brain root, the define-agent reveal from the rail tab and from the CTA.

## Commits

- `fc56c20` — the pin, its lock entry, the stamp.


Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session 91f83b9c-df95-4f72-a68f-d33f470792ac
