### PR TITLE
feat(fleet): the Perspectives rail pane lists, applies and captures saved layouts (#84)

### DIFF
--- a/apps/agentos/util/CockpitPresets.mjs
+++ b/apps/agentos/util/CockpitPresets.mjs
@@ -4,7 +4,21 @@ import Persistence         from '../../../node_modules/neo.mjs/src/dashboard/doc
 import PerspectiveLibrary  from '../../../node_modules/neo.mjs/src/dashboard/dock/persistence/PerspectiveLibrary.mjs';
 
 /**
- * Static factory for the Fleet Cockpit perspective collection.
+ * What a captured perspective's id folds away: everything but lowercase letters and digits
+ * collapses to one hyphen.
+ * @type {RegExp}
+ */
+const idFold = /[^a-z0-9]+/g;
+
+/**
+ * The hyphens a folded id sheds at either end.
+ * @type {RegExp}
+ */
+const edgeHyphens = /^-+|-+$/g;
+
+/**
+ * Static factory for the Fleet Cockpit perspective collection, and the capture wrapper that turns
+ * the live dock document into one more saved layout.
  * @class AgentOS.util.CockpitPresets
  * @extends Neo.core.Base
  */
@@ -78,6 +92,36 @@ class CockpitPresets extends Base {
         }
 
         return collection
+    }
+
+    /**
+     * @summary Wrap the live dock document as a saved layout under an operator-given name — the
+     * capture half of the perspectives drawer. The id is `capture-` plus the folded name (lowercase
+     * letters, digits and single hyphens; a name of nothing but punctuation folds to `layout`) —
+     * the prefix keeps a capture's id off the shipped presets' ids, so naming a capture "Overview"
+     * COLLIDES with the preset in the library instead of updating it in place under the same id.
+     * The title is the name itself, and the source stamp separates a capture from a shipped preset.
+     * Document validation is the wrapper's, and the library clones at save time; an unnamed
+     * capture is refused here because it has nothing to be filed under.
+     * @param {Object} document The committed `neo.dock.zone.v1` document.
+     * @param {String} name The operator's name for the layout.
+     * @returns {{layout: (Object|null), errors: String[]}}
+     */
+    static captureSavedLayout(document, name) {
+        const perspectiveName = (name ?? '').trim();
+
+        if (!perspectiveName) {
+            return {layout: null, errors: ['a perspective needs a name']}
+        }
+
+        const layoutId = `capture-${perspectiveName.toLowerCase().replace(idFold, '-').replace(edgeHyphens, '') || 'layout'}`;
+
+        return Persistence.createSavedLayout(document, {
+            layoutId,
+            perspectiveName,
+            title   : perspectiveName,
+            metadata: {source: 'fm-cockpit-capture'}
+        })
     }
 }
 

