### PR TITLE
fix(agentos): the custody heal hands its promotion to the liveness owner, so a fresh boot goes live now instead of at the next cadence tick (#62)

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -127,15 +127,30 @@ export const onStart = () => {
         }
     }
 
+    // The in-flight heal is a published fact BEFORE the shell exists — `AgentOS.fleet.custodyHeal`,
+    // a promise resolving `true` exactly when the heal retained promotion authority — so the
+    // cockpit's liveness owner can chain its immediate re-drive onto it at construct time: the
+    // construct-time reads answer on the fail-closed bridge, custody is promoted a few hundred
+    // milliseconds later, and without this the cockpit sits on that cold verdict until the next
+    // cadence tick. The heal itself still starts only AFTER shell creation (no network wait gates
+    // Neo.app()), and keeps one SharedWorker-wide window in flight: a later joining window may
+    // start a fresh bounded window after exhaustion, replacing the slot; no permanent poller lives.
+    // A boot without a heal (shell transport, a bearer already in custody) publishes no slot.
+    let settleHeal = null;
+
+    if (browserHeal && browserFleetHealPromise === null) {
+        globalThis.AgentOS.fleet.custodyHeal = new Promise(resolve => { settleHeal = resolve })
+    }
+
     Neo.app({
         mainView: Viewport,
         name    : 'AgentOS'
     });
 
