### PR TITLE
chore(institution): js-yaml ^5.2.3 aligned with the engine and the Brain; the qs moderate closed in range (#87)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "highlightjs-line-numbers.js": "^2.9.1",
                 "html-minifier-terser": "^7.2.0",
                 "inquirer": "^13.4.3",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^5.2.3",
                 "jsdoc-api": "^9.3.6",
                 "marked": "^18.0.5",
                 "mermaid": "^11.16.0",
@@ -5884,9 +5884,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
-            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+            "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
             "dev": true,
             "funding": [
                 {
@@ -5903,7 +5903,7 @@
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/js2xmlparser": {
@@ -7527,9 +7527,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "highlightjs-line-numbers.js": "^2.9.1",
         "html-minifier-terser": "^7.2.0",
         "inquirer": "^13.4.3",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.2.3",
         "jsdoc-api": "^9.3.6",
         "marked": "^18.0.5",
         "mermaid": "^11.16.0",


### PR DESCRIPTION
Resolves #87

Related: the 2026-09-02 three-repo audit (this ticket's origin) · the siblings' declared ranges — neomjs/neo `^5.2.3`, neomjs/neo-agent-brain `^5.2.3`

The Institution pinned `js-yaml ^4.1.1` (4.3.2 installed) while the engine (5.2.3) and the Brain (5.4.0) run 5.x on the same kinds of substrate files — a major behind that `npm outdated` cannot see because the range hid it. Two files, one call site:

- **`package.json`** — `js-yaml` `^4.1.1` → `^5.2.3`: the same declared range as both siblings, so the next cross-repo audit reads the alignment as intentional (the record the ticket's Fix 3 asked for lives in the declaration itself); installs 5.4.1.
- **`package-lock.json`** — js-yaml 5.4.1 (webpack-cli dedupes onto it; gray-matter keeps its own 3.15.1 as before); `npm audit fix` in range: `qs` → 6.16.0, `npm audit` **0 vulnerabilities** (AC-1). `check-visual-baselines` passed unchanged: its engine digest hashes only the `node_modules/neo.mjs` lock entry, and js-yaml and qs sit outside that axis — no stamp edit, no golden changed.

**The one call site**, read against the upstream v4→v5 migration guide (`docs/migrate_v4_to_v5.md`): `test/playwright/unit/harness/pack.spec.mjs` uses a namespace import (`import * as yaml from 'js-yaml'`, the form the guide keeps by design) and `yaml.load()` / `yaml.dump()` without options — the guide's base case, "swap the import and you're done". No code change. The two behaviours that did change, named rather than assumed equivalent (AC-2):

- `load('')` returns `undefined` in v4 and **throws `YAMLException`** in v5. No arm loads an empty document (the arms parse `harness/electron-builder.yml` and `yaml.dump({files: …})` fixtures); the helper's `?.files` guard still covers `null` and non-mapping documents, so the spec's own "closure is missing or invalid" error stays reachable for those.
- `load()` defaults to the YAML 1.2 `CORE_SCHEMA`: timestamps stay strings (v4's 1.1 default turned `2026-09-04` into a `Date`), `!!merge` is no longer implicit. Measured side by side (4.3.2 unpacked beside 5.4.1): `harness/electron-builder.yml` parses **byte-identically** under both majors — strings, lists, maps, `null` and `false` only; no timestamp, no merge key, no 1.1 boolean.

Evidence: L2 (the full local suites run against the new major; the parse target is a packaging fixture, not a rendered surface) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
| --- | --- |
| AC-1 — `npm audit` reports 0 vulnerabilities | `npm audit fix` in range (`qs` 6.16.0); `npm audit`: **found 0 vulnerabilities**. |
| AC-2 — `js-yaml` declared `^5` and installed at 5.x; every call site exercised, the ones that changed behaviour named | Declared `^5.2.3`, installed **5.4.1**; the one call site above, `pack.spec.mjs` **17/17**; the two behaviour changes named above. |
| AC-3 — the full local suites green | unit **762 passed** · components **3 passed** · isolated e2e **8 passed** (the CI set), all on 5.4.1; the Neural Link battery parses no YAML. |
| AC-4 — YAML another repo also parses checked under both majors, or noted as not shared | The only YAML this repo parses with js-yaml is `harness/electron-builder.yml` (the Electron shell's packaging config) — parsed by no sibling repo; compared anyway: identical under 4.3.2 and 5.4.1. |

## Deltas from ticket

- The alignment is recorded in the declaration (`^5.2.3`, the siblings' exact range) rather than in prose: JSON carries no comments, and a range identical across the three repos is the fact an audit compares.
- The ticket's out-of-scope majors (`inquirer` 14, `monaco-editor` 0.56 together with the engine) stay untouched.

## Test Evidence

- `npm run test-unit` **762/762** · `npm run test-components` **3/3** · `npm run test-e2e` (isolated) **8/8** — on js-yaml 5.4.1.
- `npm audit`: **0 vulnerabilities**.
- `check-visual-baselines`: *input identity matches the golden stamp* — unchanged, the stamp's engine axis is the `neo.mjs` lock entry alone; re-run as its own command on the rebased head before the push.

## Post-Merge Validation

None owed — the unmerged head carries the full suite and audit proof; the next cross-repo audit reads three identical `^5.2.3` ranges.

## Commits

- `bf3ad1f` — js-yaml `^5.2.3`, the lock (5.4.1 + `qs` 6.16.0); rebased onto `dev@ce47818` after PR #105 (was `4612a22` on `da4657c`), commit body truth-synced on the stamp.

📜 Clio · @neo-fable-clio · Claude Fable 5.1 · Claude Code · session e1f9d3cb-6f4f-423c-9e42-6f20d9cba9b3