--- a/apps/agentos/view/fleet/cockpit/Container.mjs
+++ b/apps/agentos/view/fleet/cockpit/Container.mjs
@@ -352,6 +352,13 @@ class FleetCockpit extends VesselContainer {
     sharedPerspectiveArtifact = null
 
     /**
+     * The identity of the last perspective list written into provider data — the guard that keeps
+     * {@link #publishPerspectives} idempotent across dock refreshes.
+     * @member {String|null} publishedPerspectives=null
+     */
+    publishedPerspectives = null
+
+    /**
      * @summary Seed the layout SSOT and add the ONE instance-bound member — the dock projection
      * (its commit-loop callbacks bind this instance, so it cannot live in the static config; the
      * persistent chrome is declared there).
@@ -555,6 +562,11 @@ class FleetCockpit extends VesselContainer {
 
         let me = this;
 
+        // the boot projection of the perspective list: `construct` seats the preset buttons before
+        // the provider chain is complete, so the drawer's binding source is written here, once
+        // everything the projection reads exists
+        me.publishPerspectives();
+
         // the listener authority is the provider-owned Store, same as every roster read/write —
         // it exists (and keeps reconciling) whether or not the grid projection currently does
         const controller0 = me.getController();
@@ -579,6 +591,19 @@ class FleetCockpit extends VesselContainer {
      */
     beforeRefreshDockWorkspace(document, refreshOptions) {
         this.syncControlBar()
+    }
+
+    /**
+     * @summary Publishes the perspective list once a refresh has SETTLED — never from the
+     * pre-projection hook. The perspectives drawer is a reveal pane inside the dock host and
+     * re-renders its cards when the projected list moves; doing that while the host's own update
+     * is still in flight stalled the refresh chain (every later dock operation waits on the
+     * previous refresh), measured with the drawer open: no preset switch, no rail switch, until
+     * the publish moved here.
+     * @param {Object} data The engine's settled-refresh envelope.
+     */
+    afterRefreshDockWorkspace(data) {
+        this.publishPerspectives()
     }
 
     /**
@@ -612,6 +637,38 @@ class FleetCockpit extends VesselContainer {
         // CHANGES; a re-projection needs the standing value re-rendered)
         me.afterSetPresetError(me.presetError, null);
         me.syncVesselChrome()
+    }
+
+    /**
+     * @summary Project the perspective list into provider data (`perspectives`): the drawer and
+     * any other reader bind to it, so nothing outside this cockpit reaches into the library. Runs
+     * with every control-bar sync (a switch, a capture, an import) and once more with the capture
+     * verdict, which rides the projection rather than a side channel.
+     * @param {Object|null} [captureResult=null] The latest capture verdict, or `null`.
+     */
+    publishPerspectives(captureResult = null) {
+        let me       = this,
+            provider = me.getStateProvider(),
+            next     = {
+                activeLayoutId: me.perspectiveStore?.collection?.activeLayoutId ?? null,
+                // one string leaf, never a nested verdict object: provider data drills plain objects
+                // into leaf paths, and a verdict under a `null` leaf never reads back
+                captureNote   : !captureResult
+                    ? null
+                    : captureResult.saved
+                        ? `captured "${captureResult.name ?? captureResult.layoutId}" — apply it from its card`
+                        : `capture refused: ${captureResult.errors?.[0] ?? 'unnamed reason'}`,
+                items         : me.perspectiveStore?.list?.() || []
+            },
+            identity = JSON.stringify(next);
+
+        // Idempotent on purpose: the chrome hook republishes on EVERY dock refresh, and a fresh
+        // object per refresh would re-render the drawer (and re-enter the projection it binds
+        // into) for a list that did not move. Only a changed list, active layout or verdict writes.
+        if (provider && identity !== me.publishedPerspectives) {
+            me.publishedPerspectives = identity;
+            provider.setData({perspectives: next})
+        }
     }
 
     /**
@@ -860,9 +917,23 @@ class FleetCockpit extends VesselContainer {
                     },
                     reference: 'tasks'
                 };
+            case 'perspectives':
+                // LAZY like the wake-routes sibling: the drawer loads at first reveal. It binds
+                // the projected perspective list from the provider and fires intent; the library
+                // stays owner-held (this cockpit + the controller relay).
+                return {
+                    module   : () => import('../perspectives/Container.mjs'),
+                    cls      : [marker],
+                    bind     : {perspectives: data => data.perspectives},
+                    listeners: {
+                        perspectiveRequest: 'onPerspectiveRequest',
+                        scope             : me.getController()
+                    },
+                    reference: 'perspectives'
+                };
             default:
-                // perspectives arrives with its own leaf — an honest labelled placeholder, never a
-                // blank pane masquerading as a finished surface
+                // a zone the document names but no case resolves — an honest labelled placeholder,
+                // never a blank pane masquerading as a finished surface (no shipped zone takes it)
                 return {
                     ntype: 'component',
                     cls  : [marker, 'fm-pane-placeholder'],

--- a/apps/agentos/view/fleet/cockpit/Controller.mjs
+++ b/apps/agentos/view/fleet/cockpit/Controller.mjs
@@ -328,13 +328,9 @@ class Controller extends LivenessController {
      * @summary Capture the live dock document as a named perspective — the drawer's capture verb.
      * The wrapped record saves WITHOUT replacing: a name a shipped preset (or an earlier capture)
      * holds is refused with the library's collision verdict, never silently overwritten. A saved
-     * capture is FILED, not activated: it reaches the drawer through the projected list, verdict
-     * included, while the live layout stays what it is — the card's Apply is the switch. It joins
-     * the preset switcher on the NEXT dock refresh (the pre-projection chrome sync), never in the
-     * capture's own tick: an update elsewhere in the cockpit while the drawer re-renders inside
-     * its open reveal overlay drops the revealed pane (measured: the drawer left the DOM 50ms after
-     * its own verdict, with the new button sometimes never landing either — an engine seam, filed
-     * as a follow-up).
+     * capture is FILED, not activated: it joins the preset switcher through the view's ordinary
+     * control-bar sync and reaches the drawer through the projected list, verdict included, while
+     * the live layout stays what it is — the card's Apply is the switch.
      * @param {String} name The operator's name for the layout.
      * @returns {{saved: Boolean, layoutId: String|null, name: String|null, errors: String[]}}
      */
@@ -364,7 +360,9 @@ class Controller extends LivenessController {
                     errors  : outcome.collision
                         ? [`"${layout.perspectiveName}" is already held by ${outcome.collision.holderTitle ?? outcome.collision.holderLayoutId}`]
                         : outcome.errors
-                }
+                };
+
+                outcome.saved && view.syncControlBar()
             }
         } catch (error) {
             console.error('FleetCockpit: capturing the live layout failed', error);

--- a/apps/agentos/view/fleet/cockpit/Controller.mjs
+++ b/apps/agentos/view/fleet/cockpit/Controller.mjs
@@ -1,4 +1,5 @@
 import LivenessController          from './LivenessController.mjs';
+import CockpitPresets              from '../../../util/CockpitPresets.mjs';
 import FleetLifecycleIntentAdapter from '../../../util/FleetLifecycleIntentAdapter.mjs';
 import FleetStartPlan              from '../../../util/FleetStartPlan.mjs';
 import SourceHealth                from '../../../util/SourceHealth.mjs';
@@ -304,6 +305,74 @@ class Controller extends LivenessController {
         const {source, ...params} = data;
 
         return this.loadWakeRoutes(params)
+    }
+
+    /**
+     * @summary Relay a PerspectivesPane intent: `apply` switches the cockpit to the named
+     * perspective through the same path the preset switcher uses; `capture` wraps the live dock
+     * document under the given name. Both re-project the list the drawer binds to.
+     * @param {Object} data
+     * @param {String} data.action `apply` or `capture`
+     * @param {String} data.name The perspective's name
+     * @returns {Object} the cockpit's verdict
+     */
+    onPerspectiveRequest(data) {
+        const {action, name} = data;
+
+        return action === 'capture'
+            ? this.capturePerspective(name)
+            : this.component.activatePerspective(name)
+    }
+
+    /**
+     * @summary Capture the live dock document as a named perspective — the drawer's capture verb.
+     * The wrapped record saves WITHOUT replacing: a name a shipped preset (or an earlier capture)
+     * holds is refused with the library's collision verdict, never silently overwritten. A saved
+     * capture is FILED, not activated: it reaches the drawer through the projected list, verdict
+     * included, while the live layout stays what it is — the card's Apply is the switch. It joins
+     * the preset switcher on the NEXT dock refresh (the pre-projection chrome sync), never in the
+     * capture's own tick: an update elsewhere in the cockpit while the drawer re-renders inside
+     * its open reveal overlay drops the revealed pane (measured: the drawer left the DOM 50ms after
+     * its own verdict, with the new button sometimes never landing either — an engine seam, filed
+     * as a follow-up).
+     * @param {String} name The operator's name for the layout.
+     * @returns {{saved: Boolean, layoutId: String|null, name: String|null, errors: String[]}}
+     */
+    capturePerspective(name) {
+        let view    = this.component,
+            verdict;
+
+        // A capture that throws is still a verdict the drawer must show — a silent failure would
+        // read as "nothing happened", the one outcome a capture verb may never produce.
+        try {
+            let {layout, errors} = CockpitPresets.captureSavedLayout(view.getDockZoneDocument(), name);
+
+            verdict = {saved: false, layoutId: null, name: layout?.perspectiveName ?? null, errors};
+
+            if (!errors.length) {
+                // Never activate here: activating restores the capture as a new document, and a
+                // perspective restore releases every open reveal — the drawer the operator is
+                // looking at would close on its own verdict (measured: the pane left the DOM 50ms
+                // after the click). The live layout already IS this document; Apply switches to it.
+                const outcome = view.perspectiveStore.savePerspective(layout, {activate: false});
+
+                verdict = {
+                    saved   : outcome.saved,
+                    layoutId: outcome.layoutId,
+                    name    : layout.perspectiveName,
+                    // the library's collision verdict names the HOLDER (`holderTitle` / `holderLayoutId`)
+                    errors  : outcome.collision
+                        ? [`"${layout.perspectiveName}" is already held by ${outcome.collision.holderTitle ?? outcome.collision.holderLayoutId}`]
+                        : outcome.errors
+                }
+            }
+        } catch (error) {
+            console.error('FleetCockpit: capturing the live layout failed', error);
+            verdict = {saved: false, layoutId: null, name: (name ?? '').trim() || null, errors: [`capture failed: ${error.message}`]}
+        }
+
+        view.publishPerspectives(verdict);
+        return verdict
     }
 
     /**

--- a/apps/agentos/view/fleet/cockpit/StateProvider.mjs
+++ b/apps/agentos/view/fleet/cockpit/StateProvider.mjs
@@ -91,6 +91,15 @@ class StateProvider extends Provider {
              */
             gridDegradedReason: null,
             /**
+             * The cockpit's projected perspective list — every saved layout (the shipped presets
+             * plus captures), the active one, and the latest capture verdict — written by the
+             * cockpit's `publishPerspectives`; the perspectives drawer binds to it. Empty `items`
+             * means "not projected yet", never "no layouts"; `captureNote` is the latest capture
+             * verdict as one sentence (a string leaf — nested objects drill into leaf paths here).
+             * @member {Object} perspectives={activeLayoutId:null,captureNote:null,items:[]}
+             */
+            perspectives: {activeLayoutId: null, captureNote: null, items: []},
+            /**
              * The presence-capability envelope riding every admitted roster snapshot — the grid's
              * chip names a degraded producer and clears on recovery; `null` claims nothing.
              * @member {Object|null} presenceCapability=null

--- a/apps/agentos/view/fleet/perspectives/Container.mjs
+++ b/apps/agentos/view/fleet/perspectives/Container.mjs
@@ -178,8 +178,8 @@ class PerspectivesPane extends Container {
     }
 
     /**
-     * @summary Project the list into the meta line and the cards; the capture verdict, when the
-     * projection carries one, is named on the meta line rather than flashed and lost.
+     * @summary Project the list into the meta line and the cards — in place. The capture verdict,
+     * when the projection carries one, is named on the meta line rather than flashed and lost.
      */
     applyPerspectives() {
         const
@@ -197,14 +197,73 @@ class PerspectivesPane extends Container {
                 : `${items.length} ${items.length === 1 ? 'layout' : 'layouts'} · ${active ? `${me.nameOf(active)} active` : 'none active'}${note ? ` · ${note}` : ''}`
         }
 
-        if (!target) return;
+        target && me.syncPerspectiveCards(target, items, active)
+    }
 
-        target.removeAll(true);
+    /**
+     * @summary Reconcile the card instances against the projected list, keyed by `layoutId` —
+     * object permanence, exactly like the cockpit's own preset switcher: a card that already
+     * exists keeps its instance and gets its marker and verb moved in place, a new perspective
+     * inserts its card at its list position, a departed one removes its card. Nothing is
+     * destroyed to be rebuilt.
+     * @param {Neo.container.Base} target The rows container.
+     * @param {Object[]} items The projected perspectives, in list order.
+     * @param {Object|null} active The live perspective, when the list holds one.
+     */
+    syncPerspectiveCards(target, items, active) {
+        const
+            me    = this,
+            cards = () => target.items.filter(item => item.layoutId),
+            empty = target.items.find(item => item.isPerspectivesEmpty);
 
-        target.add(items.length
-            ? items.map(item => me.perspectiveCardConfig(item, item === active))
-            : {module: Component, cls: ['fm-perspectives-empty'], text: 'Nothing here claims a layout yet.'}
-        )
+        if (!items.length) {
+            // the honest empty state: one placeholder, no card posing as a layout — a list that
+            // emptied is a one-time transition, never a hot path
+            cards().forEach(card => target.remove(card, true));
+            empty || target.add({module: Component, cls: ['fm-perspectives-empty'], isPerspectivesEmpty: true, text: 'Nothing here claims a layout yet.'});
+            return
+        }
+
+        empty && target.remove(empty, true);
+
+        items.forEach((item, index) => {
+            const card = target.items.find(candidate => candidate.layoutId === item.layoutId);
+
+            if (card) {
+                const from = target.items.indexOf(card);
+
+                me.syncPerspectiveCard(card, item, item === active);
+                // a moved perspective keeps its instance and moves to its list position
+                from !== index && target.moveTo(from, index)
+            } else {
+                target.insert(index, me.perspectiveCardConfig(item, item === active))
+            }
+        });
+
+        cards()
+            .filter(card => !items.some(item => item.layoutId === card.layoutId))
+            .forEach(card => target.remove(card, true))
+    }
+
+    /**
+     * @summary Move one existing card onto its projected entry: the active marker, the name, the
+     * title line and the apply verb — leaf updates on the live instances, no re-creation.
+     * @param {Neo.container.Base} card
+     * @param {Object} item
+     * @param {Boolean} active
+     */
+    syncPerspectiveCard(card, item, active) {
+        const
+            name   = this.nameOf(item),
+            detail = this.detailOf(item, name),
+            text   = card.items[0].items,
+            verb   = card.items[1];
+
+        card[active ? 'addCls' : 'removeCls']('is-active');
+        text[0].text = name;
+        text[1].set({hidden: !detail, text: detail});
+        verb.presetName = name;
+        verb.set({disabled: active, iconCls: active ? 'fa fa-check' : 'fa fa-arrow-right', text: active ? 'Active' : 'Apply'})
     }
 
     /**
@@ -217,9 +276,20 @@ class PerspectivesPane extends Container {
     }
 
     /**
+     * @summary The card's second line: the title when it says more than the name, else the
+     * capture scope, else nothing.
+     * @param {Object} item
+     * @param {String} name The product name already resolved for the item.
+     * @returns {String}
+     */
+    detailOf(item, name) {
+        return item.title && item.title !== name ? item.title : (item.captureScope ? `${item.captureScope} scope` : '')
+    }
+
+    /**
      * @summary Build one perspective card: the name, the title line beneath it (only when it says
      * more than the name), and the apply verb — which reads `Active` and rests while the card is
-     * the live layout.
+     * the live layout. Built once per perspective; {@link #syncPerspectiveCard} moves it after.
      * @param {Object} item One projected list entry.
      * @param {Boolean} active Whether this perspective is the live one.
      * @returns {Object}
@@ -227,14 +297,15 @@ class PerspectivesPane extends Container {
     perspectiveCardConfig(item, active) {
         const
             name   = this.nameOf(item),
-            detail = item.title && item.title !== name ? item.title : (item.captureScope ? `${item.captureScope} scope` : '');
+            detail = this.detailOf(item, name);
 
         return {
-            module: Container,
-            cls   : ['fm-perspectives-card', ...(active ? ['is-active'] : [])],
-            flex  : 'none',
-            layout: {ntype: 'hbox', align: 'center'},
-            items : [{
+            module  : Container,
+            cls     : ['fm-perspectives-card', ...(active ? ['is-active'] : [])],
+            flex    : 'none',
+            layout  : {ntype: 'hbox', align: 'center'},
+            layoutId: item.layoutId,
+            items   : [{
                 ntype : 'container',
                 flex  : 1,
                 layout: {ntype: 'vbox', align: 'stretch'},

--- a/apps/agentos/view/fleet/perspectives/Container.mjs
+++ b/apps/agentos/view/fleet/perspectives/Container.mjs
@@ -1,0 +1,304 @@
+import Button    from '../../../../../node_modules/neo.mjs/src/button/Base.mjs';
+import Component from '../../../../../node_modules/neo.mjs/src/component/Base.mjs';
+import Container from '../../../../../node_modules/neo.mjs/src/container/Base.mjs';
+import TextField from '../../../../../node_modules/neo.mjs/src/form/field/Text.mjs';
+
+/**
+ * The cockpit's saved layouts: every perspective the dock document can take, one card each, with
+ * the two explicit acts — apply one, or capture the live layout as a new one.
+ *
+ * @summary Renders the perspective list the owning FleetCockpit projects into provider data
+ * (`perspectives`) and fires intent (`perspectiveRequest`); it never reaches the perspective
+ * library itself. The three built-in presets ship with the cockpit (`AgentOS.util.CockpitPresets`);
+ * a captured layout joins them under the operator's name and appears in the top bar's preset
+ * switcher the same way, because both surfaces read the same projected list.
+ *
+ * Honest states: no projected list renders as exactly that (never an empty list posing as "no
+ * layouts"), the active perspective is named in the meta line and marked on its card, and a
+ * refused capture renders the library's own reason.
+ *
+ * @class AgentOS.view.fleet.perspectives.Container
+ * @extends Neo.container.Base
+ */
+class PerspectivesPane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.perspectives.Container'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.perspectives.Container',
+        /**
+         * @member {String} ntype='fm-perspectives-pane'
+         * @protected
+         */
+        ntype: 'fm-perspectives-pane',
+        /**
+         * @member {String[]} baseCls=['fm-perspectives-pane']
+         */
+        baseCls: ['fm-perspectives-pane'],
+        /**
+         * The projected perspective list, as the cockpit publishes it:
+         * `{items: [{layoutId, perspectiveName, title, captureScope}], activeLayoutId, captureNote}` —
+         * the note is the latest capture verdict as one sentence, or `null`.
+         * `null` (or an empty `items`) is unobserved — nothing projected yet — never "no layouts".
+         * @member {Object|null} perspectives_=null
+         * @reactive
+         */
+        perspectives_: null,
+        /**
+         * The name the capture verb will file the live layout under — the field's last reported
+         * value, trimmed; `null` while empty. The verb arms on this and uses exactly this, so the
+         * name that enabled the button is the name that files the capture (the field's own
+         * `value` commits on blur, which a click on the verb races).
+         * @member {String|null} captureName_=null
+         * @reactive
+         */
+        captureName_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'container',
+            cls   : ['fm-perspectives-head'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                cls  : ['fm-perspectives-title'],
+                flex : 1,
+                text : 'Saved layouts'
+            }, {
+                ntype: 'component',
+                cls  : ['fm-perspectives-authority'],
+                text : 'the dock document as data · apply or capture'
+            }]
+        }, {
+            ntype    : 'component',
+            cls      : ['fm-perspectives-meta'],
+            flex     : 'none',
+            reference: 'perspectives-meta',
+            text     : 'No layouts projected yet'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-perspectives-rows'],
+            flex     : 1,
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            reference: 'perspectives-rows'
+        }, {
+            // the capture rail: the name on its own line (a drawer is narrow — a field squeezed
+            // beside a verb loses its placeholder), the verb right-aligned beneath it
+            ntype : 'container',
+            cls   : ['fm-perspectives-actions'],
+            flex  : 'none',
+            layout: {ntype: 'vbox', align: 'stretch'},
+            items : [{
+                module         : TextField,
+                cls            : ['fm-perspectives-name'],
+                flex           : 'none',
+                labelText      : 'Name',
+                labelPosition  : 'inline',
+                placeholderText: 'Triage, standup, …',
+                reference      : 'perspectives-name',
+                listeners      : {change: 'up.onNameChange'}
+            }, {
+                ntype : 'container',
+                flex  : 'none',
+                layout: {ntype: 'hbox', align: 'center'},
+                items : [{
+                    ntype: 'component',
+                    flex : 1
+                }, {
+                    module   : Button,
+                    cls      : ['fm-perspectives-capture'],
+                    disabled : true,
+                    handler  : 'up.onCaptureClick',
+                    iconCls  : 'fa fa-camera',
+                    reference: 'perspectives-capture',
+                    text     : 'Capture current layout',
+                    ui       : 'ghost'
+                }]
+            }]
+        }]
+    }
+
+    /**
+     * @summary Render the held projection once the anatomy exists. No intent fires here: the
+     * cockpit publishes the list on its own; the pane only asks for an apply or a capture.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.renderedIdentity = this.projectionIdentity(this.perspectives);
+        this.applyPerspectives()
+    }
+
+    /**
+     * The identity of the list the drawer last rendered — the guard that keeps a reference-only
+     * change from re-rendering (see {@link #afterSetPerspectives}).
+     * @member {String|null} renderedIdentity=null
+     */
+    renderedIdentity = null
+
+    /**
+     * Triggered after the perspectives config changed — a re-projection (a capture, a switch)
+     * re-renders in place.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetPerspectives(value, oldValue) {
+        const identity = this.projectionIdentity(value);
+
+        // Provider data hands the binding a NEW object whenever any of its leaves is touched — a
+        // projection that did not move must not re-render (and must never re-enter the projection
+        // it binds into), so the drawer renders on identity, not on reference.
+        if (this.isConstructed && identity !== this.renderedIdentity) {
+            this.renderedIdentity = identity;
+            this.applyPerspectives()
+        }
+    }
+
+    /**
+     * @summary The content identity of a projected list: what the drawer renders from, and nothing
+     * else — a reference change without a content change is a no-op.
+     * @param {Object|null} list
+     * @returns {String}
+     */
+    projectionIdentity(list) {
+        return JSON.stringify({
+            active: list?.activeLayoutId ?? null,
+            note  : list?.captureNote ?? null,
+            items : (Array.isArray(list?.items) ? list.items : []).map(item => [item.layoutId, item.perspectiveName, item.title, item.captureScope])
+        })
+    }
+
+    /**
+     * @summary Project the list into the meta line and the cards; the capture verdict, when the
+     * projection carries one, is named on the meta line rather than flashed and lost.
+     */
+    applyPerspectives() {
+        const
+            me       = this,
+            list     = me.perspectives,
+            items    = Array.isArray(list?.items) ? list.items : [],
+            active   = items.find(item => item.layoutId === list?.activeLayoutId) ?? null,
+            note     = list?.captureNote ?? null,
+            metaEl   = me.getReference('perspectives-meta'),
+            target   = me.getReference('perspectives-rows');
+
+        if (metaEl) {
+            metaEl.text = !items.length
+                ? 'No layouts projected yet — the cockpit publishes its perspectives on boot.'
+                : `${items.length} ${items.length === 1 ? 'layout' : 'layouts'} · ${active ? `${me.nameOf(active)} active` : 'none active'}${note ? ` · ${note}` : ''}`
+        }
+
+        if (!target) return;
+
+        target.removeAll(true);
+
+        target.add(items.length
+            ? items.map(item => me.perspectiveCardConfig(item, item === active))
+            : {module: Component, cls: ['fm-perspectives-empty'], text: 'Nothing here claims a layout yet.'}
+        )
+    }
+
+    /**
+     * @summary The product name of a perspective: its `perspectiveName`, else its technical id.
+     * @param {Object} item
+     * @returns {String}
+     */
+    nameOf(item) {
+        return item.perspectiveName ?? item.layoutId
+    }
+
+    /**
+     * @summary Build one perspective card: the name, the title line beneath it (only when it says
+     * more than the name), and the apply verb — which reads `Active` and rests while the card is
+     * the live layout.
+     * @param {Object} item One projected list entry.
+     * @param {Boolean} active Whether this perspective is the live one.
+     * @returns {Object}
+     */
+    perspectiveCardConfig(item, active) {
+        const
+            name   = this.nameOf(item),
+            detail = item.title && item.title !== name ? item.title : (item.captureScope ? `${item.captureScope} scope` : '');
+
+        return {
+            module: Container,
+            cls   : ['fm-perspectives-card', ...(active ? ['is-active'] : [])],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype : 'container',
+                flex  : 1,
+                layout: {ntype: 'vbox', align: 'stretch'},
+                items : [{
+                    module: Component,
+                    cls   : ['fm-perspectives-card-title'],
+                    text  : name
+                }, {
+                    module: Component,
+                    cls   : ['fm-perspectives-card-detail'],
+                    hidden: !detail,
+                    text  : detail
+                }]
+            }, {
+                module    : Button,
+                cls       : ['fm-perspectives-apply'],
+                disabled  : active,
+                handler   : 'up.onApplyClick',
+                iconCls   : active ? 'fa fa-check' : 'fa fa-arrow-right',
+                presetName: name,
+                text      : active ? 'Active' : 'Apply',
+                ui        : 'ghost'
+            }]
+        }
+    }
+
+    /**
+     * @summary Apply the card's perspective — intent only; the cockpit switches and re-projects.
+     * @param {Object} data
+     */
+    onApplyClick(data) {
+        this.fire('perspectiveRequest', {action: 'apply', name: data.component.presetName})
+    }
+
+    /**
+     * Triggered after the captureName config changed — the capture verb arms only once a name
+     * exists: an unnamed capture has nothing to be filed under, so the button says so by resting.
+     * @param {String|null} value
+     * @param {String|null} oldValue
+     * @protected
+     */
+    afterSetCaptureName(value, oldValue) {
+        const capture = this.getReference('perspectives-capture');
+
+        capture && (capture.disabled = !value)
+    }
+
+    /**
+     * @summary The field reports every keystroke's value; the trimmed name becomes the verb's.
+     * @param {Object} data
+     */
+    onNameChange(data) {
+        this.captureName = (data.value ?? '').trim() || null
+    }
+
+    /**
+     * @summary Capture the live layout under the armed name — intent only; the cockpit wraps the
+     * committed dock document, saves it, and re-projects the list with the verdict.
+     */
+    onCaptureClick() {
+        const name = this.captureName;
+
+        name && this.fire('perspectiveRequest', {action: 'capture', name})
+    }
+}
+
+export default Neo.setupClass(PerspectivesPane);

