### PR TITLE
fix(agentos): roster cards and list items key by record, so a re-sort moves the focused node instead of replacing it (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,18 @@ NEO_AGENTOS_RUNTIME_ROOT=/absolute/path/to/neo-agent-brain npm run test-e2e:nl
 
 The script reaches every Neural Link witness under `test/playwright/e2e/agentos/` — a suffix
 match, not a prefix, so a new witness joins the battery by its name, and a red one announces
-itself instead of falling outside the glob. Add `-- --headed` for the honest receipt. Two reds are
-stated, not masked, and each has an owner. `FleetGridKeyboardA11y`'s reorder step: the roster seats
-its cards by position and renumbers them on a real reorder, so the focused node is replaced the
-moment a joiner sorts ahead — hidden until #98, whose Engine finally sorts a joiner by its tier
-(#99; its implementation, PR #101, rebases onto this Engine after the pin lands). `FleetCockpitDockNL`'s
-Review-preset arm: the FLIP-settle hold, #103 — the projection stages the detail pane and un-hides
-it on the settle, which does not always land within the wait (red 3/3 at pin 6, headless and headed;
-1/3 one Engine commit earlier; the rail-drawer witness's Escape dismissal rides the same settle;
-#66 closed without an owner for it). A red there is the race, not the battery: re-run before triage. `FleetGridScaleNL` went green with #98 — the Engine
-writes its unfiltered projection inside the mutation (neomjs/neo#18269), so the roster's fold
-decides on the whole batch and the cards it renders are the records it holds; `AddAgentJourneyNL`
-went green with #74.
+itself instead of falling outside the glob. Add `-- --headed` for the honest receipt. One red is
+stated, not masked, and it has an owner: `FleetCockpitDockNL`'s Review-preset arm, the FLIP-settle
+hold (#103) — the projection stages the detail pane and un-hides it on the settle, which does not
+always land within the wait (red 3/3 while pinning the current Engine, headless and headed; 34/34
+green one run later on the same Engine; the rail-drawer witness's Escape dismissal rides the same
+settle). A red there is the race, not the battery: re-run before triage. `FleetGridKeyboardA11y`'s
+reorder step went green with #99 — cards and list items key by record, so a joiner sorting ahead
+moves the focused node instead of replacing it (the Engine of #98 sorts a joiner by its tier, which
+is what exposed the positional ids). `FleetGridScaleNL` went green with #98 — the Engine writes its
+unfiltered projection inside the mutation (neomjs/neo#18269), so the roster's fold decides on the
+whole batch and the cards it renders are the records it holds; `AddAgentJourneyNL` went green with
+#74.
 
 Live maintainer seats also require their own local GitHub token, remote MCP bearer, and agent
 identity configuration. For Neo's team these include `GH_TOKEN`, `NEO_MCP_REMOTE_TOKEN`, and

--- a/apps/agentos/view/fleet/roster/List.mjs
+++ b/apps/agentos/view/fleet/roster/List.mjs
@@ -149,32 +149,81 @@ class List extends ComponentList {
     }
 
     /**
-     * @summary The card id keys by record, never by position: `<list>__<record key>__component`.
+     * @summary A record key as a DOM-id fragment, reversibly: every code unit outside `[A-Za-z0-9-]`
+     * — the underscore included, so the encoding never produces its own escape — becomes
+     * `_` + four hex digits. Agent ids are whatever the Brain accepted (`a__component`, a space, a
+     * non-Latin name), and a DOM id built from them must neither collide with the list's own
+     * `__item-` / `__card-` namespaces nor lose the key on the way back.
+     * @param {String|Number} key
+     * @returns {String}
+     */
+    static encodeKey(key) {
+        return String(key).replace(/[^A-Za-z0-9-]/g, char => `_${char.charCodeAt(0).toString(16).padStart(4, '0')}`)
+    }
+
+    /**
+     * @summary The exact inverse of {@link #encodeKey}.
+     * @param {String} encoded
+     * @returns {String}
+     */
+    static decodeKey(encoded) {
+        return encoded.replace(/_([0-9a-f]{4})/g, (match, hex) => String.fromCharCode(parseInt(hex, 16)))
+    }
+
+    /**
+     * @summary The card id keys by record, never by position: `<list>__card-<encoded key>` — its own
+     * namespace beside the list item's `__item-`, so no two agent ids can meet on one DOM id.
      * @param {Object} record
      * @returns {String}
      */
     getCardId(record) {
-        return `${this.id}__${this.getRecordId(record)}__component`
+        return `${this.id}__card-${List.encodeKey(this.getRecordId(record))}`
     }
 
     /**
-     * @summary The list item's id keys by record id — the `Neo.list.Base` shape, not the component
+     * @summary The list item's id keys by record id — `<list>__item-<encoded key>`, not the component
      * list's store index — so the `li` around a card keeps its node across a sort. A record resolves
      * to its key first, the way the base list reads it; the selection model hands either form.
      * @param {Object|String|Number} recordOrId
      * @returns {String}
      */
     getItemId(recordOrId) {
-        return `${this.id}__${recordOrId?.isRecord ? this.getRecordId(recordOrId) : recordOrId}`
+        return `${this.id}__item-${List.encodeKey(recordOrId?.isRecord ? this.getRecordId(recordOrId) : recordOrId)}`
     }
 
     /**
-     * @summary The inverse of {@link #getItemId}: the record id is the suffix after the list id.
+     * @summary The inverse of {@link #getItemId}: the record key decoded from the item namespace.
      * @param {String} vnodeId
      * @returns {String}
      */
     getItemRecordId(vnodeId) {
-        return vnodeId.slice(this.id.length + 2)
+        return List.decodeKey(vnodeId.slice(this.id.length + '__item-'.length))
+    }
+
+    /**
+     * @summary A rebuild, then the pool's retirement pass: a card whose record has left the whole
+     * fleet — not merely the filtered view — is destroyed and dropped, so the pool and the instance
+     * registry stay bounded by the fleet's current cardinality across any number of join/leave
+     * cycles. A filtered-out record is still in the store's unfiltered projection, and its card
+     * keeps its seat behind the rendered ones for the day the filter lifts.
+     * @param {Boolean} silent=false
+     */
+    createItems(silent=false) {
+        let me = this;
+
+        super.createItems(silent);
+
+        if (me.items) {
+            const whole = me.store.allItems ?? me.store;
+
+            me.items = me.items.filter(card => {
+                const alive = card.record && whole.get(me.getRecordId(card.record));
+
+                !alive && card.destroy();
+
+                return alive
+            })
+        }
     }
 
     /**
@@ -190,10 +239,12 @@ class List extends ComponentList {
         let me = this;
 
         if (me.items) {
+            // by key from the pool itself, never by position in `previousItems`: a store with an
+            // unfiltered projection hands the event a previous list that is already sorted
             const
-                pool         = me.items,
-                previousKeys = data.previousItems.map(record => me.getRecordId(record)),
-                sorted       = data.items.map(record => pool[previousKeys.indexOf(me.getRecordId(record))]).filter(Boolean);
+                pool   = me.items,
+                cardOf = record => pool.find(card => card.record && me.getRecordId(card.record) === me.getRecordId(record)),
+                sorted = data.items.map(cardOf).filter(Boolean);
 
             me.items       = sorted.concat(pool.filter(card => !sorted.includes(card)));
             me.updateDepth = -1

--- a/apps/agentos/view/fleet/roster/List.mjs
+++ b/apps/agentos/view/fleet/roster/List.mjs
@@ -96,13 +96,14 @@ class List extends ComponentList {
     navigator = {previousKey: 'ArrowLeft', nextKey: 'ArrowRight'}
 
     /**
-     * @summary One pooled AgentCard per RECORD, for the record's lifetime: the card seated on this
-     * record if there is one, else a new one whose id derives from the record key. A card is never
-     * re-keyed onto another record — re-keying a live component breaks its reference tree — so a
-     * rebuild that moved the record re-seats the same instance under the same id, and the DOM node
-     * with the focus inside it survives. A record that left the store leaves its card behind the
-     * rendered seats. The pool is kept in store order by swapping, because the plugin's geometry and
-     * every reader of `items` take position `index` as the card of record `index`. The
+     * @summary One pooled AgentCard per RECORD, for the record's time in the fleet: the card seated
+     * on this record if there is one, else a new one whose id derives from the record key. A card is
+     * never re-keyed onto another record — re-keying a live component breaks its reference tree —
+     * so a rebuild that moved the record re-seats the same instance under the same id, and the DOM
+     * node with the focus inside it survives. A record that left the fleet takes its card with it
+     * ({@link #onStoreMutate}); a record the view merely filters out keeps its card behind the
+     * rendered seats. The pool is kept in store order by swapping, because the plugin's geometry
+     * and every reader of `items` take position `index` as the card of record `index`. The
      * `lifecycleIntent` listener stays a string: it resolves up the controller chain at fire time
      * (card → roster controller → cockpit controller), exactly like the shipped card config did.
      * @param {Object} record
@@ -201,27 +202,52 @@ class List extends ComponentList {
     }
 
     /**
-     * @summary A rebuild, then the pool's retirement pass: a card whose record has left the whole
-     * fleet — not merely the filtered view — is destroyed and dropped, so the pool and the instance
-     * registry stay bounded by the fleet's current cardinality across any number of join/leave
-     * cycles. A filtered-out record is still in the store's unfiltered projection, and its card
-     * keeps its seat behind the rendered ones for the day the filter lifts.
-     * @param {Boolean} silent=false
+     * @summary Besides the base list's store listeners, the roster follows the store's `mutate`: the
+     * event names the records that left, and that — not a projection read inside `load` — is the
+     * authority for retiring their cards. On an engine where the unfiltered projection is mirrored
+     * by a listener registered after the store's own `load`, a `load`-time read of that projection
+     * cannot see the batch it was just handed (a joiner's fresh card would be destroyed against
+     * stale authority); the mutation payload carries the truth on every engine.
+     * @param {Neo.data.Store|null} value
+     * @param {Neo.data.Store|null} oldValue
+     * @protected
      */
-    createItems(silent=false) {
+    afterSetStore(value, oldValue) {
         let me = this;
 
-        super.createItems(silent);
+        super.afterSetStore(value, oldValue);
 
-        if (me.items) {
-            const whole = me.store.allItems ?? me.store;
+        oldValue?.un({mutate: me.onStoreMutate, scope: me});
+        value?.on({mutate: me.onStoreMutate, scope: me})
+    }
+
+    /**
+     * @summary The pool's retirement pass, on the mutation that removed the records: a card whose
+     * record left the fleet — not merely the filtered view, which fires `filter`, never `mutate` —
+     * is destroyed and dropped, so the pool and the instance registry stay bounded by the fleet's
+     * current cardinality across any number of join/leave cycles. A record re-added inside the
+     * same mutation keeps its card. Runs after the store's own `mutate` listener (registered at the
+     * store's construction), so a rebuild driven by `load` has already seated the survivors.
+     * @param {Object}   data
+     * @param {Object[]} [data.addedItems]
+     * @param {Object[]} [data.removedItems]
+     * @protected
+     */
+    onStoreMutate(data) {
+        let me = this;
+
+        if (me.items && data.removedItems?.length) {
+            const
+                removed = new Set(data.removedItems.map(record => me.getRecordId(record))),
+                readded = new Set((data.addedItems ?? []).map(record => me.getRecordId(record)));
 
             me.items = me.items.filter(card => {
-                const alive = card.record && whole.get(me.getRecordId(card.record));
+                const key    = card.record && me.getRecordId(card.record),
+                      retire = key !== null && key !== undefined && removed.has(key) && !readded.has(key);
 
-                !alive && card.destroy();
+                retire && card.destroy();
 
-                return alive
+                return !retire
             })
         }
     }

--- a/apps/agentos/view/fleet/roster/List.mjs
+++ b/apps/agentos/view/fleet/roster/List.mjs
@@ -5,10 +5,13 @@ import SelectionModel from './SelectionModel.mjs';
 /**
  * The fleet roster as a real animated list — the store-driven replacement for the destroy/recreate
  * card rebuild: one {@link AgentOS.view.fleet.roster.card.Container AgentCard} INSTANCE per rendered
- * row, pooled by index and re-seated onto its record (the calendar component-list pattern), with
- * {@link Neo.list.plugin.Animate} owning the geometry — a sort MOVES the surviving instances
- * (translate transition), a filter fades rows out and in, and the fluid column count derives from
- * the list's own measured width (`minItemWidth`), never the viewport.
+ * row, pooled by RECORD — a card's id and its `li`'s id derive from the record key, never from the
+ * position, so the same DOM nodes survive a sort and the focus inside them survives with it. (The
+ * base component list seats by index and renumbers on every rebuild — the calendar pattern — which
+ * replaces the focused node the moment a joiner sorts ahead.) {@link Neo.list.plugin.Animate} owns
+ * the geometry — a sort MOVES the surviving instances (translate transition), a filter fades rows
+ * out and in, and the fluid column count derives from the list's own measured width
+ * (`minItemWidth`), never the viewport.
  *
  * The card anatomy, its controller and the `lifecycleIntent` seam are untouched: this list only
  * changes WHO renders the rows. Selection is a first-class contract here
@@ -72,7 +75,15 @@ class List extends ComponentList {
          * @member {Neo.selection.ListModel} selectionModel=SelectionModel
          * @reactive
          */
-        selectionModel: SelectionModel
+        selectionModel: SelectionModel,
+        /**
+         * Items and cards key by the record's store key (`agentId`), the one id form every reader of
+         * this list already speaks — the selection model, the animate plugin, the cockpit's
+         * `getItemId(agentId)` calls. The base list's internal record ids would be a second form
+         * for the same row, and record-keyed DOM ids need exactly one.
+         * @member {Boolean} useInternalId=false
+         */
+        useInternalId: false
     }
 
     /**
@@ -85,45 +96,108 @@ class List extends ComponentList {
     navigator = {previousKey: 'ArrowLeft', nextKey: 'ArrowRight'}
 
     /**
-     * @summary One pooled AgentCard per rendered row (create on first use, re-seat via `record` on
-     * reuse) — instance identity is what survives a sort, so the plugin can MOVE the same rendered
-     * card instead of flashing a rebuilt one. The `lifecycleIntent` listener stays a string: it
-     * resolves up the controller chain at fire time (card → roster controller → cockpit
-     * controller), exactly like the shipped card config did.
+     * @summary One pooled AgentCard per RECORD, for the record's lifetime: the card seated on this
+     * record if there is one, else a new one whose id derives from the record key. A card is never
+     * re-keyed onto another record — re-keying a live component breaks its reference tree — so a
+     * rebuild that moved the record re-seats the same instance under the same id, and the DOM node
+     * with the focus inside it survives. A record that left the store leaves its card behind the
+     * rendered seats. The pool is kept in store order by swapping, because the plugin's geometry and
+     * every reader of `items` take position `index` as the card of record `index`. The
+     * `lifecycleIntent` listener stays a string: it resolves up the controller chain at fire time
+     * (card → roster controller → cockpit controller), exactly like the shipped card config did.
      * @param {Object} record
      * @param {Number} index
      * @returns {Object[]} The list item vdom children.
      */
     createItemContent(record, index) {
-        let me     = this,
-            items  = me.items || [],
-            card   = items[index],
-            config = {
-                id: me.getComponentId(index),
-                record
-            };
+        let me   = this,
+            pool = me.items || [],
+            key  = me.getRecordId(record),
+            card = pool.find(item => item.record && me.getRecordId(item.record) === key),
+            seat;
 
         if (card) {
-            card.setSilent(config);
+            card.setSilent({record});
             // explicit: a record MUTATION re-enters here with the SAME record instance, which the
             // config equality gate would silently drop — applyRecord() is idempotent and renders
             // both the reseat and the mutation (the old grid called it per recordChange too)
             card.applyRecord()
         } else {
-            items[index] = card = Neo.create({
+            card = Neo.create({
                 appName  : me.appName,
+                id       : me.getCardId(record),
                 module   : AgentCard,
                 listeners: {lifecycleIntent: 'onAgentLifecycleIntent'},
                 parentId : me.id,
-                windowId : me.windowId,
-                ...config
-            })
+                record,
+                windowId : me.windowId
+            });
+
+            pool.push(card)
         }
 
-        me.items       = items;
+        seat = pool.indexOf(card);
+
+        if (seat !== index && index < pool.length) {
+            [pool[index], pool[seat]] = [pool[seat], pool[index]]
+        }
+
+        me.items       = pool;
         me.updateDepth = -1;
 
         return [card.createVdomReference()]
+    }
+
+    /**
+     * @summary The card id keys by record, never by position: `<list>__<record key>__component`.
+     * @param {Object} record
+     * @returns {String}
+     */
+    getCardId(record) {
+        return `${this.id}__${this.getRecordId(record)}__component`
+    }
+
+    /**
+     * @summary The list item's id keys by record id — the `Neo.list.Base` shape, not the component
+     * list's store index — so the `li` around a card keeps its node across a sort. A record resolves
+     * to its key first, the way the base list reads it; the selection model hands either form.
+     * @param {Object|String|Number} recordOrId
+     * @returns {String}
+     */
+    getItemId(recordOrId) {
+        return `${this.id}__${recordOrId?.isRecord ? this.getRecordId(recordOrId) : recordOrId}`
+    }
+
+    /**
+     * @summary The inverse of {@link #getItemId}: the record id is the suffix after the list id.
+     * @param {String} vnodeId
+     * @returns {String}
+     */
+    getItemRecordId(vnodeId) {
+        return vnodeId.slice(this.id.length + 2)
+    }
+
+    /**
+     * @summary Reorders the pool to follow the sorted records — WITHOUT nulling the ids the way the
+     * component list does. Record-keyed ids cannot collide, and nulling them is exactly what turned
+     * the plugin's move into a node replacement on the rebuild that follows the transition. Cards
+     * whose records are not in the sorted set (filtered out, not yet reused) keep their seats behind.
+     * @param {Object}   data
+     * @param {Object[]} data.items         The sorted records
+     * @param {Object[]} data.previousItems The records in their previous order
+     */
+    sortItems(data) {
+        let me = this;
+
+        if (me.items) {
+            const
+                pool         = me.items,
+                previousKeys = data.previousItems.map(record => me.getRecordId(record)),
+                sorted       = data.items.map(record => pool[previousKeys.indexOf(me.getRecordId(record))]).filter(Boolean);
+
+            me.items       = sorted.concat(pool.filter(card => !sorted.includes(card)));
+            me.updateDepth = -1
+        }
     }
 }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
@@ -1,0 +1,176 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'FleetRosterCardIdentityTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../node_modules/neo.mjs/src/Neo.mjs';
+import * as core      from '../../../../../../../../node_modules/neo.mjs/src/core/_export.mjs';
+import Instance       from '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs';
+
+// The setup() mock set carries no Stylesheet addon — the roster list's animate plugin writes its
+// per-owner rules through it at construct/destroy. Stubbed here (the roster container spec's own
+// pattern), restored in afterAll so nothing leaks past this file.
+let priorInsertCssRules, priorDeleteCssRules;
+
+test.beforeAll(() => {
+    Neo.ns('Neo.main.addon.Stylesheet', true);
+    priorInsertCssRules = Neo.main.addon.Stylesheet.insertCssRules;
+    priorDeleteCssRules = Neo.main.addon.Stylesheet.deleteCssRules;
+    Neo.main.addon.Stylesheet.insertCssRules = () => {};
+    Neo.main.addon.Stylesheet.deleteCssRules = () => {}
+});
+
+test.afterAll(() => {
+    Neo.main.addon.Stylesheet.insertCssRules = priorInsertCssRules;
+    Neo.main.addon.Stylesheet.deleteCssRules = priorDeleteCssRules
+});
+
+/**
+ * @summary A roster card and its list item belong to a RECORD, not to a position. The base component
+ * list seats cards by index and renumbers their ids on every rebuild; on the roster that replaced the
+ * DOM node of a card the moment a joiner sorted ahead of it — and the keyboard focus inside the node
+ * died with it. Measured on engine dev@205bc52f8a, where a joiner finally sorts by the record's
+ * `tierRank` instead of landing last as a raw row. These arms pin the record-keyed identity in the
+ * unit tier, where a rebuild is `createItems()` after a store mutation.
+ */
+test.describe('Fleet roster — cards and list items keep their identity across a re-sort', () => {
+    let FleetAgent, FleetGrid, Store;
+
+    const stores = [];
+
+    // displayNames alphabet-walk in arrival order, agentIds count down — the two sort axes disagree
+    const roster = states => states.map((state, i) => ({
+        agentId       : `agent-${String(states.length - i).padStart(2, '0')}`,
+        displayName   : `Agent ${String.fromCharCode(65 + i)}`,
+        githubUsername: `neo-agent-${String(states.length - i).padStart(2, '0')}`,
+        state
+    }));
+
+    const makeStore = rows => {
+        const store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: rows});
+
+        stores.push(store);
+
+        return store
+    };
+
+    // the animate plugin loads via a dynamic import — await it, hand it a measured rect, build the pool
+    const readyList = async grid => {
+        const list = grid.getReference('roster-list');
+
+        let plugin = null;
+
+        for (let i = 0; i < 100 && !(plugin = list.getPlugin('list-animate')); i++) {
+            await new Promise(resolve => setTimeout(resolve, 10))
+        }
+
+        expect(plugin, 'list.plugin.Animate materialized').toBeTruthy();
+        plugin.applyGeometry({width: 935, height: 600});
+        list.createItems(true);
+
+        return list
+    };
+
+    // the pooled cards in RENDER order — position i is the card of record i
+    const cards  = list => (list.items ?? []).slice(0, list.store.getCount());
+    const liIds  = list => list.getVdomRoot().cn.map(node => node.id);
+    const joiner = {agentId: 'agent-00', displayName: 'AAA', githubUsername: 'neo-agent-00', state: 'ok'};
+
+    test.beforeAll(async () => {
+        FleetGrid  = (await import('../../../../../../../../apps/agentos/view/fleet/roster/Container.mjs')).default;
+        FleetAgent = (await import('../../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
+        Store      = (await import('../../../../../../../../node_modules/neo.mjs/src/data/Store.mjs')).default
+    });
+
+    test.afterAll(() => {
+        stores.forEach(store => store.destroy());
+        stores.length = 0
+    });
+
+    test('a joiner that sorts ahead moves the existing cards — same instance, same card id, same li id', async () => {
+        const store = makeStore(roster(['ok', 'ok', 'ok'])),
+              grid  = Neo.create(FleetGrid, {appName, store}),
+              list  = await readyList(grid);
+
+        const
+            bravo    = cards(list)[1],
+            bravoId  = bravo.id,
+            bravoKey = bravo.record.agentId,
+            liBefore = list.getItemId(bravoKey);
+
+        expect(cards(list).map(card => card.record.displayName)).toEqual(['Agent A', 'Agent B', 'Agent C']);
+        expect(bravoId).toBe(`${list.id}__${bravoKey}__component`);
+        expect(liIds(list)).toContain(liBefore);
+
+        // the joiner ranks equal and sorts first by name — every existing card shifts one seat
+        store.add({...joiner});
+        list.createItems(true);
+
+        expect(cards(list).map(card => card.record.displayName)).toEqual(['AAA', 'Agent A', 'Agent B', 'Agent C']);
+        expect(cards(list)[2], 'the same AgentCard instance moved with its record').toBe(bravo);
+        expect(bravo.record.agentId).toBe(bravoKey);
+        expect(bravo.id, 'the card id follows the record, not the seat').toBe(bravoId);
+        expect(list.getItemId(bravoKey), 'the li id follows the record').toBe(liBefore);
+        expect(liIds(list)).toContain(liBefore);
+        expect(list.getItemRecordId(liBefore)).toBe(bravoKey);
+
+        grid.destroy()
+    });
+
+    test('a record that leaves keeps its card behind the seats; the survivors keep theirs; a joiner gets its own', async () => {
+        const store = makeStore(roster(['ok', 'ok', 'ok'])),
+              grid  = Neo.create(FleetGrid, {appName, store}),
+              list  = await readyList(grid);
+
+        const
+            [alpha, bravo, charlie] = cards(list),
+            ids                     = [alpha.id, bravo.id, charlie.id];
+
+        store.remove(charlie.record.agentId);
+        store.add({...joiner});
+        list.createItems(true);
+
+        expect(cards(list).map(card => card.record.displayName)).toEqual(['AAA', 'Agent A', 'Agent B']);
+        expect(cards(list)[1]).toBe(alpha);
+        expect(cards(list)[2]).toBe(bravo);
+        expect([alpha.id, bravo.id]).toEqual([ids[0], ids[1]]);
+        // a card is never re-keyed onto another record: the joiner's is new, under the joiner's id
+        expect(cards(list)[0]).not.toBe(charlie);
+        expect(cards(list)[0].id).toBe(`${list.id}__agent-00__component`);
+        // Charlie's card stays behind the rendered seats, still Charlie's
+        expect(list.items.length).toBe(4);
+        expect(list.items[3]).toBe(charlie);
+        expect(charlie.id).toBe(ids[2]);
+
+        grid.destroy()
+    });
+
+    test('an explicit sort — the Animate path — reorders the pool without touching a single id', async () => {
+        const store = makeStore(roster(['ok', 'ok', 'ok'])),
+              grid  = Neo.create(FleetGrid, {appName, store}),
+              list  = await readyList(grid);
+
+        const before = cards(list).map(card => ({card, id: card.id, key: card.record.agentId}));
+
+        list.sortItems({
+            items        : [...store.items].reverse(),
+            previousItems: [...store.items]
+        });
+
+        expect(list.items.map(card => card.record.agentId)).toEqual(before.map(entry => entry.key).reverse());
+        before.forEach(({card, id}) => expect(card.id).toBe(id));
+
+        grid.destroy()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
@@ -156,7 +156,16 @@ test.describe('Fleet roster — cards and list items keep their identity across 
             charlieRow              = {...roster(['ok', 'ok', 'ok'])[2]},
             charlieKey              = charlie.record.agentId;
 
+        // the removal's own `mutate` retires Charlie's card — no rebuild in between: the store's
+        // event names the records that left, so the retirement never reads a projection that may
+        // trail the event on an older engine
         store.remove(charlieKey);
+
+        expect(charlie.isDestroyed, 'retired on the mutation that removed the record').toBe(true);
+        expect(Neo.get(ids[2])).toBeFalsy();
+        expect(list.items.length, 'the pool is bounded by the fleet').toBe(2);
+
+        // a joiner's fresh card survives its own mutation — nothing retires on an add
         store.add({...joiner});
         list.createItems(true);
 
@@ -167,22 +176,22 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         // a card is never re-keyed onto another record: the joiner's is new, under the joiner's id
         expect(cards(list)[0]).not.toBe(charlie);
         expect(cards(list)[0].id).toBe(`${list.id}__card-agent-00`);
-        // Charlie's card left with Charlie: destroyed, unregistered, out of the pool
-        expect(list.items.length, 'the pool is bounded by the fleet').toBe(3);
-        expect(charlie.isDestroyed).toBe(true);
-        expect(Neo.get(ids[2])).toBeFalsy();
+        expect(cards(list)[0].isDestroyed).toBeFalsy();
+        expect(Neo.get(`${list.id}__card-agent-00`)).toBe(cards(list)[0]);
+        expect(list.items.length).toBe(3);
 
-        // join/leave cycles of unique agents leave nothing behind — pool and registry stay bounded
+        // join/leave cycles of unique agents leave nothing behind — pool and registry stay bounded;
+        // the rebuild after the add is the production `load` path's job, the retirement is not
         for (let i = 0; i < 5; i++) {
             store.add({agentId: `cycle-${i}`, displayName: `Cycle ${i}`, githubUsername: `neo-cycle-${i}`, state: 'ok'});
             list.createItems(true);
+            expect(Neo.get(`${list.id}__card-cycle-${i}`), `cycle ${i}: the joiner's card is registered`).toBeTruthy();
+            expect(Neo.get(`${list.id}__card-cycle-${i}`).isDestroyed).toBeFalsy();
             store.remove(`cycle-${i}`);
-            list.createItems(true);
 
-            expect(Neo.get(`${list.id}__card-cycle-${i}`)).toBeFalsy()
+            expect(Neo.get(`${list.id}__card-cycle-${i}`)).toBeFalsy();
+            expect(list.items.length).toBe(3)
         }
-
-        expect(list.items.length).toBe(3);
 
         // the same agent returning gets a fresh card under the same id — freed with the old one
         store.add(charlieRow);

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
@@ -87,6 +87,14 @@ test.describe('Fleet roster — cards and list items keep their identity across 
     const liIds  = list => list.getVdomRoot().cn.map(node => node.id);
     const joiner = {agentId: 'agent-00', displayName: 'AAA', githubUsername: 'neo-agent-00', state: 'ok'};
 
+    // the joiner must sort AHEAD on every engine this repo pins: the shipped "online first" order
+    // ranks by the calculated `tierRank`, which a raw row lacks on engines before neomjs/neo#18269
+    // (a raw joiner sorted last there, which is how this defect stayed hidden). Name order reads a
+    // plain field, so `AAA` leads on either engine — the tier axis is the pin battery's witness.
+    const byName = store => {
+        store.sorters = [{direction: 'ASC', property: 'displayName', sortBy: (a, b) => (a.displayName ?? '').toLowerCase().localeCompare((b.displayName ?? '').toLowerCase())}]
+    };
+
     test.beforeAll(async () => {
         FleetGrid  = (await import('../../../../../../../../apps/agentos/view/fleet/roster/Container.mjs')).default;
         FleetAgent = (await import('../../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
@@ -113,7 +121,8 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         expect(bravoId).toBe(`${list.id}__${bravoKey}__component`);
         expect(liIds(list)).toContain(liBefore);
 
-        // the joiner ranks equal and sorts first by name — every existing card shifts one seat
+        // the joiner sorts first by name — every existing card shifts one seat
+        byName(store);
         store.add({...joiner});
         list.createItems(true);
 
@@ -137,6 +146,7 @@ test.describe('Fleet roster — cards and list items keep their identity across 
             [alpha, bravo, charlie] = cards(list),
             ids                     = [alpha.id, bravo.id, charlie.id];
 
+        byName(store);
         store.remove(charlie.record.agentId);
         store.add({...joiner});
         list.createItems(true);

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
@@ -107,9 +107,14 @@ test.describe('Fleet roster — cards and list items keep their identity across 
     });
 
     test('a joiner that sorts ahead moves the existing cards — same instance, same card id, same li id', async () => {
-        const store = makeStore(roster(['ok', 'ok', 'ok'])),
-              grid  = Neo.create(FleetGrid, {appName, store}),
-              list  = await readyList(grid);
+        const store = makeStore(roster(['ok', 'ok', 'ok']));
+
+        // seated BEFORE the grid: the controller keeps a store's own sorters, and no `sort` event
+        // fires inside the arm — the plugin's transition timer would outlive the grid otherwise
+        byName(store);
+
+        const grid = Neo.create(FleetGrid, {appName, store}),
+              list = await readyList(grid);
 
         const
             bravo    = cards(list)[1],
@@ -118,11 +123,11 @@ test.describe('Fleet roster — cards and list items keep their identity across 
             liBefore = list.getItemId(bravoKey);
 
         expect(cards(list).map(card => card.record.displayName)).toEqual(['Agent A', 'Agent B', 'Agent C']);
-        expect(bravoId).toBe(`${list.id}__${bravoKey}__component`);
+        expect(bravoId).toBe(`${list.id}__card-${bravoKey}`);
+        expect(liBefore).toBe(`${list.id}__item-${bravoKey}`);
         expect(liIds(list)).toContain(liBefore);
 
         // the joiner sorts first by name — every existing card shifts one seat
-        byName(store);
         store.add({...joiner});
         list.createItems(true);
 
@@ -137,17 +142,21 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         grid.destroy()
     });
 
-    test('a record that leaves keeps its card behind the seats; the survivors keep theirs; a joiner gets its own', async () => {
-        const store = makeStore(roster(['ok', 'ok', 'ok'])),
-              grid  = Neo.create(FleetGrid, {appName, store}),
-              list  = await readyList(grid);
+    test('a record that leaves retires its card — destroyed and dropped, the pool bounded by the fleet; survivors keep theirs, a joiner gets its own', async () => {
+        const store = makeStore(roster(['ok', 'ok', 'ok']));
+
+        byName(store);
+
+        const grid = Neo.create(FleetGrid, {appName, store}),
+              list = await readyList(grid);
 
         const
             [alpha, bravo, charlie] = cards(list),
-            ids                     = [alpha.id, bravo.id, charlie.id];
+            ids                     = [alpha.id, bravo.id, charlie.id],
+            charlieRow              = {...roster(['ok', 'ok', 'ok'])[2]},
+            charlieKey              = charlie.record.agentId;
 
-        byName(store);
-        store.remove(charlie.record.agentId);
+        store.remove(charlieKey);
         store.add({...joiner});
         list.createItems(true);
 
@@ -157,29 +166,103 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         expect([alpha.id, bravo.id]).toEqual([ids[0], ids[1]]);
         // a card is never re-keyed onto another record: the joiner's is new, under the joiner's id
         expect(cards(list)[0]).not.toBe(charlie);
-        expect(cards(list)[0].id).toBe(`${list.id}__agent-00__component`);
-        // Charlie's card stays behind the rendered seats, still Charlie's
+        expect(cards(list)[0].id).toBe(`${list.id}__card-agent-00`);
+        // Charlie's card left with Charlie: destroyed, unregistered, out of the pool
+        expect(list.items.length, 'the pool is bounded by the fleet').toBe(3);
+        expect(charlie.isDestroyed).toBe(true);
+        expect(Neo.get(ids[2])).toBeFalsy();
+
+        // join/leave cycles of unique agents leave nothing behind — pool and registry stay bounded
+        for (let i = 0; i < 5; i++) {
+            store.add({agentId: `cycle-${i}`, displayName: `Cycle ${i}`, githubUsername: `neo-cycle-${i}`, state: 'ok'});
+            list.createItems(true);
+            store.remove(`cycle-${i}`);
+            list.createItems(true);
+
+            expect(Neo.get(`${list.id}__card-cycle-${i}`)).toBeFalsy()
+        }
+
+        expect(list.items.length).toBe(3);
+
+        // the same agent returning gets a fresh card under the same id — freed with the old one
+        store.add(charlieRow);
+        list.createItems(true);
+
+        const returned = cards(list).find(card => card.record.agentId === charlieKey);
+
+        expect(returned).toBeTruthy();
+        expect(returned).not.toBe(charlie);
+        expect(returned.id).toBe(ids[2]);
         expect(list.items.length).toBe(4);
-        expect(list.items[3]).toBe(charlie);
-        expect(charlie.id).toBe(ids[2]);
 
         grid.destroy()
     });
 
-    test('an explicit sort — the Animate path — reorders the pool without touching a single id', async () => {
-        const store = makeStore(roster(['ok', 'ok', 'ok'])),
+    test('agent ids are whatever the Brain accepted — item and card namespaces never meet, and every id round-trips DOM-safe', async () => {
+        const rows  = ['plain', 'plain__component', 'item-plain', 'card-plain', 'with space', 'ünïcode', '_', 'a.b/c#d']
+                  .map((agentId, i) => ({agentId, displayName: `N${i}`, githubUsername: `g${i}`, state: 'ok'})),
+              store = makeStore(rows),
               grid  = Neo.create(FleetGrid, {appName, store}),
               list  = await readyList(grid);
 
-        const before = cards(list).map(card => ({card, id: card.id, key: card.record.agentId}));
+        const itemIds = rows.map(row => list.getItemId(row.agentId)),
+              cardIds = cards(list).map(card => card.id),
+              all     = [...itemIds, ...cardIds];
 
-        list.sortItems({
-            items        : [...store.items].reverse(),
-            previousItems: [...store.items]
-        });
+        expect(cardIds.length).toBe(rows.length);
+        expect(new Set(all).size, 'no two ids collide across both namespaces').toBe(all.length);
+        all.forEach(id => expect(id, 'DOM-safe: letters, digits, hyphen, underscore').toMatch(/^[A-Za-z0-9_-]+$/));
+        rows.forEach(row => expect(list.getItemRecordId(list.getItemId(row.agentId)), `round-trip ${row.agentId}`).toBe(row.agentId));
+        // the rendered lis carry exactly the item ids, and no li id is any card's id
+        expect(liIds(list).sort()).toEqual([...itemIds].sort());
+        expect(cardIds.some(id => liIds(list).includes(id))).toBe(false);
 
-        expect(list.items.map(card => card.record.agentId)).toEqual(before.map(entry => entry.key).reverse());
+        grid.destroy()
+    });
+
+    test('a sort through the Animate plugin moves the same nodes — translated mid-motion, rebuilt after the transition under the same ids', async () => {
+        const store  = makeStore(roster(['ok', 'ok', 'ok'])),
+              grid   = Neo.create(FleetGrid, {appName, store}),
+              list   = await readyList(grid),
+              plugin = list.getPlugin('list-animate');
+
+        plugin.transitionDuration = 20;
+
+        const
+            before    = cards(list).map(card => ({card, id: card.id, key: card.record.agentId})),
+            reversed  = before.map(entry => entry.key).reverse(),
+            nodeOf    = key => list.getVdomRoot().cn.find(node => node.id === list.getItemId(key)),
+            seatOf    = key => nodeOf(key)?.style?.transform,
+            seats     = Object.fromEntries(before.map(({key}) => [key, seatOf(key)])),
+            itemIds   = before.map(({key}) => list.getItemId(key)).sort();
+
+        before.forEach(({key}) => expect(seats[key], `${key} sits on a translated seat`).toMatch(/^translate\(/));
+
+        // the store's own `sort` event drives the plugin's `sortComponentList`: the pool follows the
+        // records at once, and not one id changes — the nodes the transition will move are the same
+        store.sorters = [{direction: 'DESC', property: 'displayName'}];
+
+        expect(list.items.map(card => card.record.agentId), 'the pool follows the sorted records').toEqual(reversed);
         before.forEach(({card, id}) => expect(card.id).toBe(id));
+        expect(liIds(list).sort(), 'the same lis, no new node').toEqual(itemIds);
+
+        // the transition callback rebuilds the items: the same instances under the same ids, and the
+        // moved records' nodes carry NEW seats — the transform changed on the same node id, which is
+        // what lets the CSS transition play instead of a rebuilt card flashing in
+        await new Promise(resolve => setTimeout(resolve, 80));
+
+        expect(cards(list).map(card => card.record.agentId)).toEqual(reversed);
+        before.forEach(({card, id, key}) => {
+            const now = cards(list).find(candidate => candidate.record.agentId === key);
+
+            expect(now, `${key} is the same AgentCard instance`).toBe(card);
+            expect(now.id).toBe(id)
+        });
+        expect(liIds(list).sort()).toEqual(itemIds);
+        expect(seatOf(before[0].key), 'the first record moved to the last seat').not.toBe(seats[before[0].key]);
+        expect(seatOf(before[2].key), 'the last record moved to the first seat').not.toBe(seats[before[2].key]);
+        expect(seatOf(before[1].key), 'the middle record kept its seat').toBe(seats[before[1].key]);
+        expect(seatOf(before[2].key)).toBe(seats[before[0].key]);
 
         grid.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs
@@ -42,7 +42,9 @@ test.afterAll(() => {
  * DOM node of a card the moment a joiner sorted ahead of it — and the keyboard focus inside the node
  * died with it. Measured on engine dev@205bc52f8a, where a joiner finally sorts by the record's
  * `tierRank` instead of landing last as a raw row. These arms pin the record-keyed identity in the
- * unit tier, where a rebuild is `createItems()` after a store mutation.
+ * unit tier on the production event chain alone: a store mutation fires the store's own `load`, the
+ * list's `onStoreLoad` rebuilds, and every assertion follows the event with no manual `createItems`
+ * between them — a rebuild the chain did not perform stays visible.
  */
 test.describe('Fleet roster — cards and list items keep their identity across a re-sort', () => {
     let FleetAgent, FleetGrid, Store;
@@ -127,9 +129,9 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         expect(liBefore).toBe(`${list.id}__item-${bravoKey}`);
         expect(liIds(list)).toContain(liBefore);
 
-        // the joiner sorts first by name — every existing card shifts one seat
+        // the joiner sorts first by name — every existing card shifts one seat; the rebuild is the
+        // store's own `load`, fired inside the mutation
         store.add({...joiner});
-        list.createItems(true);
 
         expect(cards(list).map(card => card.record.displayName)).toEqual(['AAA', 'Agent A', 'Agent B', 'Agent C']);
         expect(cards(list)[2], 'the same AgentCard instance moved with its record').toBe(bravo);
@@ -167,7 +169,6 @@ test.describe('Fleet roster — cards and list items keep their identity across 
 
         // a joiner's fresh card survives its own mutation — nothing retires on an add
         store.add({...joiner});
-        list.createItems(true);
 
         expect(cards(list).map(card => card.record.displayName)).toEqual(['AAA', 'Agent A', 'Agent B']);
         expect(cards(list)[1]).toBe(alpha);
@@ -181,10 +182,10 @@ test.describe('Fleet roster — cards and list items keep their identity across 
         expect(list.items.length).toBe(3);
 
         // join/leave cycles of unique agents leave nothing behind — pool and registry stay bounded;
-        // the rebuild after the add is the production `load` path's job, the retirement is not
+        // the rebuild after each add is the production `load` path's own, the retirement is the
+        // removal's `mutate`
         for (let i = 0; i < 5; i++) {
             store.add({agentId: `cycle-${i}`, displayName: `Cycle ${i}`, githubUsername: `neo-cycle-${i}`, state: 'ok'});
-            list.createItems(true);
             expect(Neo.get(`${list.id}__card-cycle-${i}`), `cycle ${i}: the joiner's card is registered`).toBeTruthy();
             expect(Neo.get(`${list.id}__card-cycle-${i}`).isDestroyed).toBeFalsy();
             store.remove(`cycle-${i}`);
@@ -195,7 +196,6 @@ test.describe('Fleet roster — cards and list items keep their identity across 
 
         // the same agent returning gets a fresh card under the same id — freed with the old one
         store.add(charlieRow);
-        list.createItems(true);
 
         const returned = cards(list).find(card => card.record.agentId === charlieKey);
 

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "6a7599cb3d6db8c6bde51aaa371d26b0754f7a26fd28f0291d51dec0e468c1ff",
     "inputs": {
-        "apps/agentos": "ea20942bf5ffb46ca014564f4fd43b79dc3381b79f2373d04dadb95111abcaa3",
+        "apps/agentos": "bd067067236cdc9f9b38e15629e220d921c96b84edc80ad8bb9f634cb042f305",
         "resources/scss": "ba0ce5dd3464afb60fe99b200e67f05bde2cb5df18c76cf25e255d4c86940991",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4745760abc6192d424b6a26853db152daabb4251918c4101ca2e6e4794d6dccd",


### PR DESCRIPTION
Resolves #99

Related: #98 / PR #102 (the engine pin this branch now sits on) · #17553 (the keyboard contract the A11y arm pins) · neomjs/neo#18269 (the engine fix that made the roster's sort truthful) · #103 (the battery's one remaining stated red)

A roster card belongs to its record, not to a seat. The list extends `Neo.list.Component`, whose pool seats components by index and renumbers their ids on every rebuild — the calendar pattern — so the moment a joiner sorted ahead of an agent, that agent's card was re-seated under a new positional id, the vdom engine replaced its DOM node, and the keyboard focus inside it died. On the previous pin (pin 5) this never showed: a raw joiner had no `tierRank`, sorted LAST, and nothing moved; the engine fix in neomjs/neo#18269 sorts the joiner where it belongs, and the `FleetGridKeyboardA11y` reorder step went red 3/3 (Charlie's card `__1__component` → `__2__component`, the focused Stop button inactive). Three files, no new abstraction:

- **`apps/agentos/view/fleet/roster/List.mjs`** — `createItemContent` finds the card seated on the record (by key) and creates one only when there is none; a card is never re-keyed onto another record (re-keying a live component breaks its reference tree — measured: `getReference` answered null mid-`applyRecord`). The roster follows the store's `mutate` (`afterSetStore` adds the listener beside the base list's): the event names the records that left, and `onStoreMutate` destroys and drops their cards — the pool and the instance registry stay bounded by the fleet's current cardinality across any number of join/leave cycles; a filtered-out record fires `filter`, never `mutate`, and keeps its card behind the rendered seats; a record re-added inside the same mutation keeps its card. The mutation payload is the authority on every engine — a projection read inside `load` is not. The pool stays in store order by swapping, because the animate plugin's geometry and every reader of `items` take seat `i` as record `i`. Ids live in two disjoint namespaces with a reversible DOM-safe encoding — `<list>__item-<key>` for the `li`, `<list>__card-<key>` for the card, every code unit outside `[A-Za-z0-9-]` (the underscore included) as `_` + four hex digits — so an agent literally named `a__component` cannot alias another agent's card and every id decodes back to its key (`getItemRecordId` is the exact inverse of `getItemId`, which accepts a record or a key, the base list's shape). `sortItems` reorders the pool by key, never by position; `useInternalId: false` makes the record's store key the one id form every reader of this list speaks.
- **`test/playwright/unit/apps/agentos/view/fleet/roster/cardIdentity.spec.mjs`** — new, four arms (the roster container spec's harness), every rebuild the production chain's own (`store.add` → `mutate` → the store's `load` → the list's `onStoreLoad`; no manual `createItems` between an event and its assertion): a joiner that sorts ahead moves the existing cards — same instance, same card id, same `li` id; a record that leaves retires its card on the removal's own `mutate` — destroyed, unregistered, out of the pool, with no rebuild in between — a joiner's fresh card survives its own mutation, five join/leave cycles of unique agents leave nothing behind, and the same agent returning gets a fresh card under the freed id; adversarial agent ids (`plain__component`, `item-plain`, `card-plain`, a space, `ünïcode`, `_`, `a.b/c#d`) yield unique DOM-safe ids across both namespaces that round-trip to their keys; a sort through the Animate plugin — the store's own `sort` event, `transitionDuration` 20ms — moves the same nodes: the pool follows at once, no id changes, and after the transition the same instances sit under the same ids with the moved records' nodes on new seats. **Red-first: 4 of 4 fail against the current roster list.**
- **`README.md`** — the battery paragraph states one red instead of two: the A11y reorder step is green on the pin-6 engine with this change; the FLIP-settle hold (#103) remains, owned.

Evidence: L3 (the `FleetGridKeyboardA11y` reorder step green on the branch's own pin-6 engine, red 3/3 before this change; unit arms red-first) → L3 required (a keyboard-focus contract is a rendered-DOM fact). Residual: none on this ticket; the battery's remaining red is #103.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — the A11y reorder step green on engine `dev@205bc52f8a` or later: card id and `li` id unchanged, the focused Button still focused, `aria-selected` intact, selection unchanged | `FleetGridKeyboardA11y.spec.mjs` under the Brain root on this branch's own lock (pin 6, after the rebase onto merged #102): **1 passed** (4.4s) inside the full battery: **34 passed, 0 failed** (2.0m, no retries configured) at `3e434b4`; before this change on the same engine: 3/3 failed at the card-id assertion, and with the id assertions replaced by probes the focused Button read `inactive`. |
| AC-2 — a unit arm asserts the card id and the `li` id of an existing agent survive `store.add` of a joiner that sorts ahead; red-first | `cardIdentity.spec.mjs` arm 1: `cards(list)[2]` is the same instance, `bravo.id` (`<list>__card-agent-02`) and `list.getItemId('agent-02')` (`<list>__item-agent-02`) unchanged, `getItemRecordId` the inverse — asserted straight after `store.add`, the rebuild the store's own `load`; the retirement, namespace and motion arms beside it; with `List.mjs` stashed: 4 failed. |
| AC-3 — the animate move still animates: the existing "same instance, no rebuild" arm stays green | The motion arm drives the store's real `sort` event through the Animate plugin (`transitionDuration` 20ms): the pool follows at once, no id changes, and after the transition the same instances sit under the same ids while the moved records' nodes carry new seats and the unmoved one keeps its seat — the transition plays on the same nodes instead of a rebuilt card flashing in. Roster unit tier **66 passed** (62 existing + 4 new); full institution unit tree **762 passed, 0 failed** on the pin-6 lock. |

## Deltas from ticket

- The ticket's "re-seat a freed card onto a joiner" idea is dropped: re-keying a live component (`setSilent({id})` on a card with children) broke `getReference` inside `applyRecord`; the contract became "one card per record for the record's lifetime in the fleet" — a card is never handed to another record, and it is retired with its record (the review pass below), so the pool is bounded by the fleet's current cardinality, never by its history.
- The first cut of the unit arms let the joiner's position depend on the store's shipped "online first" order — which ranks by the calculated `tierRank` a raw row lacked on pin 5 (then the CI engine): the joiner sorted LAST there and CI went red on both jobs while the same arms were green locally against the pin-6 engine. The arms set a name sorter before the joiner arrives (`AAA` leads on any engine); the tier axis stays the pin battery's witness. The vacuous-green class this ticket is about, caught in its own witness.
- `useInternalId: false` was not in the ticket: the base list keys items by internal record ids while the selection model, the cockpit and the animate plugin key by `agentId`; record-keyed DOM ids need one form, and the store key is the one every reader already speaks.
- From the reviewer's source pass, before Round 1: (1) departed records no longer keep their cards — the first cut retained every card for the list's lifetime, which would have grown the pool and the instance registry with historical fleet cardinality; the retirement bounds both, and the arm proves it through five join/leave cycles plus a return. (2) Raw record keys in the DOM ids could collide across the `li` and card namespaces (`a` vs `a__component`); disjoint prefixes plus the reversible encoding close that, and the adversarial-id arm pins uniqueness, DOM safety and the round-trip. (3) The sort arm went through `sortItems` directly and would have stayed green with the plugin's move path deleted; it now drives the store's real `sort` event through the Animate plugin and asserts the seats moved on the same node ids after the transition — the motion evidence AC-3 asked for. A stray plugin timer surfaced on the way (a sort inside a test whose grid is destroyed within `transitionDuration` fires `owner.createItems()` on a null owner) — an engine defect-note, not this PR's; the arms seat their sorter before the grid exists.
- Round 1 (the settlement-order RA): the first retirement pass ran inside `createItems` — the `load` callback — and read the store's unfiltered projection as authority; on pin 5 that projection was mirrored one listener later than `load`, so a joiner's fresh card was destroyed against stale authority. Retirement now rides the store's `mutate` event and its `removedItems` — no projection read, no rebuild dependency, the same on both engines; the arm asserts the leaver's card is destroyed right after `store.remove` with no rebuild, and that a joiner's card survives its own add.
- Round 2 (the manual-rebuild RA): the add, churn and re-add controls of the retirement arm, and the joiner add of the identity arm, still called `list.createItems(true)` before asserting — a rescue that could hide a production rebuild the chain did not perform. The four calls are gone; every assertion now follows the store event directly, and the describe's JSDoc states the chain the arms rely on. Roster tier 66/66 and unit tree 762/762 with the calls removed — the production `load` rebuilds synchronously inside the mutation.
- Rebased onto `dev` after PR #102 merged (`a8b469e`, the pin-6 engine): `1b1604d` / `0e492d0` / `5a68ff2` / `4a31607` are the four prior commits (pre-rebase `908c63c` / `776c201` / `300a0c8` / `0dc4c00`, identical content); the two stamp conflicts took dev's file, and the branch restamped in the round-2 commit. The branch's own lock is now pin 6, so the A11y arm's green is the real one, not the vacuous pin-5 one.

## Test Evidence

- `cardIdentity.spec.mjs` against the current roster list (`List.mjs` stashed): **4 failed** — with the fix: **4 passed**; roster tier **66 passed**.
- Full `npm run test-unit`: **762 passed, 0 failed** (6.3s) on this branch's own lock (pin 6, engine `205bc52f8a` verified in `node_modules`) at the round-2 head.
- NL battery under the Brain root on this branch (`npm run test-e2e:nl`): **34 passed, 0 failed** (2.0m; the config sets no retries, so no arm passed on a second try) at `3e434b4` — the A11y reorder step green, `FleetGridScaleNL` green, and the FLIP-settle arm (#103) landed this run (it is the race the README states, not a fix here).
- `check-visual-baselines`: *input identity matches the golden stamp* after `git add` → stamp → commit (`apps/agentos` is a stamp input; no golden changed), re-run as its own command before the push.

## Post-Merge Validation

- [ ] The NL battery on the merged `dev` reads as this branch's: the A11y reorder step green, one stated red (#103).

## Commits

- `3e434b4` — Round 2: the four manual `createItems(true)` rescues leave the arms; the describe JSDoc names the production chain; restamp (the rebase took dev's stamp).
- `436cd6d` — README battery truth: one stated red (#103); the A11y reorder step green on the pin-6 engine.
- `4a31607` (pre-rebase `0dc4c00`) — retirement moved from the `load`-time rebuild to the store's `mutate` event (`afterSetStore` + `onStoreMutate`); the retirement arm asserts it without a rebuild; the lifetime JSDoc truth-synced.
- `5a68ff2` (pre-rebase `300a0c8`) — the review pass: departed cards retire (destroyed, unregistered, out of the pool), disjoint DOM-safe id namespaces with a reversible encoding, `sortItems` by key, the motion arm through the plugin, the retirement and adversarial-id arms; restamp.
- `0e492d0` (pre-rebase `776c201` / `dd1f2ad`) — the card-identity arms sort by name, so the joiner leads on every pinned engine (CI at `80b291a` was red on both jobs for exactly that).
- `1b1604d` (pre-rebase `908c63c` / `80b291a`) — record-keyed cards and list items (`createItemContent`, `getCardId`, `getItemId` / `getItemRecordId`, `sortItems`, `useInternalId: false`), the three-arm witness, restamp.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session e1f9d3cb-6f4f-423c-9e42-6f20d9cba9b3