-    // Start only AFTER shell creation and keep one SharedWorker-wide window in flight. A later
-    // joining window may start a fresh bounded window after exhaustion; no permanent poller lives.
-    if (browserHeal && browserFleetHealPromise === null) {
+    if (settleHeal) {
         const current = browserFleetHealPromise = healBrowserFleetSession(browserHeal);
+
+        current.then(settleHeal);
 
         current.finally(() => {
             browserFleetHealPromise === current && (browserFleetHealPromise = null)

--- a/apps/agentos/view/fleet/cockpit/LivenessController.mjs
+++ b/apps/agentos/view/fleet/cockpit/LivenessController.mjs
@@ -664,7 +664,26 @@ class LivenessController extends ComponentController {
 
         // the daemon surface has no other first read; waiting a full cadence would leave a
         // boot-time fault invisible
-        me.loadBrainHealth()
+        me.loadBrainHealth();
+
+        me.followCustodyHeal()
+    }
+
+    /**
+     * @summary A boot-time custody heal promotes AFTER the construct-time reads answered on the
+     * fail-closed bridge — measured on a fresh boot against an armed server: promotion at 0.3s,
+     * the first wire read at the 15s cadence tick. The boot module publishes the in-flight heal as
+     * `AgentOS.fleet.custodyHeal`; its `true` resolution re-drives every seam now, the way the
+     * Reconnect click does. No slot, a heal that ends without promotion, or liveness stopped in
+     * the meantime: nothing happens.
+     * @protected
+     */
+    followCustodyHeal() {
+        const me = this;
+
+        globalThis.AgentOS?.fleet?.custodyHeal?.then(promoted => {
+            promoted && !me.isDestroyed && me.livenessTimerId !== null && me.reconnectFleet()
+        })
     }
 
     /**

--- a/apps/agentos/view/fleet/cockpit/LivenessController.mjs
+++ b/apps/agentos/view/fleet/cockpit/LivenessController.mjs
@@ -98,6 +98,13 @@ class LivenessController extends ComponentController {
      */
     livenessTimerId = null
     /**
+     * Counts liveness starts. A callback attached by an earlier start (the custody heal's) checks
+     * it before acting, so a stop/restart before the heal settles cannot deliver twice.
+     * @member {Number} livenessGeneration=0
+     * @protected
+     */
+    livenessGeneration = 0
+    /**
      * Whether any populated LIVE roster snapshot has been admitted — flips empty snapshots to
      * their ordinary authoritative meaning (a real fleet may genuinely drain).
      * @member {Boolean} rosterWired=false
@@ -649,6 +656,10 @@ class LivenessController extends ComponentController {
 
         if (me.livenessTimerId !== null) return;
 
+        // every start is a new generation: a callback attached by an earlier start — the custody
+        // heal's, pending across a stop/restart — must not act on behalf of this one
+        me.livenessGeneration++;
+
         me.livenessTimerId = setInterval(() => {
             const cap = cockpit.maxReadsInFlight;
 
@@ -675,14 +686,18 @@ class LivenessController extends ComponentController {
      * the first wire read at the 15s cadence tick. The boot module publishes the in-flight heal as
      * `AgentOS.fleet.custodyHeal`; its `true` resolution re-drives every seam now, the way the
      * Reconnect click does. No slot, a heal that ends without promotion, or liveness stopped in
-     * the meantime: nothing happens.
+     * the meantime: nothing happens. A promise callback cannot be detached, so the re-drive is
+     * fenced to the liveness generation that attached it: a stop/restart before the heal settles
+     * leaves the earlier callback inert, and the heal re-drives exactly once.
      * @protected
      */
     followCustodyHeal() {
-        const me = this;
+        const
+            me         = this,
+            generation = me.livenessGeneration;
 
         globalThis.AgentOS?.fleet?.custodyHeal?.then(promoted => {
-            promoted && !me.isDestroyed && me.livenessTimerId !== null && me.reconnectFleet()
+            promoted && !me.isDestroyed && me.livenessTimerId !== null && me.livenessGeneration === generation && me.reconnectFleet()
         })
     }
 

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -60,7 +60,7 @@ test.describe('AgentOS packaged Fleet window routing', () => {
     test('browser boot invokes Neo.app before its delayed handshake settles', async () => {
         const {onStart} = await import('../../../../../apps/agentos/app.mjs');
 
-        let releaseFetch;
+        let releaseFetch, slotAtApp;
 
         const
             originalAgentOS = globalThis.AgentOS,
@@ -72,7 +72,12 @@ test.describe('AgentOS packaged Fleet window routing', () => {
         try {
             globalThis.AgentOS = {};
             Neo.config.url     = {href: 'http://localhost:8080/apps/agentos/', search: ''};
-            Neo.app            = () => { order.push('app') };
+            Neo.app            = () => {
+                order.push('app');
+                // the in-flight heal is already a published fact when the shell constructs —
+                // the cockpit's liveness owner chains its immediate re-drive onto this slot
+                slotAtApp = globalThis.AgentOS.fleet?.custodyHeal
+            };
             globalThis.fetch   = async () => {
                 order.push('fetch');
                 await new Promise(resolve => { releaseFetch = resolve });
@@ -82,6 +87,7 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             onStart();
 
             expect(order[0]).toBe('app');
+            expect(slotAtApp).toBeInstanceOf(Promise);
             await expect.poll(() => order.includes('fetch')).toBe(true);
             expect(order).toEqual(['app', 'fetch']);
 
@@ -90,7 +96,10 @@ test.describe('AgentOS packaged Fleet window routing', () => {
             releaseFetch();
             await Promise.resolve();
             await Promise.resolve();
-            await Promise.resolve()
+            await Promise.resolve();
+
+            // the cancelled heal settles its published slot with `false` — no re-drive follows
+            await expect(slotAtApp).resolves.toBe(false)
         } finally {
             globalThis.AgentOS = originalAgentOS;
             globalThis.fetch   = originalFetch;

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/custodyHeal.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/custodyHeal.spec.mjs
@@ -1,0 +1,114 @@
+import {setup} from '../../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'AgentOSFleetCockpitCustodyHealTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core      from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import FleetActivityEvents  from '../../../../../../../../apps/agentos/store/FleetActivityEvents.mjs';
+import FleetCockpit         from '../../../../../../../../apps/agentos/view/fleet/cockpit/Container.mjs';
+import FleetRoster          from '../../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import CockpitStateProvider from '../../../../../../../../apps/agentos/view/fleet/cockpit/StateProvider.mjs';
+import ViewerWakeFeed       from '../../../../../../../../apps/agentos/store/ViewerWakeFeed.mjs';
+
+/**
+ * The liveness owner follows the boot-time custody heal. A fresh boot against an armed fleet server
+ * runs its construct-time reads on the fail-closed bridge, gets custody promoted a few hundred
+ * milliseconds later, and — before this — sat on that cold verdict until the next cadence tick
+ * (measured: promotion at 0.3s, the first wire read at 15s). The boot module publishes the in-flight
+ * heal as `AgentOS.fleet.custodyHeal`; `startLiveness` chains exactly one Reconnect-equivalent
+ * re-drive onto a `true` resolution, and nothing onto anything else.
+ */
+test.describe.serial('AgentOS.view.fleet.cockpit.LivenessController — following the custody heal', () => {
+    let cockpit, prevFleet, settleHeal;
+
+    const createCockpit = () => {
+        cockpit = Neo.create(FleetCockpit, {
+            // hermetic: the REAL cockpit provider class, with the store block overridden so no
+            // sample-seed fetch runs in the unit env
+            stateProvider: {
+                module: CockpitStateProvider,
+                stores: {
+                    fleetActivityEvents: {module: FleetActivityEvents},
+                    fleetRoster        : {module: FleetRoster, autoLoad: false},
+                    viewerWakeFeed     : {module: ViewerWakeFeed}
+                }
+            }
+        });
+
+        // the heal settles AFTER construction — the spy lands before anything can resolve
+        const controller = cockpit.getController();
+
+        controller.reconnectFleetCalls = 0;
+        controller.reconnectFleet      = () => { controller.reconnectFleetCalls++ };
+
+        return controller
+    };
+
+    test.beforeEach(() => {
+        prevFleet = globalThis.AgentOS?.fleet;
+        // the boot module's shape: the slot exists before the shell constructs
+        globalThis.AgentOS.fleet = {custodyHeal: new Promise(resolve => { settleHeal = resolve })}
+    });
+
+    test.afterEach(() => {
+        cockpit?.destroy();
+        cockpit = null;
+        // stub only the `fleet` key and restore it — never delete the AgentOS namespace
+        prevFleet === undefined ? delete globalThis.AgentOS?.fleet : globalThis.AgentOS.fleet = prevFleet
+    });
+
+    test('a heal that promotes re-drives every seam once — now, not at the next cadence tick', async () => {
+        const controller = createCockpit();
+
+        expect(controller.reconnectFleetCalls).toBe(0);
+
+        settleHeal(true);
+
+        await expect.poll(() => controller.reconnectFleetCalls).toBe(1);
+
+        // the promise is settled: nothing fires again, and the cadence timer is untouched
+        await Promise.resolve();
+        expect(controller.reconnectFleetCalls).toBe(1);
+        expect(controller.livenessTimerId).not.toBeNull()
+    });
+
+    test('a heal that ends without promotion changes nothing', async () => {
+        const controller = createCockpit();
+
+        settleHeal(false);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(controller.reconnectFleetCalls).toBe(0)
+    });
+
+    test('a promotion after liveness stopped re-drives nothing — no read on behalf of a gone surface', async () => {
+        const controller = createCockpit();
+
+        controller.stopLiveness();
+        settleHeal(true);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(controller.reconnectFleetCalls).toBe(0)
+    });
+
+    test('a boot without a published heal is the boot we had — the owner reads its slot as "no heal"', async () => {
+        delete globalThis.AgentOS.fleet.custodyHeal;
+
+        const controller = createCockpit();
+
+        await Promise.resolve();
+
+        expect(controller.reconnectFleetCalls).toBe(0);
+        expect(controller.livenessTimerId).not.toBeNull()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/custodyHeal.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/custodyHeal.spec.mjs
@@ -110,5 +110,32 @@ test.describe.serial('AgentOS.view.fleet.cockpit.LivenessController — followin
 
         expect(controller.reconnectFleetCalls).toBe(0);
         expect(controller.livenessTimerId).not.toBeNull()
+    });
+
+    // A promise callback cannot be detached: the liveness owner supports stop → start, and a restart
+    // before the heal settles would otherwise leave two callbacks that both see a running timer.
+    test('a stop/restart before the heal settles re-drives exactly once — the callback is fenced to the liveness generation that attached it', async () => {
+        const controller = createCockpit();
+
+        controller.stopLiveness();
+        controller.startLiveness();
+
+        settleHeal(true);
+
+        await expect.poll(() => controller.reconnectFleetCalls).toBe(1);
+        await Promise.resolve();
+        expect(controller.reconnectFleetCalls).toBe(1)
+    });
+
+    test('a second start while liveness runs attaches nothing — the heal still re-drives once', async () => {
+        const controller = createCockpit();
+
+        controller.startLiveness();
+
+        settleHeal(true);
+
+        await expect.poll(() => controller.reconnectFleetCalls).toBe(1);
+        await Promise.resolve();
+        expect(controller.reconnectFleetCalls).toBe(1)
     })
 });

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "14e26efb3492c66b75be3e9cc23ef03b86730dd2b97536553e2634b45c18fc29",
     "inputs": {
-        "apps/agentos": "d066bda4b3761624f28fc89db4634d8074a920886892b91beebcb0086adc200d",
+        "apps/agentos": "b76377c700c529c4dcbe05b0ed75dfac10a86755132eeccf43685ad3b9a7fff5",
         "resources/scss": "ba0ce5dd3464afb60fe99b200e67f05bde2cb5df18c76cf25e255d4c86940991",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4745760abc6192d424b6a26853db152daabb4251918c4101ca2e6e4794d6dccd",


### PR DESCRIPTION
Resolves #62

Related: #10 (parent) · the launch contract (`neo-agent-brain/ai/services/fleet/devFleetServer.mjs`, `fleetLaunchContract.mjs`) · `apps/agentos/fleet/fleetSessionCustody.mjs` (the custody machine this hands off from)

The boot heal was never broken — it was unheard. Measured today on the wire (a logging reverse proxy in front of the armed dev fleet server, a fresh headless-Chromium boot, no click): `GET /fleet/handshake` 200 at t≈0.25s, `POST resolveViewerIdentity` 200 at t≈0.26s — custody verified, promoted, published — and then nothing until t=15.0s, the first liveness cadence tick, where `fleetRoster` / `fleetActivity` / `fleetTasks` answer 200 and the cockpit leaves "fleet offline" at t≈17s. The construct-time reads had answered on the fail-closed bridge a few hundred milliseconds before the promotion, and nothing re-drove them. The 2026-08-30 "14s settle stays cold" stopped one second short of the tick. Two files, one new slot, no new abstraction:

- **`apps/agentos/app.mjs`** — `onStart` publishes the in-flight browser heal as `AgentOS.fleet.custodyHeal` BEFORE `Neo.app()`: a deferred, so the shell constructs with the fact already in place while the redeem fetch still starts only after shell creation (the pinned `app → fetch` order holds). The heal's verdict settles the slot (`true` exactly when it retained promotion authority; `false` on exhaustion or lost authority; it never rejects). A boot without a heal — shell transport, or a bearer already in custody — publishes no slot.
- **`apps/agentos/view/fleet/cockpit/LivenessController.mjs`** — `startLiveness` chains `followCustodyHeal()`: one `reconnectFleet()` when the slot resolves `true` while liveness is running — the same re-drive the Reconnect click performs, fired by the promotion instead of the click. No slot, `false`, or liveness stopped in the meantime: nothing happens.

Witness: `test/playwright/unit/apps/agentos/view/fleet/cockpit/custodyHeal.spec.mjs` (new, six arms, the residentBoot harness): a heal that promotes re-drives once and leaves the cadence timer alone; a heal that ends without promotion re-drives nothing; a promotion after `stopLiveness()` re-drives nothing; a boot without a slot is the boot we had; a stop/restart before the heal settles re-drives exactly once (the review's control: 2 without the fence); a second start while liveness runs attaches nothing. `app.spec.mjs`'s order arm is extended, not duplicated: the slot is a `Promise` when the shell constructs, the fetch still follows `Neo.app`, and the cancelled heal settles the slot with `false`. **Red-first: with `app.mjs` and `LivenessController.mjs` stashed, the same two specs run **2 failed / 16 passed** — the promotion arm (`reconnectFleetCalls` stays 0) and the order arm's `slotAtApp` (`undefined`), the three later `custodyHeal` arms skipped by their serial describe after the first red; restored: 21 passed.**

Evidence: L3 (the fixed boot measured on the wire, headless Chromium: promotion → first `fleetRoster` read in 86ms, the cockpit on the real roster at t≈3s; before: 15.0s and t≈17s) → L3 required (AC-1 is a first-run wire behavior). Residual: none in this lane. Two sightings stated on the ticket, out of scope: the dev fleet server answers `GET /fleet/events` 404 WITH a bearer (401 without), so the wake stream never arms; and the in-app Browser pane blocks the App worker's cross-port POSTs — a harness artifact.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — a fresh page load against a running, armed fleet server reaches the live spine with ZERO clicks, within ~1s of promotion, before the first cadence tick | Wire transcript on this head (12:40:30): `resolveViewerIdentity` 200 at `.344`, `fleetHistory` / `fleetTasks` / `fleetActivity` / `fleetRoster` 200 at `.430`–`.432` — **86ms** after promotion; page probe at t≈3s: 9 cards (the real registry), banner `fm-spine-banner-degraded` (the dev checkout's missing `resources/content`, the pr-lane scan — an environment residual; the same server answers `degraded` on `dev` at t≈17s). On `dev` (same server, same script): first `fleetRoster` at t=15.0s, cold until then. |
| AC-2 — a boot against a DOWN server keeps the fail-closed sample state and the Reconnect affordance; an exhausted heal re-drives nothing | The heal's own contract is unchanged (`healBrowserFleetSession` returns `false` on exhaustion; the slot resolves `false`); `custodyHeal.spec.mjs` arm 2 (no re-drive on `false`) and `app.spec.mjs` (the cancelled heal settles `false`). The cold path's rendering is untouched — no file in the banner/roster family changed. |
| AC-3 — unit witnesses: (a) exactly one re-drive on `true`, none on `false`, none after `stopLiveness()`; (b) `onStart` publishes the slot before `Neo.app()` while the fetch still starts after it | `custodyHeal.spec.mjs` arms 1–4; `app.spec.mjs` "browser boot invokes Neo.app before its delayed handshake settles" extended with `slotAtApp` (a `Promise` captured inside the fake `Neo.app`) and `await expect(slotAtApp).resolves.toBe(false)`. |

## Deltas from ticket

- The ticket's original diagnosis ("the heal's redeem/establish/promotion chain or its ordering against the liveness owner's first reads") narrowed to the last clause: the chain works; the hand-off did not exist. The ticket body carries the measured transcript and a Contract Ledger for the new slot (written before this branch).
- The witness is a new focused spec rather than more arms in `container.spec.mjs` (3095 lines — the file is already past the 1k line the operator holds source files to; tests deserve the same shape).
- From the review (Round 1): a promise callback cannot be detached, and the liveness owner supports stop → start — a restart before the heal settled left two callbacks that both saw a running timer and re-drove twice. `startLiveness` now counts a `livenessGeneration`; `followCustodyHeal` captures it at attach time and acts only while that generation is the active one. The "exactly once" in the summaries is true across the lifecycle now, not only on the straight path.
- Rebased onto `dev` after PR #94 merged (`ad0de0d`): `e7a10f7` is the original commit (pre-rebase `b5cf676`, identical content; the stamp regenerated on the merged goldens), `d6c0891` the generation fence.

## Test Evidence

- `custodyHeal.spec.mjs` + `app.spec.mjs`: **21 passed** (1.2s) on this head; red-first: with `app.mjs` and `LivenessController.mjs` stashed, the same two specs run **2 failed / 16 passed** — the promotion arm (`reconnectFleetCalls` stays 0) and the order arm's `slotAtApp` (`undefined`), the three later `custodyHeal` arms skipped by their serial describe after the first red; restored: 21 passed.
- Full `npm run test-unit`: **757 passed, 0 failed** (5.4s) at `d6c0891` (751 on `dev` + the six new arms); 755 at `b5cf676`.
- Red-first for the fence: with the controller stashed, the stop/restart arm receives **2** re-drives (expected 1); fenced: 6 passed.
- Wire: `boot62.mjs` against `proxy62.mjs` → the dev fleet server on a second port (`NEO_FLEET_PORT=8093`, cockpit at `?fleetUrl=http://127.0.0.1:8094/fleet`), fresh headless Chromium — `dev`: promotion at 0.26s, first read at 15.0s; this head: promotion at 0.34s, first read at 0.43s.
- `check-visual-baselines`: *input identity matches the golden stamp* after `git add` → stamp → commit (`apps/agentos` is a stamp input; no golden changed), re-run as its own command before the push.

## Post-Merge Validation

- [ ] The operator's own first-run: fleet server up and armed, a fresh cockpit tab, no click — live within a second.

## Commits

- `b5cf676` — the `custodyHeal` slot published before `Neo.app()` and settled by the heal; `followCustodyHeal` chained in `startLiveness`; the four-arm cockpit witness; the extended order arm; restamp (`apps/agentos` is a stamp input, no golden changed).

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session e1f9d3cb-6f4f-423c-9e42-6f20d9cba9b3