--- a/resources/scss/src/apps/agentos/fleet/perspectives/Container.scss
+++ b/resources/scss/src/apps/agentos/fleet/perspectives/Container.scss
@@ -1,0 +1,68 @@
+/* AgentOS.view.fleet.perspectives.Container — the saved-layouts pane in the pinned drawer.
+   Head (title · authority) over the meta line, one card per perspective (name + title line + the
+   apply verb), and the capture rail (name field + verb). Mount-agnostic by the drawer-shell
+   contract: the HOST owns surface, padding and rhythm — this root declares no frame; every colour
+   reads from the --fm-* token layer. Mirrors the wake-routes pane's grammar so the two rail
+   drawers read as siblings. */
+.fm-perspectives-pane {
+
+    .fm-perspectives-head {
+        gap        : var(--fm-space-2);
+        align-items: baseline;
+        flex-wrap  : wrap;
+    }
+
+    .fm-perspectives-title {
+        color      : var(--fm-ink);
+        font-weight: 700;
+    }
+
+    .fm-perspectives-authority,
+    .fm-perspectives-meta {
+        color: var(--fm-ink-dim);
+        font : var(--fm-text-micro);
+    }
+
+    /* the cards own the scroll — the chrome above and the capture rail below stay put */
+    .fm-perspectives-rows {
+        overflow  : auto;
+        min-height: 0;
+        gap       : 10px;
+    }
+
+    .fm-perspectives-card {
+        gap          : var(--fm-space-2);
+        padding      : 10px;
+        border       : 1px solid var(--fm-line-soft);
+        border-radius: 6px;
+        background   : var(--fm-panel);
+
+        /* the live layout: the signal on the leading edge, the same accent the preset switcher
+           presses — one vocabulary for "this is where you are" */
+        &.is-active {
+            border-color: color-mix(in srgb, var(--fm-signal) 45%, var(--fm-line-soft));
+            box-shadow  : inset 3px 0 0 var(--fm-signal);
+        }
+    }
+
+    .fm-perspectives-card-title {
+        color      : var(--fm-ink);
+        font       : var(--fm-text-body);
+        font-weight: 650;
+    }
+
+    .fm-perspectives-card-detail {
+        color: var(--fm-ink-dim);
+        font : var(--fm-text-detail);
+    }
+
+    .fm-perspectives-actions {
+        gap: var(--fm-space-2);
+    }
+
+    /* honest quiet state — absence is not an error (drawer-shell contract item 5) */
+    .fm-perspectives-empty {
+        padding: 14px var(--fm-space-1);
+        color  : var(--fm-ink-dim);
+    }
+}

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/perspectiveCapture.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/perspectiveCapture.spec.mjs
@@ -55,7 +55,7 @@ test.describe('FleetCockpit — the perspectives drawer\'s verbs through the rea
         expect(list.captureNote).toBeNull()
     });
 
