### PR TITLE
chore(agentos): engine pin to dev@4e0e9dd8c3 — the cockpit reads the reveal slide, the drag-shield lift and the flat inline header (#81)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "hasInstallScript": true,
             "dependencies": {
-                "neo.mjs": "github:neomjs/neo#fabb61f0011ec2aa56bcf810f5af78aad706629a"
+                "neo.mjs": "github:neomjs/neo#4e0e9dd8c3aaee8151956c9bc111e46c7c9ebd2d"
             },
             "devDependencies": {
                 "@fortawesome/fontawesome-free": "^7.3.0",
@@ -6562,8 +6562,8 @@
         },
         "node_modules/neo.mjs": {
             "version": "13.1.0",
-            "resolved": "git+ssh://git@github.com/neomjs/neo.git#fabb61f0011ec2aa56bcf810f5af78aad706629a",
-            "integrity": "sha512-iuUcf0xJl/sXcmlGz08WlG66Xn2UD8azc+ARUo3RqGhoiEYcnj+UkZHIAJVE3wkqnTfsN2xc/ZHZhHzC9XqQlQ==",
+            "resolved": "git+ssh://git@github.com/neomjs/neo.git#4e0e9dd8c3aaee8151956c9bc111e46c7c9ebd2d",
+            "integrity": "sha512-HmGaoq/4TR77peFmFkRJ7yoxm0pCZXX/o8cZLRSiScycfd2zdF0RPb6InRDVG9qxuaTKzHZgyS+w8VERZxOnDw==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "watch-themes": "node ./node_modules/neo.mjs/buildScripts/helpers/watchThemes.mjs"
     },
     "dependencies": {
-        "neo.mjs": "github:neomjs/neo#fabb61f0011ec2aa56bcf810f5af78aad706629a"
+        "neo.mjs": "github:neomjs/neo#4e0e9dd8c3aaee8151956c9bc111e46c7c9ebd2d"
     },
     "devDependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -1,6 +1,6 @@
 {
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
-    "engine": "b0cd8d5a2941bbb23e3cf63b786bc8f99aaec6c2b3c81abb4c2ad5c45a467712",
+    "engine": "9b80eeedf353883e0bfe468d34ed50e6551646c62821e25b44b2f86eb1c3c4d1",
     "inputs": {
         "apps/agentos": "f924ffacf4d9d90e0afbefc9ff82edf637ab5e9aa27b62df572e734c2ab68d40",
         "resources/scss": "1c1a579f07ec22b14a916f38684d0a89280159dfe9f72b8737c8f886dcac492a",


### PR DESCRIPTION
Resolves #81

Related: #74 / PR #77 (pin 3, `fabb61f001`), #76 / PR #79 (pin 1), #10 (parent), neomjs/neo#18074 / PR #18079 (the reveal slide), neomjs/neo#18087 / PR #18091 (the native-drag shield lift), neomjs/neo#18095 / PR #18097 (the flat inline header)

The fourth engine pin of the demo chain, and the one that puts the cockpit on the engine `dev` the WebStudio already runs: `fabb61f001` → `4e0e9dd8c3`. Five engine commits, three of them visible on the cockpit's docks — a rail reveal now enters as one panel from its strip side (the root fades in place, its content slides), a native drag out of a `nativeDragZone` row keeps its payload while a reveal is open, and the inline tab header paints flat with a hairline instead of the gradient band. The other two are test-only. Pin, lock and the visual-baseline stamp; no product code.

Evidence: L3 (unit + the NL battery under the Brain root on this pin; the reveal motion, the flat header and the lazy define-agent zone read live on the served cockpit) → L3 required (the ACs are rendered behaviour on the consumer). Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — pin + lock at `4e0e9dd8c3`, stamp green on the pushed tree | `package.json` `github:neomjs/neo#4e0e9dd8c3aaee8151956c9bc111e46c7c9ebd2d`; `package-lock.json` resolved `git+ssh://git@github.com/neomjs/neo.git#4e0e9dd8c3…` (13.1.0); `check-visual-baselines`: *input identity matches the golden stamp* after the restamp, re-run on this tree immediately before the push. |
| AC-2 — unit green; battery 32/34 with the two stated reds | Unit **734 passed** (5.1s). `test-e2e:nl` under the Brain root (34 witnesses, own server on a free port): **32 passed / 2 failed** (2.1m) — the two stated reds and nothing else: `FleetGridScaleNL` (#78) and `FleetCockpitDockNL`'s presets arm (the headless FLIP-settle hold, #66, A/B'd as pin-independent on PR #79). `AddAgentJourneyNL` green. |
| AC-3 — live read: the reveal enters as one panel; the inline header is flat, both themes | Served cockpit (`localhost:8091`, this tree, fresh App worker), neo-dark: the `Add agent` rail tab opens `.neo-dashboard-dock-reveal-overlay-right` with the root on `neo-dock-reveal-fade` 0.28s as a `size` container and both the reveal header and the pane slot on `neo-dock-reveal-from-right` 0.28s — #18079's shape, on #18085's 1px chrome floor (`1px solid rgb(38,47,61)`). `.neo-tab-header-toolbar` computes `background-image: none` on all four headers (the cockpit's own `rgb(14,19,26)` ground) — no gradient band. **neo-light** (the cockpit's own theme switch, no reload): the four headers compute `background-image: none` on `rgb(233,237,243)` / white; the same `Add agent` reveal opens with `neo-dock-reveal-fade` + `neo-dock-reveal-from-right` at 0.28s on `rgb(233,237,243)` with a `1px solid rgb(211,218,228)` floor, the form in its slot. Screenshots read in both skins: one panel from the strip side, flat headers, nothing else on the surface moved. |
| AC-4 — the define-agent zone still materializes lazily (PR #77's contract) | Rail path live: the reveal's pane slot holds `.fm-add-agent-form` (281×360, the two inputs, the harness chips, the `Add agent` verb) after the first click; CTA path: `AddAgentJourneyNL` in the battery (see AC-2). |

## Deltas from ticket

- None in scope. The battery ran on its own server (the e2e config refuses a port that is already served — the first attempt against the running 8091 server exited before any test), which is the config's contract, not a change here.

## Test Evidence

- `npm run --silent test-unit`: **734 passed**.
- `npm run --silent test-e2e:nl` with `NEO_AGENTOS_RUNTIME_ROOT` set to the Brain checkout: **32 passed / 2 failed** in 2.1m; failed = `FleetCockpitDockNL.spec.mjs:184` (perspective presets — the #66 hold) and `FleetGridScaleNL.spec.mjs:18` (#78); both red on the previous two pins as well, so the delta of this pin on the battery is zero.
- `check-visual-baselines` green after `stamp-visual-baselines` (lock + package.json are stamp inputs).
- Installed tree read, not assumed: `node_modules/neo.mjs/resources/scss/theme-neo-dark/tab/Container.scss` carries #18097's flat-surface tokens; the lock's `resolved` commit is the pin.

## Post-Merge Validation

- [ ] The operator's rehearsal read on the cockpit: the right rail's reveals slide in from the strip, the tab headers paint flat, the define-agent form appears on first reveal only.

## Commits

- `f61485f` — the pin to `dev@4e0e9dd8c3`, lock, stamp.

Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session 91f83b9c-df95-4f72-a68f-d33f470792ac
