### PR TITLE
fix(agentos): the roster decides its idle fold after the mutation settles and derives the tier from state (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ NEO_AGENTOS_RUNTIME_ROOT=/absolute/path/to/neo-agent-brain npm run test-e2e:nl
 The script reaches every Neural Link witness under `test/playwright/e2e/agentos/` — a suffix
 match, not a prefix, so a new witness joins the battery by its name, and a red one announces
 itself instead of falling outside the glob. Add `-- --headed` for the honest receipt. One red is
-stated, not masked, and it has an owner outside this repo: `FleetGridScaleNL` folds a 20-agent
-roster correctly in the store but the animated list drops the cards, because the Engine's
-unfiltered projection (`allItems`) holds a batch as raw rows while the store holds records of the
-same rows, and the list reconciles by identity (neomjs/neo#18269 — the cockpit's own defence, the
-fold decided after the mutation settles and derived from `state`, is in #78; the witness turns
-green with the pin that carries the Engine fix). `AddAgentJourneyNL` went green with #74. Two
-witnesses ride the Engine's
+stated, not masked, and it has an owner: `FleetGridScaleNL` folds a 20-agent roster correctly in
+the store but the animated list drops the cards, because the pinned Engine's unfiltered projection
+(`allItems`) holds a batch as raw rows while the store holds records of the same rows, and the
+list reconciles by identity. The Engine fix is merged (neomjs/neo#18269); the cockpit's own
+defence — the fold decided after the mutation settles and derived from `state` — is in #78; the
+witness turns green with the Engine pin that carries the fix, #98, which owns this sentence until
+then. `AddAgentJourneyNL` went green with #74. Two witnesses ride the Engine's
 FLIP settle — the Review-preset journey in `FleetCockpitDockNL` and the rail-drawer witness's Escape
 dismissal — and the settle occasionally does not land within the wait (measured 2026-09-02:
 `FleetCockpitDockNL` 2/2 green headless under the Brain root; the rail-drawer witness runs only

--- a/README.md
+++ b/README.md
@@ -146,10 +146,14 @@ NEO_AGENTOS_RUNTIME_ROOT=/absolute/path/to/neo-agent-brain npm run test-e2e:nl
 
 The script reaches every Neural Link witness under `test/playwright/e2e/agentos/` — a suffix
 match, not a prefix, so a new witness joins the battery by its name, and a red one announces
-itself instead of falling outside the glob. Add `-- --headed` for the honest receipt. Two reds are
-stated, not masked, and each has an owner: `AddAgentJourneyNL` waits on #74 (the define-agent zone
-reveals empty until the Engine's rail loads a lazy module item on reveal), and `FleetGridScaleNL`
-reads back an empty store after possessing it over the wire (#78). Two witnesses ride the Engine's
+itself instead of falling outside the glob. Add `-- --headed` for the honest receipt. One red is
+stated, not masked, and it has an owner outside this repo: `FleetGridScaleNL` folds a 20-agent
+roster correctly in the store but the animated list drops the cards, because the Engine's
+unfiltered projection (`allItems`) holds a batch as raw rows while the store holds records of the
+same rows, and the list reconciles by identity (neomjs/neo#18269 — the cockpit's own defence, the
+fold decided after the mutation settles and derived from `state`, is in #78; the witness turns
+green with the pin that carries the Engine fix). `AddAgentJourneyNL` went green with #74. Two
+witnesses ride the Engine's
 FLIP settle — the Review-preset journey in `FleetCockpitDockNL` and the rail-drawer witness's Escape
 dismissal — and the settle occasionally does not land within the wait (measured 2026-09-02:
 `FleetCockpitDockNL` 2/2 green headless under the Brain root; the rail-drawer witness runs only

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -140,17 +140,13 @@ class FleetAgent extends Model {
         }, {
             // The roster's rank tier DERIVED from `state` — the default sort's leading axis,
             // expressed as a calculated field so "online first" is a plain store sorter instead of
-            // a render-time partition: 0 = online (present and engaged: working, wedged or
-            // rate-limited — a wedged agent is a thing the operator must SEE, never calm
-            // background), 1 = idle (the calm middle, the collapsible tier), 2 = the tail
-            // (benched / offline / unknown-guest). One derivation site; every consumer sorts on
-            // the field
+            // a render-time partition. The derivation itself lives in {@link #tierRankFor}: a
+            // calculated field exists on RECORDS only, and the engine's unfiltered projection
+            // (`allItems`) carries a batch as raw rows until something hydrates them (#78,
+            // neomjs/neo#18269) — so the fold predicate derives the tier from `state` itself,
+            // the one field every row shape carries.
             name     : 'tierRank',
-            calculate: data => {
-                const {state} = data;
-
-                return (state === 'ok' || state === 'wedged' || state === 'limited') ? 0 : state === 'idle' ? 1 : 2
-            }
+            calculate: data => FleetAgent.tierRankFor(data.state)
         }, {
             // normalized `fleetCockpitStatus.rows[*].sources`: roster / repoStatus / runtime
             // provenance. Replaced as one Object on each snapshot so Store recordChange remains
@@ -159,6 +155,19 @@ class FleetAgent extends Model {
             type        : 'Object',
             defaultValue: null
         }]
+    }
+
+    /**
+     * @summary The one derivation of a resident's rank tier from its session `state`: 0 = online
+     * (present and engaged: working, wedged or rate-limited — a wedged agent is a thing the operator
+     * must SEE, never calm background), 1 = idle (the calm middle, the collapsible tier), 2 = the
+     * tail (benched / offline / unknown-guest). The `tierRank` field calculates through it, and the
+     * roster's fold predicate reads it directly, so a raw row and its record answer the same tier.
+     * @param {String} state The session state (`ok` · `wedged` · `limited` · `idle` · `off` · other).
+     * @returns {Number} 0, 1 or 2
+     */
+    static tierRankFor(state) {
+        return (state === 'ok' || state === 'wedged' || state === 'limited') ? 0 : state === 'idle' ? 1 : 2
     }
 }
 

--- a/apps/agentos/view/fleet/roster/Controller.mjs
+++ b/apps/agentos/view/fleet/roster/Controller.mjs
@@ -1,4 +1,5 @@
 import ComponentController from '../../../../../node_modules/neo.mjs/src/controller/Component.mjs';
+import FleetAgent          from '../../../model/FleetAgent.mjs';
 
 /**
  * The roster's sort modes as plain store-sorter sets — replacing the whole set keeps ONE ordering
@@ -69,7 +70,10 @@ class Controller extends ComponentController {
         store.filters = [
             {disabled: true, property: 'state',               filterBy: ({item}) => item.state === 'off'},
             {disabled: true, property: 'participationStatus', filterBy: ({item}) => item.participationStatus === 'operator_benched'},
-            {disabled: true, property: 'tierRank',            filterBy: ({item}) => item.tierRank === 1}
+            // derived from `state`, never read from the calculated `tierRank`: the engine evaluates
+            // filters over its unfiltered projection, which holds a freshly added batch as RAW rows
+            // (no calculated fields) until something hydrates them — neomjs/neo#18269, facet 2
+            {disabled: true, property: 'tierRank',            filterBy: ({item}) => FleetAgent.tierRankFor(item.state) === 1}
         ]
     }
 
@@ -106,7 +110,7 @@ class Controller extends ComponentController {
             {component} = me,
             records     = me.getWholeFleet(),
             total       = records.length,
-            idleCount   = records.filter(record => record.tierRank === 1).length,
+            idleCount   = records.filter(record => FleetAgent.tierRankFor(record.state) === 1).length,
             folded      = total >= component.foldThreshold,
             foldFilter  = component.store?.getFilter?.('tierRank'),
             {idleShown} = component,
@@ -233,11 +237,22 @@ class Controller extends ComponentController {
 
     /**
      * @summary The roster set changed (seed, live replace, joiners/leavers): re-derive counts,
-     * fold state and the CTA.
+     * fold state and the CTA — one microtask after the mutation, never inside it.
+     *
+     * The store fires `load` synchronously from its own `mutate` listener, and the Engine mirrors
+     * that same mutation into `allItems` from a LATER `mutate` listener (neomjs/neo#18269). A fold
+     * toggled here re-filters the view from an `allItems` the batch has not reached yet, and every
+     * row being added vanishes from the view — the whole batch, not only the idle tier. Deciding
+     * on the settled fleet costs one microtask and no truth: title, CTA and chip read the same
+     * whole fleet either way. Removable once the Engine mirrors inside the mutation.
      * @param {Object} data The store load event.
      */
     onRosterStoreLoad(data) {
-        this.syncRosterDerived()
+        const me = this;
+
+        queueMicrotask(() => {
+            !me.isDestroyed && !me.component?.isDestroyed && me.syncRosterDerived()
+        })
     }
 
     /**

--- a/test/playwright/e2e/agentos/FleetGridScaleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetGridScaleNL.spec.mjs
@@ -32,12 +32,19 @@ test.describe('AgentOS fleet grid — density-evidence scale (Neural Link)', () 
         // The provider-hosted FleetRoster instance, addressed by class — the store registry lists
         // more than one store of the FleetAgent model since the August rebuilds, and the first
         // registry hit is not the one the grid renders from (the sibling AgentCard witness's shape).
+        // The instance question (#78): the class query answers TWO instances — the provider-hosted
+        // store and its `-all` twin, the engine's unfiltered projection the roster's filters create
+        // (`Neo.collection.Base#filter` clones the store's own class as `<id>-all`). The grid binds
+        // the store; the twin is where the whole fleet lives once a filter is active.
         const
             app       = await neuralLink.connectToApp('AgentOS'),
-            instances = await app.findInstances({className: 'AgentOS.store.FleetRoster'}, ['id']),
-            roster    = Array.isArray(instances) ? instances[0] : instances;
+            found     = await app.findInstances({className: 'AgentOS.store.FleetRoster'}, ['id']),
+            instances = Array.isArray(found) ? found : [found],
+            roster    = instances.find(instance => !instance?.id?.endsWith('-all')),
+            wholeId   = `${roster?.id}-all`;
 
         expect(roster?.id, 'the provider-hosted FleetRoster store should be registered in the App Worker').toBeTruthy();
+        expect(instances.some(instance => instance?.id === wholeId), 'the store carries its unfiltered twin').toBe(true);
 
         // The 20-agent fixture at the evidence's ceiling band: 4 online (2 ok + 1 limited +
         // 1 wedged) · 14 idle · 2 benched — over the density-derived fold threshold (12).
@@ -71,25 +78,33 @@ test.describe('AgentOS fleet grid — density-evidence scale (Neural Link)', () 
         await app.callMethod(roster.id, 'clear');
         await app.callMethod(roster.id, 'add', [fixture]);
 
-        // The possessed store is the source of truth the grid derives from. Read the LIVE rows
-        // (`items` / `count`): `totalCount` is the remote-paging field frozen at the last URL
-        // load — it deliberately does not track local mutations, so it must never gate this.
+        // The possessed store is the source of truth the grid derives from — read BOTH halves.
+        // The whole fleet lives in the unfiltered twin (20); the view the grid renders is the
+        // folded one: 14 idle rows filtered out by the density preset, 6 rows left (`items` /
+        // `count`). `totalCount` is the remote-paging field frozen at the last URL load — it
+        // deliberately does not track local mutations, so it must never gate this.
+        await expect.poll(() => app.callMethod(wholeId, 'getCount'), {
+            message: 'the whole fleet lands in the unfiltered twin', timeout: 10000, intervals: [100]
+        }).toBe(20);
+
         const snapshot = await app.inspectStore(roster.id, 25);
-        expect(snapshot.items.length).toBe(20);
-        expect(snapshot.count).toBe(20);
+        expect(snapshot.count, 'the folded view keeps every non-idle resident').toBe(6);
+        expect(snapshot.items.map(item => item.agentId).sort()).toEqual(
+            ['scale-limited-a', 'scale-off-a', 'scale-off-b', 'scale-ok-a', 'scale-ok-b', 'scale-wedged-a']
+        );
 
         // DOM verdicts — the mounted surface obeys the density rules:
         // the header title tracks the possessed total,
         await expect(page.locator('.fm-fleet-title')).toHaveText('Fleet · 20 agents');
         // the idle tier folds to an honest count (14 idle never render as 14 cards),
-        await expect(page.locator('.fm-fleet-fold')).toHaveText('14 idle');
+        await expect(page.locator('.fm-roster-fold')).toHaveText('+14 idle · show');
         // online (4) + benched (2) stay as cards — working-first keeps the glance priority,
         await expect(page.locator('.fm-fleet-cards .fm-agent-card')).toHaveCount(6);
         // and dropping back BELOW threshold un-folds: every card renders again.
         await app.callMethod(roster.id, 'clear');
         await app.callMethod(roster.id, 'add', [fixture.slice(0, 6)]);
 
-        await expect(page.locator('.fm-fleet-fold')).toHaveCount(0);
+        await expect(page.locator('.fm-roster-fold')).toBeHidden();
         await expect(page.locator('.fm-fleet-title')).toHaveText('Fleet · 6 agents')
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/container.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/container.spec.mjs
@@ -389,6 +389,38 @@ test.describe('Fleet roster — the animated store-driven list: sorters rank, fi
         grid.destroy()
     });
 
+    test('#78: a batch that crosses the threshold keeps every non-idle resident — the fold decides after the mutation settles', async () => {
+        // The Engine mirrors a store mutation into `allItems` as a `mutate` LISTENER, one step
+        // behind the store's own synchronous `load` (neomjs/neo#18269). A fold toggled inside
+        // that `load` rebuilds the view from an `allItems` that does not hold the batch yet, and
+        // every row being added vanishes — not only the idle ones. Red against the synchronous
+        // toggle: `count` reads 0 right after `add`.
+        const store = makeStore(roster(['ok', 'ok'])),
+              grid  = Neo.create(FleetGrid, {appName, foldThreshold: 12, store}),
+              // 2 more online · 14 idle · 2 benched → 20 with the seed pair, over the threshold
+              batch = roster(['limited', 'wedged', ...Array(14).fill('idle'), 'off', 'off'])
+                  .map((row, i) => ({...row, agentId: `batch-${String(i).padStart(2, '0')}`, displayName: `Batch ${i}`}));
+
+        expect(grid.getReference('fold-chip').hidden).toBe(true);
+
+        const added = store.add(batch);
+
+        // the mutation itself is whole: every row answers as a record, the view holds the batch
+        expect(added.filter(Boolean).length, 'add answers a record per row').toBe(18);
+        expect(store.getCount(), 'no row is lost to the fold inside the mutation').toBe(20);
+
+        // one microtask later the fold is decided on the settled whole fleet
+        await Promise.resolve();
+
+        expect(store.allItems.getCount(), 'the whole fleet lives in the unfiltered twin').toBe(20);
+        expect(store.getCount(), 'the folded view keeps the six non-idle residents').toBe(6);
+        expect(store.items.every(record => record.tierRank !== 1)).toBe(true);
+        expect(grid.getReference('fleet-title').text).toBe('Fleet · 20 agents');
+        expect(grid.getReference('fold-chip').text).toBe('+14 idle · show');
+
+        grid.destroy()
+    });
+
     test('selection writes the provider truth pair and fires the detail intent; a control click never selects', async () => {
         const
             fired = [],
@@ -505,6 +537,8 @@ test.describe('Fleet roster — the animated store-driven list: sorters rank, fi
 
         list.createItems(true);
         expect(cards(list).length).toBe(3);
+        // the derived surface settles one microtask after the mutation (#78, neomjs/neo#18269)
+        await Promise.resolve();
         expect(grid.getReference('fleet-title').text).toBe('Fleet · 3 agents');
 
         grid.destroy()
@@ -724,7 +758,7 @@ test.describe('Fleet roster — the animated store-driven list: sorters rank, fi
         grid.destroy()
     });
 
-    test('the bootstrap CTA renders ONLY at roster count 0, fires addAgentRequest, and vanishes with the first agent', () => {
+    test('the bootstrap CTA renders ONLY at roster count 0, fires addAgentRequest, and vanishes with the first agent', async () => {
         const
             fired = [],
             store = makeStore([]),
@@ -740,8 +774,10 @@ test.describe('Fleet roster — the animated store-driven list: sorters rank, fi
         grid.getController().onEmptyCtaClick({});
         expect(fired).toHaveLength(1);
 
-        // the first agent retires the CTA — it is a bootstrap affordance, never ambient chrome
+        // the first agent retires the CTA — it is a bootstrap affordance, never ambient chrome;
+        // the derived surface settles one microtask after the mutation (#78, neomjs/neo#18269)
         store.add({agentId: 'first', displayName: 'First', state: 'ok'});
+        await Promise.resolve();
 
         expect(cta.hidden).toBe(true);
         expect(grid.getReference('fleet-title').text).toBe('Fleet · 1 agents');

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "14e26efb3492c66b75be3e9cc23ef03b86730dd2b97536553e2634b45c18fc29",
     "inputs": {
-        "apps/agentos": "b76377c700c529c4dcbe05b0ed75dfac10a86755132eeccf43685ad3b9a7fff5",
+        "apps/agentos": "ebfcf2b6f85e038caca5cd65eeedab82d72160edbad5f1cba3b204587293233c",
         "resources/scss": "ba0ce5dd3464afb60fe99b200e67f05bde2cb5df18c76cf25e255d4c86940991",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4745760abc6192d424b6a26853db152daabb4251918c4101ca2e6e4794d6dccd",


### PR DESCRIPTION
Resolves #78

Related: #10 (parent) · #73 / PR #75 (the disclosure) · neomjs/neo#18269 / neo PR #18273 (the engine root, two facets, filed from this measurement; merged 2026-09-04) · #98 (the successor: the engine pin that lands it, turns the DOM half green, retires the deferral and frees the README) · #90 / PR #91 (the pin this was measured on, merged)

Rebased onto `dev` after PR #91, PR #94 and PR #96 merged (`75df349`): `29a560c` is the original commit (pre-rebase `361815d` / `6345796` / `c569791`, identical content), `800f23b` restamps on the merged sources, `729a5ff` names the residual's owner in the README. Head `729a5ff`. The residual this PR states is owned by #98 — the engine pin that lands neomjs/neo#18269 (the merged cause, via neo PR #18273 on 2026-09-04) and retires the microtask deferral.

The last stated red of the cockpit battery gets its cause, its instance answer and its store half here; its DOM half waits for the engine pin (#98). The cause was never the possession idiom. `FleetGridScaleNL` possesses the provider-hosted `FleetRoster` exactly like its green sibling; what it did that the sibling did not was cross the roster's fold threshold. Measured over the Neural Link on pin 5 (the instance question answered first: the class query returns the store **and** its `-all` twin — the engine's unfiltered projection the roster's filters create; the grid binds the store):

1. **The fold's toggle raced the engine's `allItems` mirror.** The store fires `load` synchronously from its own `mutate` listener; the engine mirrors that same mutation into `allItems` from a *later* `mutate` listener. The roster decided the fold inside `load`, the toggle re-filtered the view from an `allItems` the batch had not reached, and every row being added vanished — `add` answered twenty `null`s, `count` stayed at the seed. Falsifier: with the threshold out of reach the same `add` returns the record. neomjs/neo#18269, facet 1.
2. **The mirror copies the rows as they were at splice time.** After deferring the toggle, the fold was on, `allItems` held 31, the view still held 31: on the mounted cockpit the list renders inside the store's `load` and hydrates the rows *before* the twin's mirror listener runs, so `Store#hydrateRecord`'s twin branch finds nothing to update and the twin then receives the stale raw references — the store holds records, `allItems` holds raw rows of the same residents, and `filterBy: item.tierRank === 1` saw `undefined` on every mirrored row. An explicit `filter()` after anything hydrated the twin answered 17. In the headless unit harness nothing renders inside `load`, the hydration lands after the mirror, and the same code shows no defect — the class hides from unit coverage. neomjs/neo#18269, facet 2.

Consumer-side, three small moves, no product surface changed:

- `roster/Controller.mjs` — the `load` path decides the fold **one microtask after the mutation** (`queueMicrotask`); seat, `recordChange` and the chip stay synchronous. Removable once the engine mirrors inside the mutation.
- `model/FleetAgent.mjs` — `static tierRankFor(state)`: the one tier derivation; `tierRank` calculates through it, and the fold predicate + the idle count read it from `state` directly, so a raw row and its record answer the same tier.
- `FleetGridScaleNL.spec.mjs` — picks the store by excluding the `-all` twin, reads the whole fleet from the twin (20) and the folded view from the store (6 named residents), and asserts the chip that exists (`.fm-roster-fold`, `+14 idle · show`; the old `.fm-fleet-fold` selector left with the fold row).

Evidence: L3 (the mechanism measured live over the Neural Link; a red-first unit arm; the witness's store half green under the Brain root) → L3 required (a Neural Link witness is the close target). Residual: AC-2's DOM half (12 cards for 6 rows on the pinned engine) and AC-3's red-free paragraph — both transferred to #98 in the ticket (2026-09-04). Residual-Owner: #98.

The residual, stated plainly: the witness's DOM half stays red on this pin. After the fold the store is right (twin 20, view 6, chip `+14 idle · show`), but the animated list renders **12 cards — each of the six twice** — because the Engine's projection hands the view raw rows of residents the list already holds as records, and the list reconciles by object identity. No consumer move heals that without reaching into the Engine's projection (I tried hydrating the twin: it manufactures the second instance family and is the duplicate's cause); the fix is neomjs/neo#18269 facet 2, and the witness turns green with the pin that carries it. Production is exposed the same way at twelve residents with idle rows (`data =` walks the same `add` path) — which is why the Engine ticket is the priority, not this PR.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — the instance question answered with the `findInstances` receipt | Live (session `7c43ac4e…`, then `314a866c…` on a fresh worker): `findInstances({className: 'AgentOS.store.FleetRoster'})` → `neo-state-provider-2__fleetRoster` (count 11) and `neo-state-provider-2__fleetRoster-all` (count 11, `isLoaded: false`). Same store as the grid binds; the twin is the projection. The spec now selects by suffix and asserts the twin's presence. |
| AC-2 — `FleetGridScaleNL` green headless and headed under the Brain root; red-first stated | **Partial — the DOM half is transferred to #98 (the engine pin carrying neomjs/neo#18269, merged via neo PR #18273); #78's AC-2 now reads "green in its store half", delivered here.** Red-first on the unrepaired head: `expect(snapshot.items.length).toBe(20)` received 0 (this morning's pin-5 battery, and the ticket's own text). At this head the witness passes its store half (twin 20 by poll, view `count` 6 with the six named residents, title `Fleet · 20 agents`, chip `+14 idle · show`) and fails its DOM half: `.fm-fleet-cards .fm-agent-card` expected 6, received 12 — the duplicate render of the Engine's raw/record duality, reproduced live in the pane. The unit arm `#78: a batch that crosses the threshold keeps every non-idle resident` is red against the synchronous toggle (`count` 0 right after `add`) and green here: 20 inside the mutation, 6 one microtask later, `allItems` 20, chip `+14 idle · show`. |
| AC-3 — the README's battery paragraph states this witness as a red with its cause and owner named (transferred: red-free is #98 AC-4) | Rewritten: `AddAgentJourneyNL` green with #74; `FleetGridScaleNL` stated red with the cause in one sentence and #98 as its owner — never masked; the FLIP-settle note stays. |

## Deltas from ticket

- The ticket's step 2 expected a store or provider defect; the defect is the engine's `allItems` projection (two facets), filed as neomjs/neo#18269 with the measured mechanism and a unit-witness AC. The consumer changes here are the discipline that survives either way: derive from `state`, decide after the mutation settles.
- Two existing unit arms that read the title/CTA synchronously after a `store.add` now await one microtask — the contract they assert did not change, its settling point did.

## Test Evidence

- `FleetGridScaleNL` under the Brain root: **1 failed** at the DOM count (expected 6, received 12) after every store assertion passed; the same run on the unrepaired head fails at the first store assertion (received 0).
- `test-e2e:nl` under the Brain root on this tree (34 witnesses, own server): **33 passed / 1 failed** (2.0m) — the one red is this witness's DOM half (the residual above); every other arm green, the presets arm (the #66 hold) included.
- Unit **752 passed** (751 + the new red-first arm).
- Live falsifiers over the Neural Link (session `314a866c…`, fresh App Worker on this tree): `add` of the twenty-row fixture answers twenty records (no `null`); the fold engages; `getCount` on the twin 31, the view 17 after the fold.
- `check-visual-baselines` green after the restamp (`apps/agentos` is a stamp input; no golden moved).

## Post-Merge Validation

- [ ] The next engine pin that carries neomjs/neo#18269 may drop the microtask in `onRosterStoreLoad`; the unit arm and the witness say whether it still needs it.

## Commits

- `29a560c` (pre-rebase `361815d` → `6345796` → `c569791`) — the deferred fold decision, `FleetAgent.tierRankFor`, the witness's corrected possession + assertions, the README truth, three unit arms (one new, red-first); restamp (`apps/agentos` is a stamp input).
- `800f23b` — restamp on the merged sources (PR #94's goldens, PR #96's stamp).
- `729a5ff` — the README's stated red names its owner, #98.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session e1f9d3cb-6f4f-423c-9e42-6f20d9cba9b3