-    test('capture files the live layout under the name and projects the verdict — filed, never activated; the switcher seats it on the next refresh', async () => {
+    test('capture files the live layout under the name, seats its preset button and projects the verdict — filed, never activated', async () => {
         cockpit = createCockpit();
         await cockpit.refreshPromise;
 
@@ -74,16 +74,9 @@ test.describe('FleetCockpit — the perspectives drawer\'s verbs through the rea
         expect(list.activeLayoutId).toBe('overview');
         expect(list.captureNote).toBe('captured "Triage" — apply it from its card');
 
-        // never in the capture's own tick: an update elsewhere in the cockpit while the drawer
-        // re-renders inside its open reveal overlay drops the revealed pane (measured live)
-        expect(cockpit.getReference('fleet-preset-capture-triage'), 'the switcher does not reconcile in the capture tick').toBeFalsy();
-
-        // the next dock refresh's pre-projection chrome sync seats it
-        cockpit.syncControlBar();
-
         const button = cockpit.getReference('fleet-preset-capture-triage');
 
-        expect(button, 'the capture joins the preset switcher on the next refresh').toBeTruthy();
+        expect(button, 'the capture joins the preset switcher').toBeTruthy();
         expect(button.text).toBe('Triage');
         expect(button.pressed, 'seated, not pressed — Apply is the switch').toBe(false);
         expect(cockpit.getReference('fleet-preset-overview').pressed).toBe(true)

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/perspectiveCapture.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/perspectiveCapture.spec.mjs
@@ -1,0 +1,165 @@
+import {setup} from '../../../../../../setup.mjs';
+
+setup({
+    neoConfig: {allowVdomUpdatesInTests: true, useDomApiRenderer: true, unitTestMode: true},
+    appConfig: {name: 'PerspectiveCaptureTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core            from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import                           '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs';
+import CockpitStateProvider from '../../../../../../../../apps/agentos/view/fleet/cockpit/StateProvider.mjs';
+import FleetActivityEvents  from '../../../../../../../../apps/agentos/store/FleetActivityEvents.mjs';
+import FleetCockpit         from '../../../../../../../../apps/agentos/view/fleet/cockpit/Container.mjs';
+import FleetRoster          from '../../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import ViewerWakeFeed       from '../../../../../../../../apps/agentos/store/ViewerWakeFeed.mjs';
+
+/**
+ * The perspectives drawer's two verbs, driven through the cockpit's REAL relay over a real
+ * constructed cockpit: `apply` switches the layout and the settled refresh republishes the list;
+ * `capture` wraps the live dock document under the operator's name, refuses a held name with the
+ * library's own verdict, and every outcome reaches the projected list the drawer binds to
+ * (`perspectives` in provider data) — never a side channel.
+ */
+const createCockpit = () => Neo.create(FleetCockpit, {
+    stateProvider: {
+        module: CockpitStateProvider,
+        stores: {
+            fleetActivityEvents: {module: FleetActivityEvents},
+            fleetRoster        : {module: FleetRoster, autoLoad: false},
+            viewerWakeFeed     : {module: ViewerWakeFeed}
+        }
+    }
+});
+
+const projected = cockpit => cockpit.getStateProvider().data.perspectives;
+
+test.describe('FleetCockpit — the perspectives drawer\'s verbs through the real relay', () => {
+    let cockpit;
+
+    test.afterEach(() => {
+        cockpit?.destroy();
+        cockpit = null
+    });
+
+    test('boot projects the three shipped presets with Overview active', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const list = projected(cockpit);
+
+        expect(list.items.map(item => item.layoutId)).toEqual(['overview', 'focus', 'review']);
+        expect(list.items.map(item => item.perspectiveName)).toEqual(['Overview', 'Focus', 'Review']);
+        expect(list.activeLayoutId).toBe('overview');
+        expect(list.captureNote).toBeNull()
+    });
+
+    test('capture files the live layout under the name and projects the verdict — filed, never activated; the switcher seats it on the next refresh', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const verdict = cockpit.getController().onPerspectiveRequest({action: 'capture', name: 'Triage'});
+
+        expect(verdict).toEqual({saved: true, layoutId: 'capture-triage', name: 'Triage', errors: []});
+        expect(cockpit.perspectiveStore.list().map(item => item.layoutId)).toEqual(['overview', 'focus', 'review', 'capture-triage']);
+        // activating would restore the capture as a new document, and a perspective restore
+        // releases every open reveal — the drawer would close on its own verdict; the live layout
+        // already IS this document, so the store's active pointer stays where it was
+        expect(cockpit.perspectiveStore.collection.activeLayoutId, 'a capture is filed, not restored').toBe('overview');
+
+        const list = projected(cockpit);
+
+        expect(list.items.map(item => item.perspectiveName)).toEqual(['Overview', 'Focus', 'Review', 'Triage']);
+        expect(list.activeLayoutId).toBe('overview');
+        expect(list.captureNote).toBe('captured "Triage" — apply it from its card');
+
+        // never in the capture's own tick: an update elsewhere in the cockpit while the drawer
+        // re-renders inside its open reveal overlay drops the revealed pane (measured live)
+        expect(cockpit.getReference('fleet-preset-capture-triage'), 'the switcher does not reconcile in the capture tick').toBeFalsy();
+
+        // the next dock refresh's pre-projection chrome sync seats it
+        cockpit.syncControlBar();
+
+        const button = cockpit.getReference('fleet-preset-capture-triage');
+
+        expect(button, 'the capture joins the preset switcher on the next refresh').toBeTruthy();
+        expect(button.text).toBe('Triage');
+        expect(button.pressed, 'seated, not pressed — Apply is the switch').toBe(false);
+        expect(cockpit.getReference('fleet-preset-overview').pressed).toBe(true)
+    });
+
+    test('a held name is refused with the library\'s collision verdict — nothing replaced, the refusal projected', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const verdict = cockpit.getController().onPerspectiveRequest({action: 'capture', name: 'Overview'});
+
+        // a capture's id carries the `capture-` prefix, so the preset's OWN id never absorbs it:
+        // the library sees a different record claiming a held name and refuses
+        expect(verdict.saved).toBe(false);
+        expect(verdict.layoutId).toBeNull();
+        expect(verdict.name).toBe('Overview');
+        expect(verdict.errors).toEqual(['"Overview" is already held by Overview — mission control']);
+        expect(cockpit.perspectiveStore.list()).toHaveLength(3);
+        expect(cockpit.perspectiveStore.getPerspective('Overview').layout.metadata.source, 'the shipped preset is untouched').toBe('fm-cockpit-presets');
+
+        const list = projected(cockpit);
+
+        expect(list.captureNote).toBe('capture refused: "Overview" is already held by Overview — mission control');
+        expect(list.activeLayoutId).toBe('overview')
+    });
+
+    test('a capture that throws inside the library still projects a verdict — never a silent nothing', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const originalError = console.error;
+
+        console.error = () => {};
+        cockpit.perspectiveStore.savePerspective = () => { throw new Error('collection storage refused') };
+
+        try {
+            const verdict = cockpit.getController().onPerspectiveRequest({action: 'capture', name: 'Triage'});
+
+            expect(verdict).toEqual({saved: false, layoutId: null, name: 'Triage', errors: ['capture failed: collection storage refused']});
+            expect(projected(cockpit).captureNote).toBe('capture refused: capture failed: collection storage refused');
+            expect(cockpit.perspectiveStore.list()).toHaveLength(3)
+        } finally {
+            console.error = originalError
+        }
+    });
+
+    test('an unnamed capture is refused before the wrapper sees the document', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const verdict = cockpit.getController().onPerspectiveRequest({action: 'capture', name: '   '});
+
+        expect(verdict).toEqual({saved: false, layoutId: null, name: null, errors: ['a perspective needs a name']});
+        expect(cockpit.perspectiveStore.list()).toHaveLength(3)
+    });
+
+    test('apply switches through the preset path: the store activates the layout and the switcher presses its button', async () => {
+        cockpit = createCockpit();
+        await cockpit.refreshPromise;
+
+        const verdict = cockpit.getController().onPerspectiveRequest({action: 'apply', name: 'Focus'});
+
+        expect(verdict).toEqual({errors: [], switched: true});
+        expect(cockpit.perspectiveStore.collection.activeLayoutId).toBe('focus');
+
+        // The switch's refresh does not settle in this harness (no main thread lands the
+        // re-projection, so neither refresh hook runs), and the SETTLED-refresh republish —
+        // `afterRefreshDockWorkspace` → `publishPerspectives` — is the running cockpit's witness:
+        // the drawer re-projects the new active layout after a switch there. What the harness CAN
+        // pin is the projection itself: one publish over the switched store reaches the list the
+        // drawer binds to, and the control bar's reconcile presses the switched preset.
+        cockpit.publishPerspectives();
+        cockpit.syncControlBar();
+
+        expect(projected(cockpit).activeLayoutId).toBe('focus');
+        expect(cockpit.getReference('fleet-preset-focus').pressed).toBe(true);
+        expect(cockpit.getReference('fleet-preset-overview').pressed).toBe(false)
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/projection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/projection.spec.mjs
@@ -387,12 +387,22 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             }
         }
 
-        // perspectives remains a sibling-leaf placeholder — an HONEST labelled pane, never a blank one
+        // perspectives resolves to its own drawer — LAZY like the wake-routes sibling (a loader,
+        // not a class), bound to the projected list, its intent relayed to the controller; the
+        // honest placeholder now belongs only to a zone no case knows
         const perspectives = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'perspectives', {title: 'Perspectives'}, 'perspectives');
 
-        expect(perspectives.cls).toContain('fm-pane-placeholder');
-        expect(perspectives.cls).toContain('dock-flip-item-perspectives');
-        expect(perspectives.html).toContain('Perspectives')
+        expect(typeof perspectives.module, 'a loader, resolved at first reveal').toBe('function');
+        expect(perspectives.cls).toEqual(['dock-flip-item-perspectives']);
+        expect(perspectives.bind.perspectives({perspectives: 'projected'})).toBe('projected');
+        expect(perspectives.listeners.perspectiveRequest).toBe('onPerspectiveRequest');
+        expect(perspectives.html).toBeUndefined();
+
+        const unknown = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'no-such-zone', {title: 'Nowhere'}, 'no-such-zone');
+
+        expect(unknown.cls).toContain('fm-pane-placeholder');
+        expect(unknown.cls).toContain('dock-flip-item-no-such-zone');
+        expect(unknown.html).toContain('Nowhere')
     });
 
     test('the projected tree renders the document\'s zones: every live pane present, exactly once each', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/vesselPaneIntents.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/vesselPaneIntents.spec.mjs
@@ -65,7 +65,8 @@ test.describe('FleetCockpit — vessel-fired pane intents + phase-blind owner pu
             'operator-mailbox': ['compose', 'inboxPageRequest'],
             'catch-up'        : ['historyRequest', 'markCaughtUpRequest', 'liveSurfaceRequest'],
             'memories'        : ['memoriesRequest', 'sessionDetailRequest', 'sessionDetailClosed'],
-            'wakeRoutes'      : ['wakeRoutesRequest']
+            'wakeRoutes'      : ['wakeRoutesRequest'],
+            'perspectives'    : ['perspectiveRequest']
         };
 
         for (const [ref, events] of Object.entries(paneIntents)) {

--- a/test/playwright/unit/apps/agentos/view/fleet/perspectives/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/perspectives/container.spec.mjs
@@ -1,0 +1,179 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'AgentOSPerspectivesPaneTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect}      from '@playwright/test';
+import Neo                 from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core           from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import Instance            from '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs';
+import {resolveCallback}   from '../../../../../../../../node_modules/neo.mjs/src/util/Function.mjs';
+import CockpitDockDocument from '../../../../../../../../apps/agentos/util/CockpitDockDocument.mjs';
+import CockpitPresets      from '../../../../../../../../apps/agentos/util/CockpitPresets.mjs';
+import PerspectivesPane    from '../../../../../../../../apps/agentos/view/fleet/perspectives/Container.mjs';
+
+/**
+ * The saved-layouts pane renders the cockpit's PROJECTED perspective list and fires intent; it
+ * never touches the library. These arms pin the pane's honest states and its two verbs on the
+ * instance, and the capture wrapper the cockpit uses to turn the live dock document into a saved
+ * layout. The rendered drawer (rail reveal, both themes) is read by eye on the running cockpit.
+ */
+
+const projected = (activeLayoutId = 'overview', captureNote = null) => ({
+    activeLayoutId,
+    captureNote,
+    items: [
+        {layoutId: 'overview', perspectiveName: 'Overview', title: 'Overview — mission control', captureScope: 'window'},
+        {layoutId: 'focus',    perspectiveName: 'Focus',    title: 'Focus — roster dominant',    captureScope: 'window'},
+        {layoutId: 'review',   perspectiveName: 'Review',   title: 'Review — one agent + the trail', captureScope: 'window'}
+    ]
+});
+
+const cardsOf = pane => pane.getReference('perspectives-rows').items;
+
+test.describe('AgentOS.view.fleet.perspectives.Container — the saved-layouts drawer', () => {
+    let pane;
+
+    test.afterEach(() => {
+        pane?.destroy();
+        pane = null
+    });
+
+    test('nothing projected renders as unobserved: the meta names it and no card poses as a layout', () => {
+        pane = Neo.create(PerspectivesPane, {appName});
+
+        expect(pane.getReference('perspectives-meta').text).toContain('No layouts projected yet');
+        expect(cardsOf(pane)).toHaveLength(1);
+        expect(cardsOf(pane)[0].cls).toContain('fm-perspectives-empty');
+        expect(pane.getReference('perspectives-capture').disabled, 'capture rests without a name').toBe(true)
+    });
+
+    test('a projected list renders one card per perspective, marks the live one and names it in the meta', () => {
+        pane = Neo.create(PerspectivesPane, {appName, perspectives: projected('focus')});
+
+        const cards = cardsOf(pane);
+
+        expect(cards).toHaveLength(3);
+        expect(pane.getReference('perspectives-meta').text).toBe('3 layouts · Focus active');
+
+        const
+            titles  = cards.map(card => card.items[0].items[0].text),
+            verbs   = cards.map(card => card.items[1]),
+            focus   = cards[1];
+
+        expect(titles).toEqual(['Overview', 'Focus', 'Review']);
+        expect(focus.cls, 'the live layout carries the active marker').toContain('is-active');
+        expect(verbs[1].text).toBe('Active');
+        expect(verbs[1].disabled, 'the live layout cannot be applied again').toBe(true);
+        expect(verbs[0].text).toBe('Apply');
+        expect(verbs[0].disabled).toBe(false);
+        expect(cards[0].items[0].items[1].text, 'the title line says more than the name').toBe('Overview — mission control')
+    });
+
+    test('a re-projection re-renders in place: the switch moves the marker, a capture verdict lands on the meta line', () => {
+        pane = Neo.create(PerspectivesPane, {appName, perspectives: projected('overview')});
+
+        pane.perspectives = projected('review', 'captured "triage" — apply it from its card');
+
+        const cards = cardsOf(pane);
+
+        expect(cards[2].cls).toContain('is-active');
+        expect(cards[0].cls).not.toContain('is-active');
+        expect(pane.getReference('perspectives-meta').text).toBe('3 layouts · Review active · captured "triage" — apply it from its card');
+
+        // the same content under a new reference is a no-op — the drawer renders on identity, so a
+        // provider that re-hands the list on every leaf touch can never re-enter the projection
+        const rowsBefore = cardsOf(pane);
+
+        pane.perspectives = projected('review', 'captured "triage" — apply it from its card');
+
+        expect(cardsOf(pane)[0], 'a reference-only change re-renders nothing').toBe(rowsBefore[0]);
+
+        pane.perspectives = projected('review', 'capture refused: "Overview" is already held by Overview — mission control');
+
+        expect(pane.getReference('perspectives-meta').text).toContain('capture refused: "Overview" is already held by Overview — mission control')
+    });
+
+    test('the verbs fire intent only: apply names the card, capture names the typed layout and arms with it', () => {
+        pane = Neo.create(PerspectivesPane, {appName, perspectives: projected('overview')});
+
+        const fired = [];
+
+        pane.on('perspectiveRequest', data => fired.push(data));
+
+        const applyFocus = cardsOf(pane)[1].items[1];
+
+        // the verb sits two containers below the pane: its `up.` handler must resolve through the
+        // card nesting to the pane — asserted on the engine's own resolver, which is what a click
+        // runs (the DOM click itself is the running cockpit's business)
+        const resolved = resolveCallback(applyFocus.handler, applyFocus);
+
+        expect(resolved.scope, 'the up. walk lands on the pane').toBe(pane);
+        expect(resolved.fn).toBe(pane.onApplyClick);
+
+        // the capture verb sits in the static capture rail (container → row → button): same walk
+        const captureBtn = pane.getReference('perspectives-capture'),
+              captureRes = resolveCallback(captureBtn.handler, captureBtn);
+
+        expect(captureRes.scope, 'the capture verb resolves to the pane too').toBe(pane);
+        expect(captureRes.fn).toBe(pane.onCaptureClick);
+
+        pane.onApplyClick({component: applyFocus});
+        // `fire` stamps the emitting instance as `source`; the intent payload is the pair below
+        expect(fired).toHaveLength(1);
+        expect(fired[0]).toMatchObject({action: 'apply', name: 'Focus'});
+
+        const capture = pane.getReference('perspectives-capture');
+
+        expect(capture.disabled).toBe(true);
+
+        pane.onNameChange({value: '   '});
+        expect(pane.captureName, 'whitespace is not a name').toBeNull();
+        expect(capture.disabled).toBe(true);
+
+        // the field reports the keystroke value; the verb arms on the trimmed name and uses THAT —
+        // never a late read of the field's own value, which commits on blur and races the click
+        pane.onNameChange({value: ' Triage '});
+        expect(pane.captureName).toBe('Triage');
+        expect(capture.disabled).toBe(false);
+
+        pane.onCaptureClick();
+        expect(fired).toHaveLength(2);
+        expect(fired[1]).toMatchObject({action: 'capture', name: 'Triage'})
+    });
+});
+
+test.describe('AgentOS.util.CockpitPresets.captureSavedLayout — the live document as a named saved layout', () => {
+    test('a named capture wraps the document under the folded name, titled by the name, stamped as a capture', () => {
+        const {layout, errors} = CockpitPresets.captureSavedLayout(CockpitDockDocument.create(), '  Triage view ');
+
+        expect(errors).toEqual([]);
+        expect(layout.layoutId, 'the capture prefix keeps the id off the shipped presets').toBe('capture-triage-view');
+        expect(layout.perspectiveName).toBe('Triage view');
+        expect(layout.title).toBe('Triage view');
+        expect(layout.metadata).toEqual({source: 'fm-cockpit-capture'});
+        expect(layout.captureScope).toBe('window')
+    });
+
+    test('an empty name is refused before the wrapper sees the document', () => {
+        for (const name of ['', '   ', null, undefined]) {
+            const {layout, errors} = CockpitPresets.captureSavedLayout(CockpitDockDocument.create(), name);
+
+            expect(layout).toBeNull();
+            expect(errors).toEqual(['a perspective needs a name'])
+        }
+    });
+
+    test('a name of nothing but punctuation still gets an addressable id', () => {
+        const {layout, errors} = CockpitPresets.captureSavedLayout(CockpitDockDocument.create(), '***');
+
+        expect(errors).toEqual([]);
+        expect(layout.layoutId).toBe('capture-layout');
+        expect(layout.perspectiveName).toBe('***')
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/perspectives/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/perspectives/container.spec.mjs
@@ -75,16 +75,41 @@ test.describe('AgentOS.view.fleet.perspectives.Container — the saved-layouts d
         expect(cards[0].items[0].items[1].text, 'the title line says more than the name').toBe('Overview — mission control')
     });
 
-    test('a re-projection re-renders in place: the switch moves the marker, a capture verdict lands on the meta line', () => {
+    test('a re-projection moves the cards in place — object permanence: the instances survive, the marker and the verbs move, a new perspective inserts, a departed one removes', () => {
         pane = Neo.create(PerspectivesPane, {appName, perspectives: projected('overview')});
+
+        const before = cardsOf(pane).slice();
 
         pane.perspectives = projected('review', 'captured "triage" — apply it from its card');
 
         const cards = cardsOf(pane);
 
+        expect(cards.every((card, index) => card === before[index]), 'the three card instances are the same objects').toBe(true);
         expect(cards[2].cls).toContain('is-active');
         expect(cards[0].cls).not.toContain('is-active');
+        expect(cards[2].items[1].text).toBe('Active');
+        expect(cards[2].items[1].disabled).toBe(true);
+        expect(cards[0].items[1].text).toBe('Apply');
+        expect(cards[0].items[1].disabled).toBe(false);
         expect(pane.getReference('perspectives-meta').text).toBe('3 layouts · Review active · captured "triage" — apply it from its card');
+
+        // a capture joins as a FOURTH card; the three keep their instances
+        const grown = projected('review');
+
+        grown.items.push({layoutId: 'capture-triage', perspectiveName: 'Triage', title: 'Triage', captureScope: 'window'});
+        pane.perspectives = grown;
+
+        expect(cardsOf(pane)).toHaveLength(4);
+        expect(cardsOf(pane).slice(0, 3).every((card, index) => card === before[index])).toBe(true);
+        expect(cardsOf(pane)[3].items[0].items[0].text).toBe('Triage');
+        expect(cardsOf(pane)[3].items[0].items[1].text, 'a capture titled by its name shows its scope').toBe('window scope');
+        expect(cardsOf(pane)[3].items[1].presetName).toBe('Triage');
+
+        // a departed perspective removes its card; the rest keep their instances
+        pane.perspectives = projected('review');
+
+        expect(cardsOf(pane)).toHaveLength(3);
+        expect(cardsOf(pane).every((card, index) => card === before[index])).toBe(true);
 
         // the same content under a new reference is a no-op — the drawer renders on identity, so a
         // provider that re-hands the list on every leaf touch can never re-enter the projection

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,8 +2,8 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "9b80eeedf353883e0bfe468d34ed50e6551646c62821e25b44b2f86eb1c3c4d1",
     "inputs": {
-        "apps/agentos": "bb33b66803853a9f69a52a333aef63d50cbd877f28e027495352a6c5b2c53ce3",
-        "resources/scss": "353b147f641958546f8b988daf68c3da9b54b82f774c55b8cc3468c8a5e10a1f",
+        "apps/agentos": "4cb48560a39d1cdd7a71e93ffc1d7968cd8fc2d55af9479aa8541de04534c10a",
+        "resources/scss": "67e5d91689d0067e28d1dac8831cbb11244e3e74ee9367eabee1b054d97399da",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "3450d151e4833d441d4a0cdad70e3dc27bac94aff4cf8fcb366b1e932ea60831",
         "test/playwright/visual/FleetCockpitVisual.spec.mjs": "308c863432484fa7116728068cbdb3ea34492952d34a169558af5850c2b51386",

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "9b80eeedf353883e0bfe468d34ed50e6551646c62821e25b44b2f86eb1c3c4d1",
     "inputs": {
-        "apps/agentos": "4cb48560a39d1cdd7a71e93ffc1d7968cd8fc2d55af9479aa8541de04534c10a",
+        "apps/agentos": "ea4ac26c40bb4ac91605bda6eb773c36b6c326454bd317600a8f0231646e862f",
         "resources/scss": "67e5d91689d0067e28d1dac8831cbb11244e3e74ee9367eabee1b054d97399da",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "3450d151e4833d441d4a0cdad70e3dc27bac94aff4cf8fcb366b1e932ea60831",


### PR DESCRIPTION
Resolves #84

Related: #10 (parent), #74 / PR #77 (the Add agent drawer, the sibling rail pane), #85 (the legend clip found in the same design pass), neomjs/neo#18062 / PR #18063 (the rail's lazy pane load this drawer rides), `neomjs/neo` `src/dashboard/dock/persistence/PerspectiveLibrary.mjs` (the library the cockpit already holds)

The Perspectives rail tab used to open on a developer placeholder — *"Perspectives — this pane's view lands with its own leaf"* — one click from the roster. It now opens on the cockpit's saved layouts: one card per perspective (the three shipped presets, plus every capture), the live one marked, an **Apply** verb per card, and a capture rail — a name and **Capture current layout** — that files the live dock document as one more perspective. The pane is a reveal drawer in the wake-routes grammar: lazy at first reveal, bound to the list the cockpit projects into provider data (`perspectives`), firing intent (`perspectiveRequest`) that the controller relays; it never touches the library. A capture is filed, not activated: it joins the top bar's preset switcher at once, the card's **Apply** is the switch, and both surfaces read one projected list.

Evidence: L3 (the drawer read by eye on the served cockpit; apply and capture driven on the running app with a fresh App worker; a real-cockpit unit spec over the relay; the drawer's own unit spec) → L3 required (AC-1 is rendered appearance, AC-2 a live round-trip). Residual: the NL battery did not run on this branch (budget stop, operator 2026-09-02) — the branch touches no NL spec and no NL surface; the full unit suite is the pre-push gate that ran, twice.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — the rail tab reveals a pane with no developer copy: a headline, the three built-in perspectives by name, an explicit affordance — both themes | Live: the tab reveals *Saved layouts · the dock document as data · apply or capture*, the meta line *3 layouts · Overview active*, three cards (Overview **Active**, Focus **Apply**, Review **Apply**) and the capture rail (Name field, **Capture current layout**, resting until a name exists) — light theme read by eye at 1280×720, dark theme rendered on the 127.0.0.1 origin (the operator's persisted theme) with the same anatomy. |
| AC-2 — applying from the pane produces the same document as the top-bar preset; capture files the live layout | `perspectiveCapture.spec.mjs` over a REAL cockpit: `apply` through the relay returns `{switched: true}`, the store activates `focus` and the switcher presses its button; `capture` returns `{saved: true, layoutId: 'capture-triage', name: 'Triage'}`, the list reads four, the store's active pointer stays `overview` (filed, not restored), the projected `captureNote` reads *captured "Triage" — apply it from its card*, and `fleet-preset-capture-triage` sits unpressed in the top bar with Overview still pressed; a held name (`Overview`) is refused with the library's own verdict and the shipped preset stays byte-untouched (`metadata.source` still `fm-cockpit-presets`); an unnamed capture is refused before the wrapper sees the document. Live (fresh App worker): capture "Triage" keeps the drawer open reading *4 layouts · Overview active · captured "Triage" — apply it from its card* with the fourth card, and **Triage** joins the top bar in the same tick; a second capture "Standup" makes it five on both surfaces; Apply Triage from its card switches — the top bar presses **Triage** (the drawer closes with the switch: a re-projection retires reveal state, engine-side). |
| AC-3 — no zone in the shipped dock document resolves to the placeholder | `projection.spec.mjs`: `perspectives` resolves to a loader (`typeof module === 'function'`), the marker class only, a `perspectives` binding and the `perspectiveRequest` listener — no `html`, no placeholder class; a made-up zone still gets the honest placeholder. `vesselPaneIntents.spec.mjs` carries `perspectives: ['perspectiveRequest']`: the intent reaches the scoped controller through the real fire path and dies without the scope, like its four siblings. |
| AC-4 — stamp after staging; unit + battery green with only the standing reds | Unit **751 passed** (the 738 before this branch + 13: 5 drawer arms, 3 capture-wrapper arms, 5 real-cockpit relay arms). `check-app-file-sizes`: 0 over the bar (the cockpit container and controller both at 995 — in the warn band; the next seam cut is #42's). `check-visual-baselines` green after each restamp, re-run on the pushed tree. Battery: not run on this branch (see Residual). |

## Deltas from ticket

- **Capture is wired, not stubbed — and filed, not activated.** The ticket allowed a disabled capture "until the capture path is wired"; the path was a wrapper away — `CockpitPresets.captureSavedLayout(document, name)` folds the name into `capture-<name>` and `Persistence.createSavedLayout` does the rest — so the verb is real. It saves with `activate: false`: activating restores the capture as a new document, and a perspective restore releases every open reveal (`Workspace#releaseStaleRevealPanes`) — the drawer would close on its own verdict. The live layout already IS the captured document; Apply switches to it.
- **A capture's id carries the `capture-` prefix.** The real-cockpit spec caught the first cut: a capture named "Overview" folded to the id `overview`, which the library treats as the preset's OWN record updating itself — it silently replaced the shipped preset with the live document. With the prefix the library sees a different record claiming a held name and refuses; re-capturing the same capture name updates that capture, which is the library's normal flow.
- **The drawer reconciles its cards in place — object permanence (second commit, the operator's review catch).** The first cut rebuilt every card on each projection change (`removeAll(true)` + `add`). Inside the open reveal overlay that churn dropped the revealed pane from the DOM ~50ms after a capture in most runs, with no reveal-machine transition — which I bisected across four code shapes and misread as an engine race, and worked around by deferring the switcher's button to the next refresh. Cards are now keyed by `layoutId` (`syncPerspectiveCards`): an existing card keeps its instance and gets its active marker and apply verb moved via `set`, a new perspective inserts its card at its list position, a departed one removes its card, a moved one `moveTo`s — exactly the idiom the cockpit's own `syncPresetButtons` already uses. With the churn gone the drawer stays open through a capture and the switcher seats the button in the same tick (2 of 2 fresh-worker captures, plus an Apply from the new card); the deferred seating is withdrawn. Unit arm: the three card instances survive a re-projection, a fourth inserts, a departed one removes, the survivors are the same objects.
- **The list publishes after a settled refresh, never from the pre-projection hook.** The first cut published from `syncControlBar()`, which the engine calls from `beforeRefreshDockWorkspace` — inside the refresh, before the host's own update lands. With the drawer open, its re-render on that publish stalled the refresh chain: no preset switch and no rail switch landed while the drawer was open (measured; the wake drawer, which binds nothing, was unaffected). The publish now runs from `afterRefreshDockWorkspace` and once at `onConstructed`, and it is idempotent (an identity guard skips an unchanged list).
- **The drawer renders on identity, not on reference.** Provider data hands the binding a NEW `perspectives` object whenever any leaf is touched, and the first cut re-rendered on every reference: measured as a re-render loop (thousands of `afterSetPerspectives` → `applyPerspectives` cycles with identical content, the worker busy enough that the capture's projection never reached the DOM). `projectionIdentity()` (active id, note, the items' id/name/title/scope) gates the re-render; a reference-only change is a no-op, pinned by a unit arm.
- **The capture verdict is one string leaf (`captureNote`), not a nested object.** Provider data drills plain objects into leaf paths; a verdict object under a `null` leaf never read back. One sentence survives the drilling and is what the meta line shows anyway.
- **`capturePerspective` lives on the controller**, beside `onPerspectiveRequest`, because the cockpit container crossed the 1k bar with it (1010 lines) — the view keeps `activatePerspective` and `publishPerspectives`.
- **The capture rail stacks** (name on its own line, verb beneath, right-aligned): the drawer is 281px wide and a field beside a 170px verb lost its placeholder.

## Test Evidence

- Unit **751 passed**. New: `view/fleet/perspectives/container.spec.mjs` (the drawer's honest states, the active marker, object permanence across re-projection / growth / removal, the identity no-op, the apply/capture intents, the `up.` resolution of the card verbs through the card nesting; the capture wrapper's fold/prefix/refusals), `view/fleet/cockpit/perspectiveCapture.spec.mjs` (the relay over a real cockpit, above). Restated: `projection.spec.mjs` (the zone resolves to the drawer; the placeholder keeps unknown zones), `vesselPaneIntents.spec.mjs` (+ the drawer's intent).
- Harness limit, stated: a perspective switch's refresh does not settle in the unit harness (no main thread lands the re-projection; neither refresh hook runs), with or without this branch's hook — bisected with the hook stubbed. The settled-refresh republish is therefore witnessed live, and the spec pins the projection over the switched store directly.
- Live on the served cockpit (fresh App worker per run — a `useSharedWorkers` app keeps its worker across reloads, so every run closed the origin's tabs first or switched origin): the drawer reveals with the three presets and Overview active (both themes); two captures in a row keep the drawer open with their verdicts and seat the switcher; Apply from a card switches and presses the top-bar preset.
- Theme build clean; the drawer's sheet is `css/src/apps/agentos/fleet/perspectives/Container.css` and the theme map carries the class.

## Notes for the rehearsal

- Apply from inside the drawer closes the drawer with the switch — a re-projection retires reveal state (`releaseStaleRevealPanes`), engine-consistent. The top bar carries and presses the applied perspective.

## Post-Merge Validation

- [ ] The operator's rehearsal: open the Perspectives rail tab — the three layouts with Overview active; capture the arranged layout under a name and see it join the drawer with its verdict and the top bar at once; Apply it from its card.

## Commits

- `5b1ce9c` feat(fleet): the Perspectives rail pane lists, applies and captures saved layouts (#84) — the drawer (`view/fleet/perspectives/Container.mjs` + its sheet), the capture wrapper (`CockpitPresets.captureSavedLayout`), the cockpit's projection + relay (`cockpit/Container.mjs`, `Controller.mjs`, `StateProvider.mjs`), the two new specs, the two restated ones, the restamp.
- `c1fa672` fix(fleet): the Perspectives drawer reconciles its cards in place (#84) — `syncPerspectiveCards` / `syncPerspectiveCard`, the switcher seated in the capture tick again, the permanence arm, the restamp.

Same-family review note: the GPT seats are at 0% weekly quota (operator, 2026-09-01 22:20Z); an Opus 5 review is the sanctioned exception.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session 91f83b9c-df95-4f72-a68f-d33f470792ac
