### PR TITLE
fix(harness): the pack stage assembles from explicit product, Engine and Brain roots, and the launcher gates the Brain root on the Brain leg (#4)

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -160,14 +160,19 @@ and nothing else: the PRODUCT root (this checkout — the renderer's source grap
 contentPolicy allowlist, one authority: a new allowlist prefix ships automatically), the ENGINE
 package (the pinned `neo.mjs` dependency, installed into the stage from the product's own pin),
 and the BRAIN root (`NEO_AGENTOS_RUNTIME_ROOT`, absolute — the same contract the checkout launcher
-uses; the stage copies its `ai/` tree, minus examples and the not-yet-enabled temporal-summary
-daemon, plus the one `buildScripts` module the Brain entrypoints import). Every owner is proven
+uses; the stage copies its `ai/` and `src/` trees, minus examples and the not-yet-enabled
+temporal-summary daemon with its aggregation script; the Engine modules the Brain imports bare,
+its sanitizer among them, come from the staged install). Every owner is proven
 BEFORE the stage dir is touched: a missing or relative Brain authority, or a root without its
 markers, fails the pack with nothing removed, built or installed — never a cwd or sibling guess.
-The dependency manifest is GENERATED: the staged trees' bare imports, pinned to the versions the
-product `package.json` and the Brain root's `package.json` declare (the product wins a shared
-name — the Engine is its dependency; fail-loud on any undeclared import), and the install is then
-verified to resolve every pin. `organism-build-info.json` records the three owners. **No checkout
+The dependency manifest is GENERATED with each import's provenance kept: the renderer graph's
+bare imports are pinned by the product `package.json`, the Brain tree's by the Brain root's
+`package.json`, a name both trees import must carry the same declaration in both (a disagreement
+fails the pack — never a silent precedence), and `neo.mjs` is the one named exception: the Engine
+is the product's pin. An import its owner never declared fails loud; on the complete stage every
+pin is checked to be present under its `node_modules` and every relative import of a staged module
+to resolve inside the stage. `organism-build-info.json` records the three owners as role, name,
+version, pin and Brain revision — never a build-host path. **No checkout
 instance overlay ever ships:** any `config.mjs` with a `config.template.mjs` sibling — the
 top-level `ai/config.mjs` AND every per-server MCP overlay, all of which can carry hand-edited
 operator credentials — is excluded by DERIVATION, a post-copy assertion fails the build on any

--- a/harness/README.md
+++ b/harness/README.md
@@ -165,9 +165,10 @@ temporal-summary daemon with its aggregation script; the Engine modules the Brai
 its sanitizer among them, come from the staged install). Every owner is proven
 BEFORE the stage dir is touched: a missing or relative Brain authority, or a root without its
 markers, fails the pack with nothing removed, built or installed — never a cwd or sibling guess.
-The dependency manifest is GENERATED with each import's provenance kept: the renderer graph's
-bare imports are pinned by the product `package.json`, the Brain tree's by the Brain root's
-`package.json`, a name both trees import must carry the same declaration in both (a disagreement
+The dependency manifest is GENERATED with each import's provenance kept — each owner's COPIED
+files are scanned on their own, so the `src/` both owners share credits nothing to the wrong one:
+the renderer graph's bare imports are pinned by the product `package.json`, the Brain trees' by
+the Brain root's `package.json`, a name both trees import must carry the same declaration in both (a disagreement
 fails the pack — never a silent precedence), and `neo.mjs` is the one named exception: the Engine
 is the product's pin. An import its owner never declared fails loud; on the complete stage every
 pin is checked to be present under its `node_modules` and every relative import of a staged module

--- a/harness/README.md
+++ b/harness/README.md
@@ -150,16 +150,24 @@ provide the renderer-identity and clean process-group receipts.
 
 ```bash
 cd harness
-npm run dist    # pack.mjs stages the organism, electron-builder emits dist-artifacts/*.zip
+NEO_AGENTOS_RUNTIME_ROOT=/absolute/path/to/neo-agent-brain npm run dist
+# pack.mjs stages the organism from its three owners, electron-builder emits dist-artifacts/*.zip
 ```
 
 The artifact is ONE double-clickable app (unsigned — signing/notarization is release-line,
-operator-owned; never repo tooling) wrapping the ORGANISM: the renderer's source graph derived
-from the contentPolicy allowlist (one authority — a new allowlist prefix ships automatically),
-the Brain tree (`ai/`, minus examples and the not-yet-enabled temporal-summary daemon), a
-GENERATED dependency manifest (this repo declares only devDependencies, so the runtime closure
-is derived from the bundled trees' bare imports and pinned to repo-declared versions —
-fail-loud on any undeclared import), and pack-time-fresh instance configs. **No checkout
+operator-owned; never repo tooling) wrapping the ORGANISM, assembled from three explicit owners
+and nothing else: the PRODUCT root (this checkout — the renderer's source graph derived from the
+contentPolicy allowlist, one authority: a new allowlist prefix ships automatically), the ENGINE
+package (the pinned `neo.mjs` dependency, installed into the stage from the product's own pin),
+and the BRAIN root (`NEO_AGENTOS_RUNTIME_ROOT`, absolute — the same contract the checkout launcher
+uses; the stage copies its `ai/` tree, minus examples and the not-yet-enabled temporal-summary
+daemon, plus the one `buildScripts` module the Brain entrypoints import). Every owner is proven
+BEFORE the stage dir is touched: a missing or relative Brain authority, or a root without its
+markers, fails the pack with nothing removed, built or installed — never a cwd or sibling guess.
+The dependency manifest is GENERATED: the staged trees' bare imports, pinned to the versions the
+product `package.json` and the Brain root's `package.json` declare (the product wins a shared
+name — the Engine is its dependency; fail-loud on any undeclared import), and the install is then
+verified to resolve every pin. `organism-build-info.json` records the three owners. **No checkout
 instance overlay ever ships:** any `config.mjs` with a `config.template.mjs` sibling — the
 top-level `ai/config.mjs` AND every per-server MCP overlay, all of which can carry hand-edited
 operator credentials — is excluded by DERIVATION, a post-copy assertion fails the build on any

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -65,6 +65,32 @@ export function resolveAgentOsRuntimeRoot(env = process.env) {
 }
 
 /**
+ * @summary The launcher's runtime-root rule per boot shape. Packaged: the assembled organism root,
+ * always. Checkout with the Brain leg on: the explicit absolute Brain checkout, required (the
+ * contract above). Checkout with the Brain leg off: that root when the operator supplies one (the
+ * UI-only transport self-supplies from it), `null` when absent — the shell then boots as the UI
+ * alone, spawns nothing and loads no Brain contract. A RELATIVE value stays an error in every shape:
+ * never a cwd guess.
+ * @param {Object} options
+ * @param {Boolean} options.brainMode `resolveBrainMode`'s verdict.
+ * @param {Object} [options.env=process.env]
+ * @param {Boolean} options.packaged `app.isPackaged` at the call site.
+ * @param {String|null} [options.packagedOrganismRoot=null]
+ * @returns {String|null}
+ */
+export function resolveLauncherRuntimeRoot({brainMode, env = process.env, packaged, packagedOrganismRoot = null}) {
+    if (packaged) {
+        return packagedOrganismRoot
+    }
+
+    if (brainMode || env.NEO_AGENTOS_RUNTIME_ROOT !== undefined) {
+        return resolveAgentOsRuntimeRoot(env)
+    }
+
+    return null
+}
+
+/**
  * Loads Fleet trust primitives from the selected organism instead of the shell bundle.
  * @summary Keeps checkout and packaged launchers on one canonical Fleet contract implementation.
  * @param {String} [repoRoot=resolveAgentOsRuntimeRoot()] Authoritative Brain checkout or packaged organism root.

--- a/harness/fleetCapability.mjs
+++ b/harness/fleetCapability.mjs
@@ -76,6 +76,31 @@ export function projectPublicCredentialIntent(method, params) {
 }
 
 /**
+ * @summary The capability a shell WITHOUT a Brain root exposes (a checkout with the Brain leg off and
+ * no `NEO_AGENTOS_RUNTIME_ROOT`): the IPC route stays registered and every request REJECTS with the
+ * reason that names the shape. No envelope is minted — the wire contract that would shape one is
+ * exactly what this boot does not load, and a hand-made envelope would fail the renderer's inspection
+ * as "malformed" (a lie: it is absent). A rejection reaches the bridge as its closed transport failure,
+ * which is the truth — there is no transport — while the reason stays readable on the IPC error and
+ * in the shell log. Sender trust is checked first, exactly like the real capability's.
+ * @param {Object} options
+ * @param {Function} options.isTrustedSender Validates a real Electron IPC event.
+ * @param {String} options.reason Names the boot shape that has no transport.
+ * @returns {{request: Function}}
+ */
+export function createAbsentFleetCapability({isTrustedSender, reason}) {
+    if (typeof isTrustedSender !== 'function' || typeof reason !== 'string' || !reason) {
+        throw new TypeError('createAbsentFleetCapability requires isTrustedSender and the reason that names the shell shape')
+    }
+
+    return {
+        async request(event) {
+            throw new Error(isTrustedSender(event) ? reason : 'fleet: untrusted shell sender')
+        }
+    }
+}
+
+/**
  * @summary Creates the Electron-main owner for Fleet IPC. Sender trust and request shape are checked
  * before Brain readiness or network access; the bearer is attached only here, and every reply is
  * positively censused against both the bearer and (for Add-Peer) the submitted credential.

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -24,7 +24,7 @@ import {
     computeFirstPaintVerdict
 } from './adapterWitness.mjs';
 import {createAppLifecycle}    from './appLifecycle.mjs';
-import {createFleetCapability} from './fleetCapability.mjs';
+import {createAbsentFleetCapability, createFleetCapability} from './fleetCapability.mjs';
 import {
     APP_HOST,
     CONTENT_SECURITY_POLICY,
@@ -48,7 +48,7 @@ import {
     probePort,
     registerOwnedChild,
     resolveBrainMode,
-    resolveAgentOsRuntimeRoot,
+    resolveLauncherRuntimeRoot,
     resolveUiFleetTransport,
     resolveBrainPaths,
     resolveProductBrainPlan,
@@ -64,10 +64,8 @@ const
     repoRoot             = path.resolve(harnessDir, '..'),
     packagedMode         = app.isPackaged,
     packagedOrganismRoot = packagedMode ? path.join(process.resourcesPath, 'organism') : null,
-    // Renderer assets stay product-owned. Brain executables resolve through their own explicit
-    // runtime root in checkout mode; the packaged artifact supplies one assembled organism root.
+    // Renderer assets stay product-owned.
     productRoot           = packagedMode ? packagedOrganismRoot : repoRoot,
-    agentosRuntimeRoot    = packagedMode ? packagedOrganismRoot : resolveAgentOsRuntimeRoot(),
     // DEV MODE, deliberately (operator decision 2026-07-10): the harness window loads the
     // zero-build SOURCE app — Neural Link possession needs real ESM, which minification destroys.
     APP_URL      = `app://${APP_HOST}/apps/agentos/index.html`,
@@ -78,10 +76,15 @@ const
     // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
     // on a checkout (dev machines carry a canonical Brain; see brain.mjs#resolveBrainMode).
     brainMode             = resolveBrainMode({env: process.env, packaged: packagedMode}),
-    fleetRuntimeContracts = await loadFleetRuntimeContracts(agentosRuntimeRoot),
+    // Brain executables resolve through their own explicit runtime root in checkout mode; the
+    // packaged artifact supplies one assembled organism root; a checkout with the Brain leg OFF and
+    // no root boots as the UI alone — no root, no contracts, no transport (the resolver's rule).
+    agentosRuntimeRoot    = resolveLauncherRuntimeRoot({brainMode, env: process.env, packaged: packagedMode, packagedOrganismRoot}),
+    fleetRuntimeContracts = agentosRuntimeRoot ? await loadFleetRuntimeContracts(agentosRuntimeRoot) : null,
     // ONE main-owned secret per Electron boot. It crosses only into the Fleet child environment
     // and main-process Authorization headers; preload/renderer/App-Worker receive no getter or byte.
-    fleetBearerToken = fleetRuntimeContracts.resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}),
+    // `null` when this boot carries no transport: nothing to protect, nothing to censor.
+    fleetBearerToken = fleetRuntimeContracts ? fleetRuntimeContracts.resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}) : null,
     smokeState       = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
@@ -163,7 +166,7 @@ function recordSmokeFailure(type, details) {
 
     const
         raw           = String(details?.message ?? details ?? 'unknown'),
-        containsToken = raw.includes(fleetBearerToken),
+        containsToken = fleetBearerToken !== null && raw.includes(fleetBearerToken),
         message       = `${type}: ${containsToken ? '[secret-bearing detail redacted]' : raw.slice(0, 500)}`;
 
     containsToken && smokeState.secretLeaks.add(type);
@@ -440,21 +443,27 @@ h1{font-size:20px;margin:0 0 16px}p{color:#b9c4d8;margin:8px 0}.hint{color:#8ea4
 
 // The handler closures own the only renderer→Fleet route in the packaged topology. The Brain
 // promise is read at call time so an early-rendering UI receives a named not-ready envelope while a
-// later call joins the exact boot the lifecycle owner retained.
-const fleetCapability = createFleetCapability({
-    bearerToken        : fleetBearerToken,
-    createWireOffer    : fleetRuntimeContracts.createFleetWireOffer,
-    createWireRequest  : fleetRuntimeContracts.createFleetWireRequest,
-    createWireResponse : fleetRuntimeContracts.createFleetWireResponse,
-    credentialMethods  : fleetRuntimeContracts.FLEET_CREDENTIAL_METHODS,
-    credentialProvider : promptFleetCredential,
-    getBrain           : () => brainBootPromise,
-    inspectWireResponse: fleetRuntimeContracts.inspectFleetWireResponse,
-    isTrustedSender    : isTrustedIpcSender,
-    onAdmitted         : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method),
-    responseStates     : fleetRuntimeContracts.FLEET_WIRE_RESPONSE_STATES,
-    wireMethods        : fleetRuntimeContracts.FLEET_WIRE_METHODS
-});
+// later call joins the exact boot the lifecycle owner retained. A boot without a Brain root keeps
+// the route registered and rejects every request with the named reason — never a missing handler.
+const fleetCapability = fleetRuntimeContracts
+    ? createFleetCapability({
+        bearerToken        : fleetBearerToken,
+        createWireOffer    : fleetRuntimeContracts.createFleetWireOffer,
+        createWireRequest  : fleetRuntimeContracts.createFleetWireRequest,
+        createWireResponse : fleetRuntimeContracts.createFleetWireResponse,
+        credentialMethods  : fleetRuntimeContracts.FLEET_CREDENTIAL_METHODS,
+        credentialProvider : promptFleetCredential,
+        getBrain           : () => brainBootPromise,
+        inspectWireResponse: fleetRuntimeContracts.inspectFleetWireResponse,
+        isTrustedSender    : isTrustedIpcSender,
+        onAdmitted         : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method),
+        responseStates     : fleetRuntimeContracts.FLEET_WIRE_RESPONSE_STATES,
+        wireMethods        : fleetRuntimeContracts.FLEET_WIRE_METHODS
+    })
+    : createAbsentFleetCapability({
+        isTrustedSender: isTrustedIpcSender,
+        reason         : 'fleet: this shell boots without a Brain root (NEO_HARNESS_BRAIN is off and NEO_AGENTOS_RUNTIME_ROOT is unset) — no Fleet transport in this boot'
+    });
 
 /**
  * @summary Reduces an untrusted boot-report payload to its allowlisted primitive fields.
@@ -726,7 +735,7 @@ async function invokeFleetFromWindow(win, request, timeoutMs = 8000) {
         }), timeoutMs))
     ]);
 
-    if (JSON.stringify(reply).includes(fleetBearerToken)) {
+    if (fleetBearerToken !== null && JSON.stringify(reply).includes(fleetBearerToken)) {
         smokeState.secretLeaks.add('ipc-reply');
         return {
             envelope : {error: 'secret-bearing reply rejected by smoke census', ok: false},
@@ -861,7 +870,7 @@ process.on('unhandledRejection', async error => {
 const brainState = {children: [], isolationRoot: null};
 
 function brainLog(line) {
-    if (line.includes(fleetBearerToken)) {
+    if (fleetBearerToken !== null && line.includes(fleetBearerToken)) {
         smokeState.secretLeaks.add('brain-log');
         console.log('HARNESS_BRAIN [secret-bearing line redacted]')
     } else {
@@ -1177,8 +1186,10 @@ app.whenReady().then(async () => {
     // The banner fact enters 'starting' exactly when a transport boot is actually in flight —
     // brain mode boots the organism's fleet leg, UI-only product self-supplies. Plain UI-only
     // smoke spawns nothing by isolation contract and keeps `null`: no transport story to tell.
-    if (brainMode || !diagnosticMode) {
+    if (brainMode || (!diagnosticMode && agentosRuntimeRoot)) {
         uiTransportFact = {phase: 'starting'}
+    } else if (!diagnosticMode) {
+        console.log('HARNESS_UI_FLEET none — no Brain root in this boot: the shell runs as the UI alone')
     }
 
     brainBootPromise = brainMode
@@ -1192,9 +1203,10 @@ app.whenReady().then(async () => {
                 uiTransportFact = normalizeTransportFact(boot);
                 return boot
             })
-        : (diagnosticMode
+        : (diagnosticMode || !agentosRuntimeRoot
             // Plain smoke keeps its isolation contract: UI-only legs spawn nothing (a dev machine
-            // may carry a live transport); the fleet leg's evidence lives in smoke:brain.
+            // may carry a live transport); the fleet leg's evidence lives in smoke:brain. A checkout
+            // without a Brain root has nothing to self-supply from: the UI alone, no transport story.
             ? Promise.resolve(null)
             // UI-only product path: self-supply the transport. Tray Brain state is deliberately
             // untouched — a fleet transport is not a Brain claim.
@@ -1331,7 +1343,7 @@ app.whenReady().then(async () => {
                     JSON.stringify(probe.shellKeys) === JSON.stringify(expectedShellKeys)
                 ),
                 urlSecretFree     = BrowserWindow.getAllWindows().every(win =>
-                    !win.webContents.getURL().includes(fleetBearerToken)
+                    fleetBearerToken === null || !win.webContents.getURL().includes(fleetBearerToken)
                 );
 
             fleetFromWindow = {

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -25,6 +25,7 @@ import {builtinModules}                             from 'node:module';
 import path                                         from 'node:path';
 import {fileURLToPath}                              from 'node:url';
 import {parse}                                      from 'acorn';
+import {resolveAgentOsRuntimeRoot}                  from './brain.mjs';
 import {ALLOWED_EXACT_PATHS, ALLOWED_PATH_PREFIXES} from './contentPolicy.mjs';
 
 const
@@ -35,8 +36,8 @@ export const STAGE_DIR = path.join(harnessDir, '.stage', 'organism');
 
 // Runtime trees the renderer allowlist cannot know about: the Brain, plus the single buildScripts
 // module its entrypoints import (shipping the whole util dir would drag lint-tooling deps into the
-// organism manifest). node_modules-prefixed allowlist entries are NOT copied — they come from the
-// staged dependency install.
+// organism manifest). Both resolve against the BRAIN root, never this checkout. node_modules-prefixed
+// allowlist entries are NOT copied — they come from the staged dependency install.
 export const BRAIN_TREES = Object.freeze([
     'ai'
 ]);
@@ -54,6 +55,11 @@ export const TREE_EXCLUDES = Object.freeze([
     'ai/daemons/temporal-summary',
     'ai/scripts/diagnostics/genesisProbe.mjs'
 ]);
+
+// The theme builder the stage runs before copying `dist/development/css`: an ENGINE-package script
+// (the product's own `build-themes` is the same path), resolved inside the pinned install — the
+// product root carries no buildScripts/build of its own since the split.
+export const ENGINE_THEME_BUILD = 'buildScripts/build/themes.mjs';
 
 /**
  * @summary True when a repo-relative path is a checkout-instance CONFIG OVERLAY — a `config.mjs`
@@ -116,13 +122,14 @@ export const OPTIONAL_LAZY_PACKAGES = Object.freeze([
 ]);
 
 /**
- * @summary Derives the filesystem trees/files to stage from the renderer allowlist (URL-path
- * form) + the Brain set. One authority: a new allowlist prefix automatically ships.
- * @returns {{trees: String[], files: String[]}} repo-relative copy specs.
+ * @summary Derives the copy specs per OWNER: the renderer's source graph from the allowlist (URL-path
+ * form, product-root-relative) and the Brain set (Brain-root-relative). One authority each: a new
+ * allowlist prefix ships automatically; the Brain set is the two constants above.
+ * @returns {{brain: {files: String[], trees: String[]}, product: {files: String[], trees: String[]}}}
  */
 export function deriveCopySpecs() {
     const
-        trees = new Set(BRAIN_TREES),
+        trees = new Set(),
         files = new Set();
 
     for (const prefix of ALLOWED_PATH_PREFIXES) {
@@ -137,9 +144,48 @@ export function deriveCopySpecs() {
         }
     }
 
-    BRAIN_FILES.forEach(file => files.add(file));
+    return {
+        brain  : {files: [...BRAIN_FILES], trees: [...BRAIN_TREES]},
+        product: {files: [...files].sort(), trees: [...trees].sort()}
+    }
+}
 
-    return {files: [...files].sort(), trees: [...trees].sort()}
+/**
+ * @summary Resolves the three owners the stage assembles from, and proves each BEFORE anything is
+ * mutated: the PRODUCT root (this checkout — the renderer graph and its `package.json`), the ENGINE
+ * package (the pinned `neo.mjs` install inside it), and the BRAIN root (`NEO_AGENTOS_RUNTIME_ROOT`,
+ * absolute by the one runtime-root contract in brain.mjs — never a cwd or sibling guess). A missing
+ * or relative Brain authority, or a root without its markers, throws here: no stage dir removed, no
+ * theme built, nothing installed.
+ * @param {Object} [options]
+ * @param {Object} [options.env=process.env]
+ * @param {String} [options.productRoot] Defaults to this checkout.
+ * @returns {{brainRoot: String, enginePackageRoot: String, productRoot: String}}
+ */
+export function resolvePackRoots({env = process.env, productRoot = repoRoot} = {}) {
+    const
+        resolvedProduct   = path.resolve(productRoot),
+        enginePackageRoot = path.join(resolvedProduct, 'node_modules', 'neo.mjs'),
+        brainRoot         = resolveAgentOsRuntimeRoot(env),
+        owners            = [
+            ['product',        resolvedProduct,   ['apps/agentos', 'package.json']],
+            ['engine package', enginePackageRoot, ['package.json', ENGINE_THEME_BUILD]],
+            ['brain',          brainRoot,         ['package.json', ...BRAIN_TREES, ...BRAIN_FILES]]
+        ];
+
+    for (const [owner, root, markers] of owners) {
+        for (const marker of markers) {
+            if (!fs.existsSync(path.join(root, marker))) {
+                throw new Error(`pack: the ${owner} root ${root} carries no ${marker} — refusing to stage`)
+            }
+        }
+    }
+
+    return {brainRoot, enginePackageRoot, productRoot: resolvedProduct}
+}
+
+function readPackageJson(root) {
+    return JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
 }
 
 // npm package-name shape — rejects non-package specifiers before manifest projection.
@@ -268,23 +314,33 @@ export function collectTreeBarePackages({rootDir}) {
 
 /**
  * @summary Builds the organism's dependency manifest: every scanned bare package pinned to the
- * version the repo declares — under `devDependencies` of EITHER install-tier manifest. The root
- * `package.json` is no longer the whole authority since the tier split: the Brain runtime the
- * organism ships (Memory Core's `better-sqlite3`, the `chromadb` client) is declared in
- * `package.brain.json`, and a scan that cannot see it hard-errors exactly where a broken
- * artifact would otherwise ship. An import with NO declared version in either tier is a hard
- * error: the checkout would have failed too, and silence here would ship a broken artifact.
+ * version one of the two owners declares. The PRODUCT `package.json` declares the renderer graph's
+ * closure (the pinned Engine among it); the BRAIN root's `package.json` is the runtime tier the
+ * organism ships (Memory Core's `better-sqlite3`, the `chromadb` client) — required, never optional:
+ * a scan that cannot see it hard-errors exactly where a broken artifact would otherwise ship. Both
+ * tiers of each manifest count, and on a name both owners declare the product's pin wins (the Engine
+ * is the product's dependency). An import with NO declared version in either owner is a hard error:
+ * the checkout would have failed too, and silence here would ship a broken artifact.
  * @param {Object} options
  * @param {String[]} options.packages Scanned package names.
- * @param {Object} options.repoPackageJson Parsed repo package.json.
- * @param {Object} [options.brainPackageJson] Parsed repo package.brain.json (Brain-tier authority).
+ * @param {Object} options.productPackageJson Parsed product package.json.
+ * @param {Object} options.brainPackageJson Parsed Brain-root package.json.
  * @param {String[]} [options.supplemental=SUPPLEMENTAL_DEPENDENCIES]
  * @param {String[]} [options.optionalLazy=OPTIONAL_LAZY_PACKAGES]
- * @returns {Object} `{name, private, dependencies}` — the staged package.json.
+ * @returns {Object} `{name, private, type, version, dependencies}` — the staged package.json.
  */
-export function buildOrganismManifest({packages, repoPackageJson, brainPackageJson = null, supplemental = SUPPLEMENTAL_DEPENDENCIES, optionalLazy = OPTIONAL_LAZY_PACKAGES}) {
+export function buildOrganismManifest({packages, productPackageJson, brainPackageJson, supplemental = SUPPLEMENTAL_DEPENDENCIES, optionalLazy = OPTIONAL_LAZY_PACKAGES}) {
+    if (!productPackageJson || !brainPackageJson) {
+        throw new Error('organism manifest: the product package.json and the Brain package.json are both required dependency authorities')
+    }
+
     const
-        declared     = {...repoPackageJson.dependencies, ...repoPackageJson.devDependencies, ...brainPackageJson?.devDependencies},
+        declared     = {
+            ...brainPackageJson.devDependencies,
+            ...brainPackageJson.dependencies,
+            ...productPackageJson.devDependencies,
+            ...productPackageJson.dependencies
+        },
         dependencies = {},
         missing      = [];
 
@@ -305,7 +361,25 @@ export function buildOrganismManifest({packages, repoPackageJson, brainPackageJs
         name   : 'neo-harness-organism',
         private: true,
         type   : 'module',
-        version: repoPackageJson.version ?? '0.0.0'
+        version: productPackageJson.version ?? '0.0.0'
+    }
+}
+
+/**
+ * @summary The packaged-runtime import closure, verified after the install: every package the
+ * manifest pins resolves inside the stage's own `node_modules`. npm reports an optional or
+ * platform-skipped package as a warning at most — a stranger's double-click would find out at the
+ * first import instead.
+ * @param {Object} options
+ * @param {Object} options.manifest The staged package.json.
+ * @param {String} options.stageDir
+ */
+export function assertImportClosure({manifest, stageDir}) {
+    const missing = Object.keys(manifest.dependencies)
+        .filter(name => !fs.existsSync(path.join(stageDir, 'node_modules', name, 'package.json')));
+
+    if (missing.length > 0) {
+        throw new Error(`pack: the staged install lacks pinned package(s): ${missing.join(', ')}`)
     }
 }
 
@@ -347,23 +421,45 @@ function copyTree(sourceRoot, targetRoot, relative) {
     })
 }
 
+function copyFile(sourceRoot, targetRoot, relative) {
+    const source = path.join(sourceRoot, relative);
+
+    if (!fs.existsSync(source)) {
+        throw new Error(`pack: staged file missing in ${sourceRoot}: ${relative}`)
+    }
+
+    fs.mkdirSync(path.dirname(path.join(targetRoot, relative)), {recursive: true});
+    fs.copyFileSync(source, path.join(targetRoot, relative))
+}
+
 function run(command, args, options = {}) {
     execFileSync(command, args, {stdio: 'inherit', ...options})
 }
 
 /**
- * @summary Stages the complete organism: trees + files (allowlist-derived), generated dependency
- * manifest + install, the @electron/rebuild attempt (falsifier-gated arm), the pack-time-fresh
- * instance config, and the node shim. Idempotent: the stage dir is rebuilt from scratch.
+ * @summary Stages the complete organism from its three owners: the product graph (allowlist-derived)
+ * and the Brain set (from the explicit Brain root), the generated dependency manifest + install with
+ * its verified closure, the @electron/rebuild attempt (falsifier-gated arm), the pack-time-fresh
+ * instance config, and the node shim. Idempotent: the stage dir is rebuilt from scratch — but only
+ * once every owner is proven, so a missing authority never leaves a half-staged tree behind.
  * @param {Object} [options]
- * @param {String} [options.stageDir=STAGE_DIR]
  * @param {String} [options.electronVersion] Version for @electron/rebuild (harness devDep pin).
+ * @param {Object} [options.env=process.env] Carries `NEO_AGENTOS_RUNTIME_ROOT`, the Brain authority.
+ * @param {String} [options.productRoot] Defaults to this checkout.
+ * @param {String} [options.stageDir=STAGE_DIR]
  * @returns {Object} build info (also written to `<stageDir>/organism-build-info.json`).
  */
-export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
+export function stageOrganism({electronVersion, env = process.env, productRoot = repoRoot, stageDir = STAGE_DIR} = {}) {
     if (!electronVersion) {
         throw new Error('pack: electronVersion is required — the staged natives MUST target the bundled runtime ABI.')
     }
+
+    const
+        roots              = resolvePackRoots({env, productRoot}),
+        productPackageJson = readPackageJson(roots.productRoot),
+        enginePackageJson  = readPackageJson(roots.enginePackageRoot),
+        brainPackageJson   = readPackageJson(roots.brainRoot),
+        {brain, product}   = deriveCopySpecs();
 
     fs.rmSync(stageDir, {force: true, recursive: true});
     fs.mkdirSync(stageDir, {recursive: true});
@@ -373,40 +469,43 @@ export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
     // (live incident: a theming merge landed after the last local theme build). The artifact
     // never trusts checkout state — it rebuilds.
     console.log('[pack] building dev themes from current SCSS');
-    run('node', ['buildScripts/build/themes.mjs', '-f', '-n', '-e', 'dev', '-t', 'all'], {cwd: repoRoot});
+    run('node', [path.join(roots.enginePackageRoot, ENGINE_THEME_BUILD), '-f', '-n', '-e', 'dev', '-t', 'all'], {cwd: roots.productRoot});
 
-    const {files, trees} = deriveCopySpecs();
-
-    for (const tree of trees) {
-        copyTree(repoRoot, stageDir, tree)
-    }
-
-    for (const file of files) {
-        fs.mkdirSync(path.dirname(path.join(stageDir, file)), {recursive: true});
-        fs.copyFileSync(path.join(repoRoot, file), path.join(stageDir, file))
-    }
+    product.trees.forEach(tree => copyTree(roots.productRoot, stageDir, tree));
+    product.files.forEach(file => copyFile(roots.productRoot, stageDir, file));
+    brain.trees.forEach(tree => copyTree(roots.brainRoot, stageDir, tree));
+    brain.files.forEach(file => copyFile(roots.brainRoot, stageDir, file));
 
     // Security stop-line: no checkout instance overlay may exist in the stage BEFORE the fresh
     // template-defaults generation below. Runs pre-install so the walk stays cheap.
     assertNoInstanceOverlays(stageDir);
 
     const
-        repoPackageJson  = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
-        brainPath        = path.join(repoRoot, 'package.brain.json'),
-        brainPackageJson = fs.existsSync(brainPath) ? JSON.parse(fs.readFileSync(brainPath, 'utf8')) : null,
-        packages         = [...new Set(trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort(),
-        manifest         = buildOrganismManifest({packages, repoPackageJson, brainPackageJson});
+        trees    = [...product.trees, ...brain.trees],
+        packages = [...new Set(trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort(),
+        manifest = buildOrganismManifest({brainPackageJson, packages, productPackageJson});
 
     fs.writeFileSync(path.join(stageDir, 'package.json'), JSON.stringify(manifest, null, 4), 'utf8');
 
-    console.log(`[pack] staged ${trees.length} trees + ${files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
+    console.log(`[pack] staged ${trees.length} trees + ${product.files.length + brain.files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
     run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {cwd: stageDir});
+    assertImportClosure({manifest, stageDir});
 
     // Mandatory ABI targeting: the staged natives rebuild for the bundled Electron. Failure fails
     // the build — a catch-and-ship here is a silently-broken-artifact vector.
     run('npx', ['@electron/rebuild', '--module-dir', stageDir, '--version', electronVersion], {cwd: harnessDir});
 
-    const buildInfo = {electronVersion, rebuilt: true, stagedAt: new Date().toISOString()};
+    const buildInfo = {
+        electronVersion,
+        rebuilt : true,
+        // the owners this artifact was assembled from — the provenance a reader of the bundle needs
+        roots   : {
+            brain  : {name: brainPackageJson.name, root: roots.brainRoot, version: brainPackageJson.version},
+            engine : {pin: productPackageJson.dependencies?.['neo.mjs'] ?? null, version: enginePackageJson.version},
+            product: {name: productPackageJson.name, root: roots.productRoot, version: productPackageJson.version}
+        },
+        stagedAt: new Date().toISOString()
+    };
 
     // Pack-time-fresh instance config: template-current by construction, so the packaged first
     // boot never needs to WRITE into the (possibly read-only, translocated) resources dir.

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -296,29 +296,24 @@ export function extractBarePackages(source) {
 }
 
 /**
- * @summary Walks the staged runtime trees and collects every bare package import.
+ * @summary Collects every bare package import of an explicit FILE SET — the files one owner copied,
+ * never a directory walk: both owners land a `src/` in the stage, and walking the merged directory
+ * would credit every import in it to both owners (a Brain-only import declared by the Brain alone
+ * would then read as missing for the product, and the reverse). Non-script files are skipped.
  * @param {Object} options
- * @param {String} options.rootDir Directory whose `.mjs`/`.cjs`/`.js` files are scanned.
- * @returns {String[]} unique package names across the tree.
+ * @param {String[]} options.files Stage-relative paths.
+ * @param {String} options.rootDir The stage.
+ * @returns {String[]} unique package names across the set.
  */
-export function collectTreeBarePackages({rootDir}) {
+export function collectBarePackages({files, rootDir}) {
     const packages = new Set();
 
-    const walk = dir => {
-        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
-            const fullPath = path.join(dir, entry.name);
-
-            if (entry.isDirectory()) {
-                if (entry.name !== 'node_modules' && entry.name !== '.git') {
-                    walk(fullPath)
-                }
-            } else if (/\.(mjs|cjs|js)$/.test(entry.name)) {
-                extractBarePackages(fs.readFileSync(fullPath, 'utf8')).forEach(name => packages.add(name))
-            }
+    for (const file of files) {
+        if (/\.(mjs|cjs|js)$/.test(file)) {
+            extractBarePackages(fs.readFileSync(path.join(rootDir, file), 'utf8')).forEach(name => packages.add(name))
         }
-    };
+    }
 
-    walk(rootDir);
     return [...packages].sort()
 }
 
@@ -539,8 +534,11 @@ export function buildNodeShim() {
 
 // Two owners may share a directory in the stage (both carry a `src/`), never a file: an existing
 // target is a collision between owners and fails the copy instead of letting the later one win.
+// Both copiers return the stage-relative files they placed — the owner's provenance for the scan.
 function copyTree(sourceRoot, targetRoot, relative) {
-    const source = path.join(sourceRoot, relative);
+    const
+        source = path.join(sourceRoot, relative),
+        copied = [];
 
     if (!fs.existsSync(source)) {
         throw new Error(`pack: staged tree missing in ${sourceRoot}: ${relative}`)
@@ -550,13 +548,17 @@ function copyTree(sourceRoot, targetRoot, relative) {
         fs.cpSync(source, path.join(targetRoot, relative), {
             errorOnExist: true,
             filter      : entry => {
-                const rel = path.relative(sourceRoot, entry);
+                const
+                    rel   = path.relative(sourceRoot, entry),
+                    ships = !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
+                        !isInstanceOverlayPath(sourceRoot, rel) &&
+                        !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
+                        !/(^|\/)\.env(\.|$)/.test(rel) &&
+                        !rel.endsWith('.DS_Store');
 
-                return !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
-                    !isInstanceOverlayPath(sourceRoot, rel) &&
-                    !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
-                    !/(^|\/)\.env(\.|$)/.test(rel) &&
-                    !rel.endsWith('.DS_Store')
+                ships && fs.statSync(entry).isFile() && copied.push(rel);
+
+                return ships
             },
             force    : false,
             recursive: true
@@ -568,6 +570,8 @@ function copyTree(sourceRoot, targetRoot, relative) {
 
         throw error
     }
+
+    return copied
 }
 
 function copyFile(sourceRoot, targetRoot, relative) {
@@ -584,7 +588,40 @@ function copyFile(sourceRoot, targetRoot, relative) {
     }
 
     fs.mkdirSync(path.dirname(target), {recursive: true});
-    fs.copyFileSync(source, target)
+    fs.copyFileSync(source, target);
+
+    return relative
+}
+
+/**
+ * @summary Copies every owner's set into the stage — the product's allowlist trees and files from
+ * the product root, the Brain's trees from the Brain root — and scans each owner's COPIED files for
+ * their bare imports. This is the boundary where provenance is kept: the merged stage cannot show
+ * which owner a file came from once both have landed a `src/`, so the scan reads the file sets the
+ * copiers returned, never the directory. The instance-overlay stop-line runs here too, before any
+ * fresh-config generation, while the walk is cheap.
+ * @param {Object} options
+ * @param {{brainRoot: String, productRoot: String}} options.roots Resolved by `resolvePackRoots`.
+ * @param {String} options.stageDir
+ * @returns {{copied: {brain: String[], product: String[]}, scanned: {brain: String[], product: String[]}}}
+ */
+export function stageOwners({roots, stageDir}) {
+    const
+        {brain, product} = deriveCopySpecs(),
+        copied           = {
+            brain  : brain.trees.flatMap(tree => copyTree(roots.brainRoot, stageDir, tree)),
+            product: [
+                ...product.trees.flatMap(tree => copyTree(roots.productRoot, stageDir, tree)),
+                ...product.files.map(file => copyFile(roots.productRoot, stageDir, file))
+            ]
+        };
+
+    assertNoInstanceOverlays(stageDir);
+
+    return {
+        copied,
+        scanned: Object.fromEntries(Object.entries(copied).map(([owner, files]) => [owner, collectBarePackages({files, rootDir: stageDir})]))
+    }
 }
 
 function run(command, args, options = {}) {
@@ -626,25 +663,13 @@ export function stageOrganism({electronVersion, env = process.env, productRoot =
     console.log('[pack] building dev themes from current SCSS');
     run('node', [path.join(roots.enginePackageRoot, ENGINE_THEME_BUILD), '-f', '-n', '-e', 'dev', '-t', 'all'], {cwd: roots.productRoot});
 
-    product.trees.forEach(tree => copyTree(roots.productRoot, stageDir, tree));
-    product.files.forEach(file => copyFile(roots.productRoot, stageDir, file));
-    brain.trees.forEach(tree => copyTree(roots.brainRoot, stageDir, tree));
-
-    // Security stop-line: no checkout instance overlay may exist in the stage BEFORE the fresh
-    // template-defaults generation below. Runs pre-install so the walk stays cheap.
-    assertNoInstanceOverlays(stageDir);
-
-    // Each owner's trees are scanned on their own, so every import keeps the owner that stages it.
     const
-        scanned  = Object.fromEntries(Object.entries({brain, product}).map(([owner, specs]) => [
-            owner,
-            [...new Set(specs.trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort()
-        ])),
-        manifest = buildOrganismManifest({brainPackageJson, productPackageJson, scanned});
+        {copied, scanned} = stageOwners({roots, stageDir}),
+        manifest          = buildOrganismManifest({brainPackageJson, productPackageJson, scanned});
 
     fs.writeFileSync(path.join(stageDir, 'package.json'), JSON.stringify(manifest, null, 4), 'utf8');
 
-    console.log(`[pack] staged ${product.trees.length + brain.trees.length} trees + ${product.files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
+    console.log(`[pack] staged ${copied.product.length} product + ${copied.brain.length} Brain files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
     run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {cwd: stageDir});
 
     // Mandatory ABI targeting: the staged natives rebuild for the bundled Electron. Failure fails

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -445,7 +445,8 @@ export function assertImportClosure({manifest, stageDir, trees = []}) {
         }
     };
 
-    trees.forEach(tree => walk(path.join(stageDir, tree)));
+    // two owners may name the same stage path (both carry a `src/`): walk it once
+    [...new Set(trees)].forEach(tree => walk(path.join(stageDir, tree)));
 
     if (missing.length > 0) {
         throw new Error(`pack: the staged install lacks pinned package(s): ${missing.join(', ')}`)
@@ -454,6 +455,40 @@ export function assertImportClosure({manifest, stageDir, trees = []}) {
     if (dangling.length > 0) {
         throw new Error(`pack: staged module(s) import outside the stage: ${dangling.join(', ')}`)
     }
+}
+
+/**
+ * @summary Materializes every instance-overlay slot the copy filter left empty: a staged
+ * `config.template.mjs` whose `config.mjs` sibling is absent gets the template as its pack-time-fresh
+ * instance — the same DERIVED rule the exclusion uses, so a slot the Brain's own setup script does
+ * not know (its `src/evolution/config.mjs`, for one) still ships template-current. A slot the setup
+ * script already filled is left alone.
+ * @param {Object} options
+ * @param {String} options.stageDir
+ * @param {String[]} options.trees Stage-relative trees to walk.
+ * @returns {String[]} the stage-relative configs written.
+ */
+export function materializeOverlaySlots({stageDir, trees}) {
+    const written = [];
+
+    const walk = dir => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (entry.name !== 'node_modules' && entry.name !== '.git') {
+                    walk(fullPath)
+                }
+            } else if (entry.name === 'config.template.mjs' && !fs.existsSync(path.join(dir, 'config.mjs'))) {
+                fs.copyFileSync(fullPath, path.join(dir, 'config.mjs'));
+                written.push(path.relative(stageDir, path.join(dir, 'config.mjs')))
+            }
+        }
+    };
+
+    [...new Set(trees)].forEach(tree => walk(path.join(stageDir, tree)));
+
+    return written.sort()
 }
 
 /**
@@ -624,11 +659,18 @@ export function stageOrganism({electronVersion, env = process.env, productRoot =
     };
 
     // Pack-time-fresh instance config: template-current by construction, so the packaged first
-    // boot never needs to WRITE into the (possibly read-only, translocated) resources dir.
+    // boot never needs to WRITE into the (possibly read-only, translocated) resources dir. The
+    // Brain's setup script fills the slots it knows; the derived pass fills the rest.
     run('node', ['ai/scripts/setup/initServerConfigs.mjs'], {cwd: stageDir});
 
-    // The closure is checked on the COMPLETE stage: the generated configs above are import targets.
-    assertImportClosure({manifest, stageDir, trees: [...product.trees, ...brain.trees]});
+    const
+        trees    = [...product.trees, ...brain.trees],
+        filled   = materializeOverlaySlots({stageDir, trees});
+
+    filled.length && console.log(`[pack] materialized ${filled.length} overlay slot(s) the setup script left empty: ${filled.join(', ')}`);
+
+    // The closure is checked on the COMPLETE stage: the configs above are import targets.
+    assertImportClosure({manifest, stageDir, trees});
 
     const shimsDir = path.join(stageDir, 'shims');
 

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -1,10 +1,10 @@
 // The E6 pack stage: materializes the ORGANISM the packaged shell ships — the renderer's source
-// graph (derived from the contentPolicy allowlist, one authority), the Brain tree, a generated
-// dependency manifest (this repo declares ONLY devDependencies, so the runtime closure is derived
-// from the bundled trees' bare imports), a pack-time-fresh instance config (killing the first-boot
-// write into a possibly read-only resources dir), and a `node` shim so shebang children (the
-// chroma CLI) run on the bundled Electron runtime via ELECTRON_RUN_AS_NODE — a stranger's machine
-// carries no Node.
+// graph (derived from the contentPolicy allowlist, one authority) from the product root, the Brain
+// tree from the explicit Brain root, a generated dependency manifest (each staged tree's bare
+// imports, pinned by the owner that stages it — the product's package.json for the renderer graph,
+// the Brain root's for `ai/`), a pack-time-fresh instance config (killing the first-boot write into
+// a possibly read-only resources dir), and a `node` shim so shebang children (the chroma CLI) run
+// on the bundled Electron runtime via ELECTRON_RUN_AS_NODE — a stranger's machine carries no Node.
 //
 // Shell-ADR bindings implemented here (§2.5 — the E6 row):
 //   §2.5.1  one double-clickable artifact wrapping the organism; the packaging root owns it
@@ -34,25 +34,27 @@ const
 
 export const STAGE_DIR = path.join(harnessDir, '.stage', 'organism');
 
-// Runtime trees the renderer allowlist cannot know about: the Brain, plus the single buildScripts
-// module its entrypoints import (shipping the whole util dir would drag lint-tooling deps into the
-// organism manifest). Both resolve against the BRAIN root, never this checkout. node_modules-prefixed
-// allowlist entries are NOT copied — they come from the staged dependency install.
+// Runtime trees the renderer allowlist cannot know about: the Brain's `ai/` and its own `src/`
+// (composition, evolution — `ai/` imports it relatively). Both resolve against the BRAIN root, never
+// this checkout; the Engine modules the Brain imports bare (`neo.mjs/src/…`, its sanitizer among
+// them) come from the staged dependency install, like every node_modules-prefixed allowlist entry.
+// The Brain's `src/` lands beside the product's `src/` in the stage: distinct subtrees today, and a
+// same-path collision between the two owners fails the copy loud.
 export const BRAIN_TREES = Object.freeze([
-    'ai'
-]);
-
-export const BRAIN_FILES = Object.freeze([
-    'buildScripts/util/sanitizer.mjs'
+    'ai',
+    'src'
 ]);
 
 // Coordinates inside staged trees that are NOT runtime surface. Entries may name a subtree or one
-// exact file: demo/example apps carry demo deps; the temporal-summary daemon is not runtime-enabled;
-// and the Genesis probe is a checkout-only operator command whose browser runtime is supplied by
-// the checkout rather than the double-clickable organism. Runtime diagnostics stay staged.
+// exact file: demo/example apps carry demo deps; the temporal-summary daemon is not runtime-enabled
+// (its aggregation script imports it and goes with it — a staged importer of an excluded tree is a
+// dangling import); and the Genesis probe is a checkout-only operator command whose browser runtime
+// is supplied by the checkout rather than the double-clickable organism. Runtime diagnostics stay
+// staged.
 export const TREE_EXCLUDES = Object.freeze([
     'ai/examples',
     'ai/daemons/temporal-summary',
+    'ai/scripts/maintenance/aggregate-temporal-summary.mjs',
     'ai/scripts/diagnostics/genesisProbe.mjs'
 ]);
 
@@ -105,12 +107,20 @@ export function assertNoInstanceOverlays(stageDir) {
     }
 }
 
-// Dependencies the bare-import scan cannot see: CSS-linked packages (fontawesome) and
-// dynamic-provider modules resolved at runtime.
-export const SUPPLEMENTAL_DEPENDENCIES = Object.freeze([
-    '@chroma-core/default-embed',
-    '@fortawesome/fontawesome-free'
-]);
+// Dependencies the bare-import scan cannot see, each under the OWNER whose manifest declares it:
+// the CSS-linked fontawesome package (the product's allowlist serves its files) and the Chroma
+// embed provider the Brain resolves dynamically at runtime.
+export const SUPPLEMENTAL_DEPENDENCIES = Object.freeze({
+    brain  : Object.freeze(['@chroma-core/default-embed']),
+    product: Object.freeze(['@fortawesome/fontawesome-free'])
+});
+
+// Shared names with ONE declared owner, whichever tree imports them: the Engine is the product's
+// pin — the Brain checkout's own `neo.mjs` declaration never reaches the organism. Every other
+// name both owners declare must agree, or the pack fails loud (no silent precedence).
+export const OWNER_EXCEPTIONS = Object.freeze({
+    'neo.mjs': 'product'
+});
 
 // Lazily-imported packages on modes the packaged product never enters (the MCP shared transport's
 // HTTP/cloud leg) — ALSO phantom deps the repo never declares (they resolve transitively on dev
@@ -124,8 +134,8 @@ export const OPTIONAL_LAZY_PACKAGES = Object.freeze([
 /**
  * @summary Derives the copy specs per OWNER: the renderer's source graph from the allowlist (URL-path
  * form, product-root-relative) and the Brain set (Brain-root-relative). One authority each: a new
- * allowlist prefix ships automatically; the Brain set is the two constants above.
- * @returns {{brain: {files: String[], trees: String[]}, product: {files: String[], trees: String[]}}}
+ * allowlist prefix ships automatically; the Brain set is `BRAIN_TREES`.
+ * @returns {{brain: {trees: String[]}, product: {files: String[], trees: String[]}}}
  */
 export function deriveCopySpecs() {
     const
@@ -145,7 +155,7 @@ export function deriveCopySpecs() {
     }
 
     return {
-        brain  : {files: [...BRAIN_FILES], trees: [...BRAIN_TREES]},
+        brain  : {trees: [...BRAIN_TREES]},
         product: {files: [...files].sort(), trees: [...trees].sort()}
     }
 }
@@ -170,7 +180,7 @@ export function resolvePackRoots({env = process.env, productRoot = repoRoot} = {
         owners            = [
             ['product',        resolvedProduct,   ['apps/agentos', 'package.json']],
             ['engine package', enginePackageRoot, ['package.json', ENGINE_THEME_BUILD]],
-            ['brain',          brainRoot,         ['package.json', ...BRAIN_TREES, ...BRAIN_FILES]]
+            ['brain',          brainRoot,         ['package.json', ...BRAIN_TREES]]
         ];
 
     for (const [owner, root, markers] of owners) {
@@ -313,47 +323,81 @@ export function collectTreeBarePackages({rootDir}) {
 }
 
 /**
- * @summary Builds the organism's dependency manifest: every scanned bare package pinned to the
- * version one of the two owners declares. The PRODUCT `package.json` declares the renderer graph's
- * closure (the pinned Engine among it); the BRAIN root's `package.json` is the runtime tier the
- * organism ships (Memory Core's `better-sqlite3`, the `chromadb` client) — required, never optional:
- * a scan that cannot see it hard-errors exactly where a broken artifact would otherwise ship. Both
- * tiers of each manifest count, and on a name both owners declare the product's pin wins (the Engine
- * is the product's dependency). An import with NO declared version in either owner is a hard error:
- * the checkout would have failed too, and silence here would ship a broken artifact.
+ * @summary Builds the organism's dependency manifest with the PROVENANCE of every import kept: a
+ * package the product's trees import is pinned by the product `package.json`, one the Brain tree
+ * imports by the Brain root's `package.json` (both tiers of each), and a name both trees import
+ * must carry the SAME declaration in both owners — a disagreement fails the pack, never a silent
+ * precedence. `ownerExceptions` names the shared packages one owner governs outright (`neo.mjs`:
+ * the Engine is the product's pin). Both manifests are required: a scan that cannot see the Brain's
+ * hard-errors exactly where a broken artifact would otherwise ship. An import its own owner never
+ * declared is a hard error too — the checkout would have failed the same way.
  * @param {Object} options
- * @param {String[]} options.packages Scanned package names.
+ * @param {{brain: String[], product: String[]}} options.scanned Bare package names per staging owner.
  * @param {Object} options.productPackageJson Parsed product package.json.
  * @param {Object} options.brainPackageJson Parsed Brain-root package.json.
- * @param {String[]} [options.supplemental=SUPPLEMENTAL_DEPENDENCIES]
+ * @param {{brain: String[], product: String[]}} [options.supplemental=SUPPLEMENTAL_DEPENDENCIES]
  * @param {String[]} [options.optionalLazy=OPTIONAL_LAZY_PACKAGES]
+ * @param {Object} [options.ownerExceptions=OWNER_EXCEPTIONS]
  * @returns {Object} `{name, private, type, version, dependencies}` — the staged package.json.
  */
-export function buildOrganismManifest({packages, productPackageJson, brainPackageJson, supplemental = SUPPLEMENTAL_DEPENDENCIES, optionalLazy = OPTIONAL_LAZY_PACKAGES}) {
+export function buildOrganismManifest({
+    scanned,
+    productPackageJson,
+    brainPackageJson,
+    supplemental = SUPPLEMENTAL_DEPENDENCIES,
+    optionalLazy = OPTIONAL_LAZY_PACKAGES,
+    ownerExceptions = OWNER_EXCEPTIONS
+}) {
     if (!productPackageJson || !brainPackageJson) {
         throw new Error('organism manifest: the product package.json and the Brain package.json are both required dependency authorities')
     }
 
     const
-        declared     = {
-            ...brainPackageJson.devDependencies,
-            ...brainPackageJson.dependencies,
-            ...productPackageJson.devDependencies,
-            ...productPackageJson.dependencies
-        },
-        dependencies = {},
-        missing      = [];
+        manifests     = {brain: brainPackageJson, product: productPackageJson},
+        declaredBy    = owner => ({...manifests[owner].devDependencies, ...manifests[owner].dependencies}),
+        wanted        = Object.fromEntries(Object.keys(manifests).map(owner => [owner, new Set([...(scanned?.[owner] ?? []), ...(supplemental[owner] ?? [])])])),
+        names         = [...new Set(Object.values(wanted).flatMap(set => [...set]))].sort(),
+        dependencies  = {},
+        missing       = [],
+        disagreements = [];
 
-    for (const name of [...new Set([...packages, ...supplemental])].sort()) {
-        if (declared[name]) {
-            dependencies[name] = declared[name]
-        } else if (!optionalLazy.includes(name)) {
-            missing.push(name)
+    for (const name of names) {
+        const governing = ownerExceptions[name];
+
+        if (governing) {
+            const range = declaredBy(governing)[name];
+
+            range ? (dependencies[name] = range) : missing.push(`${name} (${governing})`);
+            continue
         }
+
+        const ranges = Object.keys(wanted)
+            .filter(owner => wanted[owner].has(name))
+            .map(owner => [owner, declaredBy(owner)[name]]);
+
+        ranges.filter(([, range]) => !range && !optionalLazy.includes(name))
+            .forEach(([owner]) => missing.push(`${name} (${owner})`));
+
+        const declared = ranges.filter(([, range]) => range);
+
+        if (declared.length === 0) {
+            continue
+        }
+
+        if (new Set(declared.map(([, range]) => range)).size > 1) {
+            disagreements.push(`${name}: ${declared.map(([owner, range]) => `${owner} ${range}`).join(' vs ')}`);
+            continue
+        }
+
+        dependencies[name] = declared[0][1]
     }
 
     if (missing.length > 0) {
         throw new Error(`organism manifest: no declared version for imported package(s): ${missing.join(', ')}`)
+    }
+
+    if (disagreements.length > 0) {
+        throw new Error(`organism manifest: the owners disagree on ${disagreements.join('; ')} — align the declarations or name a governing owner in OWNER_EXCEPTIONS`)
     }
 
     return {
@@ -366,20 +410,78 @@ export function buildOrganismManifest({packages, productPackageJson, brainPackag
 }
 
 /**
- * @summary The packaged-runtime import closure, verified after the install: every package the
- * manifest pins resolves inside the stage's own `node_modules`. npm reports an optional or
- * platform-skipped package as a warning at most — a stranger's double-click would find out at the
- * first import instead.
+ * @summary The packaged-runtime import closure, checked once the stage is complete (after the
+ * install AND the fresh config generation — the generated `config.mjs` files are import targets):
+ * every package the manifest pins is PRESENT under the stage's own `node_modules` (its package.json
+ * exists — package presence, not module resolution), and every RELATIVE import of a staged module
+ * resolves to a file inside the stage. npm reports an optional or platform-skipped package as a
+ * warning at most, and a tree copied without the sibling tree it imports looks complete on disk —
+ * a stranger's double-click would find out at the first import instead.
  * @param {Object} options
  * @param {Object} options.manifest The staged package.json.
  * @param {String} options.stageDir
+ * @param {String[]} [options.trees=[]] Stage-relative trees whose modules' relative imports are checked.
  */
-export function assertImportClosure({manifest, stageDir}) {
-    const missing = Object.keys(manifest.dependencies)
-        .filter(name => !fs.existsSync(path.join(stageDir, 'node_modules', name, 'package.json')));
+export function assertImportClosure({manifest, stageDir, trees = []}) {
+    const
+        missing  = Object.keys(manifest.dependencies)
+            .filter(name => !fs.existsSync(path.join(stageDir, 'node_modules', name, 'package.json'))),
+        dangling = [];
+
+    const walk = dir => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (entry.name !== 'node_modules' && entry.name !== '.git') {
+                    walk(fullPath)
+                }
+            } else if (/\.(mjs|cjs|js)$/.test(entry.name)) {
+                extractLiteralImportSpecifiers(fs.readFileSync(fullPath, 'utf8'))
+                    .filter(specifier => specifier.startsWith('./') || specifier.startsWith('../'))
+                    .filter(specifier => !fs.existsSync(path.resolve(dir, specifier)))
+                    .forEach(specifier => dangling.push(`${path.relative(stageDir, fullPath)} → ${specifier}`))
+            }
+        }
+    };
+
+    trees.forEach(tree => walk(path.join(stageDir, tree)));
 
     if (missing.length > 0) {
         throw new Error(`pack: the staged install lacks pinned package(s): ${missing.join(', ')}`)
+    }
+
+    if (dangling.length > 0) {
+        throw new Error(`pack: staged module(s) import outside the stage: ${dangling.join(', ')}`)
+    }
+}
+
+/**
+ * @summary The provenance the shipped artifact carries: role, package name, version, the Engine's
+ * pin and the Brain's revision — and NO build-host coordinate. The stage's `organism-build-info.json`
+ * rides `extraResources` verbatim, so an absolute checkout path written here would ship to every
+ * stranger's machine.
+ * @param {Object} options
+ * @param {Object} options.brainPackageJson
+ * @param {Object} options.enginePackageJson
+ * @param {Object} options.productPackageJson
+ * @param {{brainRoot: String}} options.roots Consulted for the Brain revision only; never recorded.
+ * @param {Function} [options.revisionOf=readRevision] `(root) => String|null`, injectable for tests.
+ * @returns {{brain: Object, engine: Object, product: Object}}
+ */
+export function describeOwners({brainPackageJson, enginePackageJson, productPackageJson, roots, revisionOf = readRevision}) {
+    return {
+        brain  : {name: brainPackageJson.name ?? null, revision: revisionOf(roots.brainRoot), version: brainPackageJson.version ?? null},
+        engine : {name: enginePackageJson.name ?? 'neo.mjs', pin: productPackageJson.dependencies?.['neo.mjs'] ?? null, version: enginePackageJson.version ?? null},
+        product: {name: productPackageJson.name ?? null, version: productPackageJson.version ?? null}
+    }
+}
+
+function readRevision(root) {
+    try {
+        return execFileSync('git', ['rev-parse', 'HEAD'], {cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']}).trim() || null
+    } catch {
+        return null
     }
 }
 
@@ -400,36 +502,54 @@ export function buildNodeShim() {
     ].join('\n')
 }
 
+// Two owners may share a directory in the stage (both carry a `src/`), never a file: an existing
+// target is a collision between owners and fails the copy instead of letting the later one win.
 function copyTree(sourceRoot, targetRoot, relative) {
     const source = path.join(sourceRoot, relative);
 
     if (!fs.existsSync(source)) {
-        throw new Error(`pack: staged tree missing in checkout: ${relative}`)
+        throw new Error(`pack: staged tree missing in ${sourceRoot}: ${relative}`)
     }
 
-    fs.cpSync(source, path.join(targetRoot, relative), {
-        filter: entry => {
-            const rel = path.relative(sourceRoot, entry);
+    try {
+        fs.cpSync(source, path.join(targetRoot, relative), {
+            errorOnExist: true,
+            filter      : entry => {
+                const rel = path.relative(sourceRoot, entry);
 
-            return !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
-                !isInstanceOverlayPath(sourceRoot, rel) &&
-                !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
-                !/(^|\/)\.env(\.|$)/.test(rel) &&
-                !rel.endsWith('.DS_Store')
-        },
-        recursive: true
-    })
+                return !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
+                    !isInstanceOverlayPath(sourceRoot, rel) &&
+                    !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
+                    !/(^|\/)\.env(\.|$)/.test(rel) &&
+                    !rel.endsWith('.DS_Store')
+            },
+            force    : false,
+            recursive: true
+        })
+    } catch (error) {
+        if (error?.code === 'ERR_FS_CP_EEXIST') {
+            throw new Error(`pack: two owners stage the same path under ${relative} — ${error.message}`)
+        }
+
+        throw error
+    }
 }
 
 function copyFile(sourceRoot, targetRoot, relative) {
-    const source = path.join(sourceRoot, relative);
+    const
+        source = path.join(sourceRoot, relative),
+        target = path.join(targetRoot, relative);
 
     if (!fs.existsSync(source)) {
         throw new Error(`pack: staged file missing in ${sourceRoot}: ${relative}`)
     }
 
-    fs.mkdirSync(path.dirname(path.join(targetRoot, relative)), {recursive: true});
-    fs.copyFileSync(source, path.join(targetRoot, relative))
+    if (fs.existsSync(target)) {
+        throw new Error(`pack: two owners stage the same path: ${relative}`)
+    }
+
+    fs.mkdirSync(path.dirname(target), {recursive: true});
+    fs.copyFileSync(source, target)
 }
 
 function run(command, args, options = {}) {
@@ -474,22 +594,23 @@ export function stageOrganism({electronVersion, env = process.env, productRoot =
     product.trees.forEach(tree => copyTree(roots.productRoot, stageDir, tree));
     product.files.forEach(file => copyFile(roots.productRoot, stageDir, file));
     brain.trees.forEach(tree => copyTree(roots.brainRoot, stageDir, tree));
-    brain.files.forEach(file => copyFile(roots.brainRoot, stageDir, file));
 
     // Security stop-line: no checkout instance overlay may exist in the stage BEFORE the fresh
     // template-defaults generation below. Runs pre-install so the walk stays cheap.
     assertNoInstanceOverlays(stageDir);
 
+    // Each owner's trees are scanned on their own, so every import keeps the owner that stages it.
     const
-        trees    = [...product.trees, ...brain.trees],
-        packages = [...new Set(trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort(),
-        manifest = buildOrganismManifest({brainPackageJson, packages, productPackageJson});
+        scanned  = Object.fromEntries(Object.entries({brain, product}).map(([owner, specs]) => [
+            owner,
+            [...new Set(specs.trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort()
+        ])),
+        manifest = buildOrganismManifest({brainPackageJson, productPackageJson, scanned});
 
     fs.writeFileSync(path.join(stageDir, 'package.json'), JSON.stringify(manifest, null, 4), 'utf8');
 
-    console.log(`[pack] staged ${trees.length} trees + ${product.files.length + brain.files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
+    console.log(`[pack] staged ${product.trees.length + brain.trees.length} trees + ${product.files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
     run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {cwd: stageDir});
-    assertImportClosure({manifest, stageDir});
 
     // Mandatory ABI targeting: the staged natives rebuild for the bundled Electron. Failure fails
     // the build — a catch-and-ship here is a silently-broken-artifact vector.
@@ -497,19 +618,17 @@ export function stageOrganism({electronVersion, env = process.env, productRoot =
 
     const buildInfo = {
         electronVersion,
+        owners  : describeOwners({brainPackageJson, enginePackageJson, productPackageJson, roots}),
         rebuilt : true,
-        // the owners this artifact was assembled from — the provenance a reader of the bundle needs
-        roots   : {
-            brain  : {name: brainPackageJson.name, root: roots.brainRoot, version: brainPackageJson.version},
-            engine : {pin: productPackageJson.dependencies?.['neo.mjs'] ?? null, version: enginePackageJson.version},
-            product: {name: productPackageJson.name, root: roots.productRoot, version: productPackageJson.version}
-        },
         stagedAt: new Date().toISOString()
     };
 
     // Pack-time-fresh instance config: template-current by construction, so the packaged first
     // boot never needs to WRITE into the (possibly read-only, translocated) resources dir.
     run('node', ['ai/scripts/setup/initServerConfigs.mjs'], {cwd: stageDir});
+
+    // The closure is checked on the COMPLETE stage: the generated configs above are import targets.
+    assertImportClosure({manifest, stageDir, trees: [...product.trees, ...brain.trees]});
 
     const shimsDir = path.join(stageDir, 'shims');
 

--- a/test/playwright/unit/harness/fleetCapability.spec.mjs
+++ b/test/playwright/unit/harness/fleetCapability.spec.mjs
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test';
 import {
+    createAbsentFleetCapability,
     createFleetCapability,
     projectPublicAgentIntent,
     projectPublicCredentialIntent
@@ -31,6 +32,22 @@ const createCapability = options => createFleetCapability({
 });
 
 test.describe('harness Fleet capability', () => {
+    // A checkout booted with the Brain leg off and no Brain root has no contract to build the real
+    // capability from; the route still answers — by rejecting with the reason that names the shape
+    // (never a hand-made envelope the renderer would read as malformed), sender trust first.
+    test('the absent capability rejects every request with the named reason, sender trust first', async () => {
+        const
+            reason     = 'fleet: this shell boots without a Brain root',
+            capability = createAbsentFleetCapability({isTrustedSender: event => event?.trusted === true, reason}),
+            request    = {method: 'listAgents', params: {}};
+
+        await expect(capability.request({trusted: true}, request)).rejects.toThrow(reason);
+        await expect(capability.request({trusted: false}, request)).rejects.toThrow('fleet: untrusted shell sender');
+
+        expect(() => createAbsentFleetCapability({isTrustedSender: null, reason})).toThrow(TypeError);
+        expect(() => createAbsentFleetCapability({isTrustedSender: () => true, reason: ''})).toThrow(TypeError)
+    });
+
     test('requires credential methods inside the wire allowlist and snapshots both inputs', async () => {
         expect(() => createCapability({
             credentialMethods: ['defineAgent', 'ghostCredentialVerb'],

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -1,12 +1,15 @@
 import {expect, test}             from '@playwright/test';
 import * as yaml                  from 'js-yaml';
-import {mkdtemp, readFile, rm}    from 'node:fs/promises';
-import {mkdirSync, writeFileSync} from 'node:fs';
-import {tmpdir}                   from 'node:os';
-import {fileURLToPath}            from 'node:url';
+import {mkdtemp, readFile, rm}                from 'node:fs/promises';
+import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
+import {tmpdir}                               from 'node:os';
+import {fileURLToPath}                        from 'node:url';
 import {
+    BRAIN_FILES,
     BRAIN_TREES,
+    ENGINE_THEME_BUILD,
     TREE_EXCLUDES,
+    assertImportClosure,
     assertNoInstanceOverlays,
     buildNodeShim,
     buildOrganismManifest,
@@ -15,10 +18,12 @@ import {
     extractBarePackages,
     extractLiteralImportSpecifiers,
     extractLocalMjsImports,
-    isInstanceOverlayPath
+    isInstanceOverlayPath,
+    resolvePackRoots,
+    stageOrganism
 } from '../../../../harness/pack.mjs';
-import {buildPackagedBrainEnv, resolveBrainMode} from '../../../../harness/brain.mjs';
-import path                                      from 'node:path';
+import {buildPackagedBrainEnv, resolveBrainMode, resolveLauncherRuntimeRoot} from '../../../../harness/brain.mjs';
+import path                                                                  from 'node:path';
 
 /**
  * @summary Traverses the packaged main-process `.mjs` graph from one entry file. Relative literals
@@ -246,22 +251,101 @@ test.describe('harness pack stage', () => {
         }
     });
 
-    test('deriveCopySpecs rides the contentPolicy allowlist plus the Brain trees, skipping node_modules entries', () => {
-        const {files, trees} = deriveCopySpecs();
+    test('deriveCopySpecs keeps the two owners apart: the allowlist names the product graph, the constants name the Brain set, node_modules entries ride the install', () => {
+        const {brain, product} = deriveCopySpecs();
 
-        for (const tree of BRAIN_TREES) {
-            expect(trees).toContain(tree)
-        }
+        expect(brain.trees).toEqual([...BRAIN_TREES]);
+        expect(brain.files).toEqual([...BRAIN_FILES]);
 
         // Allowlist-derived: the renderer's source graph ships automatically.
-        expect(trees).toContain('src');
-        expect(trees).toContain('apps/agentos');
-        expect(trees).toContain('dist/development/css');
-        expect(files).toContain('resources/theme-map.json');
-        expect(files).toContain('resources/images/logo/neo_logo_primary.svg');
+        expect(product.trees).toContain('src');
+        expect(product.trees).toContain('apps/agentos');
+        expect(product.trees).toContain('dist/development/css');
+        expect(product.files).toContain('resources/theme-map.json');
+        expect(product.files).toContain('resources/images/logo/neo_logo_primary.svg');
 
-        // node_modules-prefixed allowlist entries come from the staged dependency install.
-        expect([...trees, ...files].some(entry => entry.includes('node_modules'))).toBe(false)
+        // no owner stages the other's tree; node_modules-prefixed allowlist entries come from the
+        // staged dependency install
+        expect(product.trees).not.toContain('ai');
+        expect([...product.trees, ...product.files, ...brain.trees, ...brain.files].some(entry => entry.includes('node_modules'))).toBe(false)
+    });
+
+    // The split-root assembly: three owners, each proven before the stage is touched. A tmp tree
+    // stands in for the two checkouts and the Engine install; nothing here runs the real stage.
+    const scaffoldRoots = async () => {
+        const
+            root    = await mkdtemp(path.join(tmpdir(), 'neo-pack-roots-')),
+            product = path.join(root, 'product'),
+            brain   = path.join(root, 'brain');
+
+        mkdirSync(path.join(product, 'apps', 'agentos'), {recursive: true});
+        mkdirSync(path.join(product, 'node_modules', 'neo.mjs', 'buildScripts', 'build'), {recursive: true});
+        writeFileSync(path.join(product, 'package.json'), JSON.stringify({name: 'product', version: '1.0.0'}), 'utf8');
+        writeFileSync(path.join(product, 'node_modules', 'neo.mjs', 'package.json'), JSON.stringify({name: 'neo.mjs', version: '13.1.0'}), 'utf8');
+        writeFileSync(path.join(product, 'node_modules', 'neo.mjs', ENGINE_THEME_BUILD), 'export default {}', 'utf8');
+        mkdirSync(path.join(brain, 'ai'), {recursive: true});
+        mkdirSync(path.join(brain, 'buildScripts', 'util'), {recursive: true});
+        writeFileSync(path.join(brain, 'package.json'), JSON.stringify({name: 'neo-agent-brain', version: '0.0.0'}), 'utf8');
+        writeFileSync(path.join(brain, 'buildScripts', 'util', 'sanitizer.mjs'), 'export default {}', 'utf8');
+
+        return {brain, product, root}
+    };
+
+    test('resolvePackRoots proves the product, the Engine package and the Brain root — the Brain authority explicit and absolute, every marker present', async () => {
+        const {brain, product, root} = await scaffoldRoots();
+
+        try {
+            expect(resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: brain}, productRoot: product})).toEqual({
+                brainRoot        : brain,
+                enginePackageRoot: path.join(product, 'node_modules', 'neo.mjs'),
+                productRoot      : product
+            });
+
+            // the Brain authority: missing or relative fails on the one runtime-root contract
+            expect(() => resolvePackRoots({env: {}, productRoot: product})).toThrow(/NEO_AGENTOS_RUNTIME_ROOT/);
+            expect(() => resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: 'brain'}, productRoot: product})).toThrow(/absolute/);
+            // a root without its markers is named, never guessed around
+            expect(() => resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: root}, productRoot: product})).toThrow(/brain root .* carries no package\.json/);
+            expect(() => resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: brain}, productRoot: root})).toThrow(/product root .* carries no apps\/agentos/);
+
+            // the Engine owner is proven too: the theme builder the stage runs lives in the pinned
+            // package, and a product root without an installed Engine fails before any mutation
+            await rm(path.join(product, 'node_modules', 'neo.mjs', ENGINE_THEME_BUILD), {force: true});
+            expect(() => resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: brain}, productRoot: product})).toThrow(/engine package root .* carries no buildScripts\/build\/themes\.mjs/)
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
+    });
+
+    test('stageOrganism fails before mutation on a missing Brain authority: the stage dir keeps its contents, nothing is built or installed', async () => {
+        const
+            {product, root} = await scaffoldRoots(),
+            stageDir        = path.join(root, 'stage');
+
+        mkdirSync(stageDir, {recursive: true});
+        writeFileSync(path.join(stageDir, 'sentinel'), 'still here', 'utf8');
+
+        try {
+            expect(() => stageOrganism({electronVersion: '38.0.0', env: {}, productRoot: product, stageDir})).toThrow(/NEO_AGENTOS_RUNTIME_ROOT/);
+            expect(existsSync(path.join(stageDir, 'sentinel'))).toBe(true)
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
+    });
+
+    test('assertImportClosure fails loud when the staged install lacks a pinned package', async () => {
+        const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-closure-'));
+
+        try {
+            mkdirSync(path.join(root, 'node_modules', 'chromadb'), {recursive: true});
+            writeFileSync(path.join(root, 'node_modules', 'chromadb', 'package.json'), '{}', 'utf8');
+
+            expect(() => assertImportClosure({manifest: {dependencies: {chromadb: '3.5.0'}}, stageDir: root})).not.toThrow();
+            expect(() => assertImportClosure({manifest: {dependencies: {'better-sqlite3': '12.0.0', chromadb: '3.5.0'}}, stageDir: root}))
+                .toThrow(/lacks pinned package.*better-sqlite3/)
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
     });
 
     test('the Genesis probe is checkout-only without excluding runtime diagnostics wholesale', () => {
@@ -358,51 +442,61 @@ test.describe('harness pack stage', () => {
         }
     });
 
-    test('buildOrganismManifest pins scanned packages to repo-declared versions and fails loud on undeclared imports', () => {
-        const repoPackageJson = {
-            devDependencies: {'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'},
-            version        : '11.11.0'
-        };
+    test('buildOrganismManifest pins scanned packages to the owners\' declared versions and fails loud on undeclared imports', () => {
+        const
+            productPackageJson = {dependencies: {'neo.mjs': 'github:neomjs/neo#abc'}, devDependencies: {webpack: '^5.0.0'}, version: '11.11.0'},
+            brainPackageJson   = {dependencies: {'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'}};
 
         const manifest = buildOrganismManifest({
-            packages    : ['better-sqlite3', 'chromadb'],
-            repoPackageJson,
+            brainPackageJson,
+            packages    : ['better-sqlite3', 'chromadb', 'neo.mjs'],
+            productPackageJson,
             supplemental: []
         });
 
-        expect(manifest.dependencies).toEqual({'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'});
+        expect(manifest.dependencies).toEqual({'better-sqlite3': '^12.0.0', chromadb: '^3.5.0', 'neo.mjs': 'github:neomjs/neo#abc'});
         expect(manifest.private).toBe(true);
         expect(manifest.type).toBe('module');
+        expect(manifest.version).toBe('11.11.0');
 
         expect(() => buildOrganismManifest({
+            brainPackageJson,
             packages    : ['ghost-package'],
-            repoPackageJson,
+            productPackageJson,
             supplemental: []
         })).toThrow(/no declared version.*ghost-package/)
     });
 
-    test('buildOrganismManifest reads the Brain-tier manifest as dependency authority (the tier split)', () => {
-        // The root package.json is no longer the whole authority: the Brain runtime the organism
-        // ships is declared in package.brain.json. A scan that cannot see it must hard-error —
-        // that was the review falsifier this witness pins.
-        const repoPackageJson  = {devDependencies: {webpack: '^5.0.0'}, version: '13.1.0'},
-              brainPackageJson = {devDependencies: {'better-sqlite3': '12.11.1', chromadb: '3.5.0'}};
+    test('buildOrganismManifest takes the Brain root\'s package.json as the runtime tier — required, both tiers read, the product winning a shared name', () => {
+        // Post-split the Brain runtime the organism ships (Memory Core's better-sqlite3, the
+        // chromadb client) is declared by the Brain checkout's own package.json; the product
+        // declares the renderer closure and pins the Engine. A shared name resolves to the
+        // product's pin, and a scan without the Brain authority must hard-error.
+        const
+            productPackageJson = {dependencies: {'neo.mjs': 'github:neomjs/neo#product-pin'}, devDependencies: {webpack: '^5.0.0'}, version: '13.1.0'},
+            brainPackageJson   = {dependencies: {'better-sqlite3': '12.11.1', 'neo.mjs': 'github:neomjs/neo#brain-pin'}, devDependencies: {chromadb: '3.5.0'}};
 
         const manifest = buildOrganismManifest({
-            packages    : ['better-sqlite3', 'chromadb', 'webpack'],
-            repoPackageJson,
             brainPackageJson,
+            packages    : ['better-sqlite3', 'chromadb', 'neo.mjs', 'webpack'],
+            productPackageJson,
             supplemental: []
         });
 
-        expect(manifest.dependencies).toEqual({'better-sqlite3': '12.11.1', chromadb: '3.5.0', webpack: '^5.0.0'});
+        expect(manifest.dependencies).toEqual({
+            'better-sqlite3': '12.11.1',
+            chromadb        : '3.5.0',
+            'neo.mjs'       : 'github:neomjs/neo#product-pin',
+            webpack         : '^5.0.0'
+        });
 
-        // Without the brain authority the same scan fails loud — never a silently broken artifact.
+        // No Brain authority, no manifest — never a silently broken artifact (the pre-split
+        // package.brain.json was optional; the Brain root's package.json is not).
         expect(() => buildOrganismManifest({
             packages    : ['better-sqlite3'],
-            repoPackageJson,
+            productPackageJson,
             supplemental: []
-        })).toThrow(/no declared version.*better-sqlite3/)
+        })).toThrow(/Brain package\.json/)
     });
 
     test('the node shim fails loud without the runtime binary and execs it in node mode', () => {
@@ -466,6 +560,18 @@ test.describe('harness pack stage', () => {
         expect(resolveBrainMode({env: {NEO_HARNESS_BRAIN: '0'}, packaged: true})).toBe(false);
         expect(resolveBrainMode({env: {}, packaged: false})).toBe(false);
         expect(resolveBrainMode({env: {NEO_HARNESS_BRAIN: '1'}, packaged: false})).toBe(true)
+    });
+
+    // The launcher-ordering half: a checkout with the Brain leg off must boot without a Brain root
+    // and without loading a Brain contract; the root stays required while the leg is on, and a
+    // relative value is an error in every shape.
+    test('resolveLauncherRuntimeRoot: packaged → the organism root; Brain on → the absolute checkout, required; Brain off → the supplied root or none, relative never', () => {
+        expect(resolveLauncherRuntimeRoot({brainMode: true, env: {}, packaged: true, packagedOrganismRoot: '/app/organism'})).toBe('/app/organism');
+        expect(resolveLauncherRuntimeRoot({brainMode: true, env: {NEO_AGENTOS_RUNTIME_ROOT: '/abs/brain'}, packaged: false})).toBe('/abs/brain');
+        expect(() => resolveLauncherRuntimeRoot({brainMode: true, env: {}, packaged: false})).toThrow(/NEO_AGENTOS_RUNTIME_ROOT/);
+        expect(resolveLauncherRuntimeRoot({brainMode: false, env: {}, packaged: false})).toBeNull();
+        expect(resolveLauncherRuntimeRoot({brainMode: false, env: {NEO_AGENTOS_RUNTIME_ROOT: '/abs/brain'}, packaged: false})).toBe('/abs/brain');
+        expect(() => resolveLauncherRuntimeRoot({brainMode: false, env: {NEO_AGENTOS_RUNTIME_ROOT: 'brain'}, packaged: false})).toThrow(/absolute/)
     });
 
     // The security stop-line: a checkout's gitignored config overlay (which CAN carry hand-edited

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -1,7 +1,7 @@
 import {expect, test}             from '@playwright/test';
 import * as yaml                  from 'js-yaml';
-import {mkdtemp, readFile, rm}                from 'node:fs/promises';
-import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
+import {mkdtemp, readFile, rm}                              from 'node:fs/promises';
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs';
 import {tmpdir}                               from 'node:os';
 import {fileURLToPath}                        from 'node:url';
 import {
@@ -19,6 +19,7 @@ import {
     extractLiteralImportSpecifiers,
     extractLocalMjsImports,
     isInstanceOverlayPath,
+    materializeOverlaySlots,
     resolvePackRoots,
     stageOrganism
 } from '../../../../harness/pack.mjs';
@@ -354,9 +355,25 @@ test.describe('harness pack stage', () => {
             expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai']}))
                 .toThrow(/import outside the stage: ai\/daemons\/daemon\.mjs → \.\.\/\.\.\/src\/evolution\/createRemDigestion\.mjs/);
 
-            // once the sibling tree is staged the same module closes
+            // once the sibling tree is staged the same module closes — and a tree named by both
+            // owners (`src`) is walked once, so a finding is reported once
             mkdirSync(path.join(root, 'src', 'evolution'), {recursive: true});
             writeFileSync(path.join(root, 'src', 'evolution', 'createRemDigestion.mjs'), 'export default {}', 'utf8');
+            expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai', 'src', 'src']})).not.toThrow();
+
+            // an overlay slot the copy filter left empty (template present, config absent) is the
+            // closure's next finding — the derived materialization fills it, once, template-verbatim,
+            // and leaves a slot the setup script already filled alone
+            writeFileSync(path.join(root, 'src', 'evolution', 'config.template.mjs'), "export default {slot: 'template'}", 'utf8');
+            writeFileSync(path.join(root, 'src', 'evolution', 'RemDigestion.mjs'), "import config from './config.mjs';\nexport default config", 'utf8');
+            writeFileSync(path.join(root, 'ai', 'config.template.mjs'), "export default {slot: 'template'}", 'utf8');
+            expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai', 'src']}))
+                .toThrow(/src\/evolution\/RemDigestion\.mjs → \.\/config\.mjs/);
+
+            expect(materializeOverlaySlots({stageDir: root, trees: ['ai', 'src', 'src']})).toEqual(['src/evolution/config.mjs']);
+            expect(readFileSync(path.join(root, 'src', 'evolution', 'config.mjs'), 'utf8')).toBe("export default {slot: 'template'}");
+            expect(readFileSync(path.join(root, 'ai', 'config.mjs'), 'utf8')).toBe('export default {}');
+            expect(materializeOverlaySlots({stageDir: root, trees: ['ai', 'src']})).toEqual([]);
             expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai', 'src']})).not.toThrow()
         } finally {
             await rm(root, {force: true, recursive: true})

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -12,7 +12,7 @@ import {
     assertNoInstanceOverlays,
     buildNodeShim,
     buildOrganismManifest,
-    collectTreeBarePackages,
+    collectBarePackages,
     deriveCopySpecs,
     describeOwners,
     extractBarePackages,
@@ -21,7 +21,8 @@ import {
     isInstanceOverlayPath,
     materializeOverlaySlots,
     resolvePackRoots,
-    stageOrganism
+    stageOrganism,
+    stageOwners
 } from '../../../../harness/pack.mjs';
 import {buildPackagedBrainEnv, resolveBrainMode, resolveLauncherRuntimeRoot} from '../../../../harness/brain.mjs';
 import path                                                                  from 'node:path';
@@ -335,6 +336,54 @@ test.describe('harness pack stage', () => {
         }
     });
 
+    test('stageOwners keeps provenance across the shared src tree: each owner is scanned from the files IT copied, and a merged scan is the red control', async () => {
+        const
+            {brain, product, root} = await scaffoldRoots(),
+            stageDir               = path.join(root, 'stage'),
+            productPackageJson     = {dependencies: {'product-only-pkg': '1.0.0'}, name: 'product', version: '1.0.0'},
+            brainPackageJson       = {dependencies: {'brain-only-pkg': '2.0.0'}, name: 'neo-agent-brain', version: '0.0.0'};
+
+        // the product's allowlist set (trees + exact files) and the Brain's two trees; both owners
+        // carry a `src/` — the product's loader beside the Brain's evolution module — and each
+        // imports a package only ITS owner declares
+        mkdirSync(path.join(product, 'src'), {recursive: true});
+        mkdirSync(path.join(product, 'dist', 'development', 'css'), {recursive: true});
+        mkdirSync(path.join(product, 'resources', 'images', 'logo'), {recursive: true});
+        writeFileSync(path.join(product, 'resources', 'theme-map.json'), '{}', 'utf8');
+        writeFileSync(path.join(product, 'resources', 'images', 'logo', 'neo_logo_primary.svg'), '<svg/>', 'utf8');
+        writeFileSync(path.join(product, 'src', 'MicroLoader.mjs'), "import loader from 'product-only-pkg';\nexport default loader", 'utf8');
+        mkdirSync(path.join(brain, 'src', 'evolution'), {recursive: true});
+        writeFileSync(path.join(brain, 'ai', 'x.mjs'), 'export default {}', 'utf8');
+        writeFileSync(path.join(brain, 'src', 'evolution', 'rem.mjs'), "import sqlite from 'brain-only-pkg';\nimport x from '../../ai/x.mjs';\nexport default {sqlite, x}", 'utf8');
+
+        try {
+            const
+                roots             = resolvePackRoots({env: {NEO_AGENTOS_RUNTIME_ROOT: brain}, productRoot: product}),
+                {copied, scanned} = stageOwners({roots, stageDir});
+
+            expect(copied.brain.sort()).toEqual(['ai/x.mjs', 'src/evolution/rem.mjs']);
+            expect(copied.product.sort()).toEqual(['resources/images/logo/neo_logo_primary.svg', 'resources/theme-map.json', 'src/MicroLoader.mjs']);
+            expect(scanned).toEqual({brain: ['brain-only-pkg'], product: ['product-only-pkg']});
+            expect(buildOrganismManifest({brainPackageJson, productPackageJson, scanned, supplemental: NO_SUPPLEMENTAL}).dependencies)
+                .toEqual({'brain-only-pkg': '2.0.0', 'product-only-pkg': '1.0.0'});
+
+            // the red control: a scan of the MERGED stage/src credits both imports to both owners,
+            // and the manifest then reports a Brain-only import as missing for the product
+            const merged = collectBarePackages({files: ['src/MicroLoader.mjs', 'src/evolution/rem.mjs'], rootDir: stageDir});
+
+            expect(merged).toEqual(['brain-only-pkg', 'product-only-pkg']);
+            expect(() => buildOrganismManifest({brainPackageJson, productPackageJson, scanned: {brain: merged, product: merged}, supplemental: NO_SUPPLEMENTAL}))
+                .toThrow(/no declared version.*brain-only-pkg \(product\)/);
+
+            // two owners may share the directory, never a file
+            writeFileSync(path.join(brain, 'src', 'MicroLoader.mjs'), 'export default {}', 'utf8');
+            await rm(stageDir, {force: true, recursive: true});
+            expect(() => stageOwners({roots, stageDir})).toThrow(/two owners stage the same path/)
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
+    });
+
     test('assertImportClosure fails loud on a missing pinned package and on a staged module importing outside the stage', async () => {
         const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-closure-'));
 
@@ -451,7 +500,7 @@ test.describe('harness pack stage', () => {
         ])
     });
 
-    test('collectTreeBarePackages scans staged mjs, cjs, and js files through the shared syntax scanner', async () => {
+    test('collectBarePackages scans an explicit file set — mjs, cjs, and js through the shared syntax scanner, other files skipped', async () => {
         const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-import-scan-'));
 
         try {
@@ -467,8 +516,12 @@ test.describe('harness pack stage', () => {
                 "export {value} from '@scope/js-package/deep/path.mjs';",
                 "const runtime = import(runtimeSpecifier);"
             ].join('\n'), 'utf8');
+            writeFileSync(path.join(root, 'notes.md'), "import ghost from 'md-ghost';", 'utf8');
+            writeFileSync(path.join(root, 'unlisted.mjs'), "import ghost from 'unlisted-ghost';", 'utf8');
 
-            expect(collectTreeBarePackages({rootDir: root})).toEqual([
+            // only the files named are read — a file on disk but outside the owner's set (the other
+            // owner's file in a shared directory) contributes nothing
+            expect(collectBarePackages({files: ['module.mjs', 'common.cjs', 'plain.js', 'notes.md'], rootDir: root})).toEqual([
                 '@scope/js-package',
                 'cjs-package',
                 'mjs-package'

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -5,7 +5,6 @@ import {existsSync, mkdirSync, writeFileSync} from 'node:fs';
 import {tmpdir}                               from 'node:os';
 import {fileURLToPath}                        from 'node:url';
 import {
-    BRAIN_FILES,
     BRAIN_TREES,
     ENGINE_THEME_BUILD,
     TREE_EXCLUDES,
@@ -15,6 +14,7 @@ import {
     buildOrganismManifest,
     collectTreeBarePackages,
     deriveCopySpecs,
+    describeOwners,
     extractBarePackages,
     extractLiteralImportSpecifiers,
     extractLocalMjsImports,
@@ -254,8 +254,10 @@ test.describe('harness pack stage', () => {
     test('deriveCopySpecs keeps the two owners apart: the allowlist names the product graph, the constants name the Brain set, node_modules entries ride the install', () => {
         const {brain, product} = deriveCopySpecs();
 
-        expect(brain.trees).toEqual([...BRAIN_TREES]);
-        expect(brain.files).toEqual([...BRAIN_FILES]);
+        // the Brain's own `src/` rides with `ai/` (it imports it relatively); the Engine modules the
+        // Brain imports bare come from the install, never from a copied file
+        expect(brain).toEqual({trees: ['ai', 'src']});
+        expect(BRAIN_TREES).toEqual(['ai', 'src']);
 
         // Allowlist-derived: the renderer's source graph ships automatically.
         expect(product.trees).toContain('src');
@@ -267,7 +269,7 @@ test.describe('harness pack stage', () => {
         // no owner stages the other's tree; node_modules-prefixed allowlist entries come from the
         // staged dependency install
         expect(product.trees).not.toContain('ai');
-        expect([...product.trees, ...product.files, ...brain.trees, ...brain.files].some(entry => entry.includes('node_modules'))).toBe(false)
+        expect([...product.trees, ...product.files, ...brain.trees].some(entry => entry.includes('node_modules'))).toBe(false)
     });
 
     // The split-root assembly: three owners, each proven before the stage is touched. A tmp tree
@@ -284,9 +286,8 @@ test.describe('harness pack stage', () => {
         writeFileSync(path.join(product, 'node_modules', 'neo.mjs', 'package.json'), JSON.stringify({name: 'neo.mjs', version: '13.1.0'}), 'utf8');
         writeFileSync(path.join(product, 'node_modules', 'neo.mjs', ENGINE_THEME_BUILD), 'export default {}', 'utf8');
         mkdirSync(path.join(brain, 'ai'), {recursive: true});
-        mkdirSync(path.join(brain, 'buildScripts', 'util'), {recursive: true});
+        mkdirSync(path.join(brain, 'src'), {recursive: true});
         writeFileSync(path.join(brain, 'package.json'), JSON.stringify({name: 'neo-agent-brain', version: '0.0.0'}), 'utf8');
-        writeFileSync(path.join(brain, 'buildScripts', 'util', 'sanitizer.mjs'), 'export default {}', 'utf8');
 
         return {brain, product, root}
     };
@@ -333,22 +334,40 @@ test.describe('harness pack stage', () => {
         }
     });
 
-    test('assertImportClosure fails loud when the staged install lacks a pinned package', async () => {
+    test('assertImportClosure fails loud on a missing pinned package and on a staged module importing outside the stage', async () => {
         const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-closure-'));
 
         try {
             mkdirSync(path.join(root, 'node_modules', 'chromadb'), {recursive: true});
             writeFileSync(path.join(root, 'node_modules', 'chromadb', 'package.json'), '{}', 'utf8');
+            mkdirSync(path.join(root, 'ai', 'daemons'), {recursive: true});
+            writeFileSync(path.join(root, 'ai', 'config.mjs'), 'export default {}', 'utf8');
+            // a sibling-tree import that resolves (../config.mjs) beside one that does not: the
+            // real stage carried exactly this shape — `ai/` importing a `src/` nobody copied
+            writeFileSync(path.join(root, 'ai', 'daemons', 'daemon.mjs'), "import config from '../config.mjs';\nimport rem from '../../src/evolution/createRemDigestion.mjs';\nexport default {config, rem}", 'utf8');
 
-            expect(() => assertImportClosure({manifest: {dependencies: {chromadb: '3.5.0'}}, stageDir: root})).not.toThrow();
+            const manifest = {dependencies: {chromadb: '3.5.0'}};
+
+            expect(() => assertImportClosure({manifest, stageDir: root})).not.toThrow();
             expect(() => assertImportClosure({manifest: {dependencies: {'better-sqlite3': '12.0.0', chromadb: '3.5.0'}}, stageDir: root}))
-                .toThrow(/lacks pinned package.*better-sqlite3/)
+                .toThrow(/lacks pinned package.*better-sqlite3/);
+            expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai']}))
+                .toThrow(/import outside the stage: ai\/daemons\/daemon\.mjs → \.\.\/\.\.\/src\/evolution\/createRemDigestion\.mjs/);
+
+            // once the sibling tree is staged the same module closes
+            mkdirSync(path.join(root, 'src', 'evolution'), {recursive: true});
+            writeFileSync(path.join(root, 'src', 'evolution', 'createRemDigestion.mjs'), 'export default {}', 'utf8');
+            expect(() => assertImportClosure({manifest, stageDir: root, trees: ['ai', 'src']})).not.toThrow()
         } finally {
             await rm(root, {force: true, recursive: true})
         }
     });
 
     test('the Genesis probe is checkout-only without excluding runtime diagnostics wholesale', () => {
+        // an importer of an excluded tree goes with it — a staged module must never import a
+        // module the stage does not carry
+        expect(TREE_EXCLUDES).toContain('ai/daemons/temporal-summary');
+        expect(TREE_EXCLUDES).toContain('ai/scripts/maintenance/aggregate-temporal-summary.mjs');
         expect(TREE_EXCLUDES).toContain('ai/scripts/diagnostics/genesisProbe.mjs');
         expect(TREE_EXCLUDES).not.toContain('ai/scripts/diagnostics');
         expect(TREE_EXCLUDES).not.toContain('ai/scripts/diagnostics/mcpHealthcheck.mjs')
@@ -442,61 +461,107 @@ test.describe('harness pack stage', () => {
         }
     });
 
-    test('buildOrganismManifest pins scanned packages to the owners\' declared versions and fails loud on undeclared imports', () => {
+    const NO_SUPPLEMENTAL = {brain: [], product: []};
+
+    test('buildOrganismManifest pins each tree\'s imports by the owner that stages it, and fails loud on an import that owner never declared', () => {
         const
             productPackageJson = {dependencies: {'neo.mjs': 'github:neomjs/neo#abc'}, devDependencies: {webpack: '^5.0.0'}, version: '11.11.0'},
             brainPackageJson   = {dependencies: {'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'}};
 
         const manifest = buildOrganismManifest({
             brainPackageJson,
-            packages    : ['better-sqlite3', 'chromadb', 'neo.mjs'],
             productPackageJson,
-            supplemental: []
+            scanned     : {brain: ['better-sqlite3', 'chromadb'], product: ['neo.mjs', 'webpack']},
+            supplemental: NO_SUPPLEMENTAL
         });
 
-        expect(manifest.dependencies).toEqual({'better-sqlite3': '^12.0.0', chromadb: '^3.5.0', 'neo.mjs': 'github:neomjs/neo#abc'});
+        expect(manifest.dependencies).toEqual({'better-sqlite3': '^12.0.0', chromadb: '^3.5.0', 'neo.mjs': 'github:neomjs/neo#abc', webpack: '^5.0.0'});
         expect(manifest.private).toBe(true);
         expect(manifest.type).toBe('module');
         expect(manifest.version).toBe('11.11.0');
 
+        // provenance is strict: a Brain import the Brain never declared is missing even where the
+        // product happens to declare the same name — the checkout would have failed the same way
         expect(() => buildOrganismManifest({
             brainPackageJson,
-            packages    : ['ghost-package'],
             productPackageJson,
-            supplemental: []
-        })).toThrow(/no declared version.*ghost-package/)
+            scanned     : {brain: ['webpack'], product: []},
+            supplemental: NO_SUPPLEMENTAL
+        })).toThrow(/no declared version.*webpack \(brain\)/);
+
+        expect(() => buildOrganismManifest({
+            brainPackageJson,
+            productPackageJson,
+            scanned     : {brain: [], product: ['ghost-package']},
+            supplemental: NO_SUPPLEMENTAL
+        })).toThrow(/no declared version.*ghost-package \(product\)/)
     });
 
-    test('buildOrganismManifest takes the Brain root\'s package.json as the runtime tier — required, both tiers read, the product winning a shared name', () => {
-        // Post-split the Brain runtime the organism ships (Memory Core's better-sqlite3, the
-        // chromadb client) is declared by the Brain checkout's own package.json; the product
-        // declares the renderer closure and pins the Engine. A shared name resolves to the
-        // product's pin, and a scan without the Brain authority must hard-error.
+    test('buildOrganismManifest keeps owner authority at a collision: agreement passes, disagreement fails loud, the Engine is the product\'s by name', () => {
+        // The live pair disagrees on chalk (product ^6.0.0, Brain ^5.6.2) and on neo.mjs. A Brain
+        // import of chalk stays the Brain's pin; a name BOTH trees import must agree; neo.mjs is
+        // the named exception — the Engine is the product's dependency wherever it is imported.
         const
-            productPackageJson = {dependencies: {'neo.mjs': 'github:neomjs/neo#product-pin'}, devDependencies: {webpack: '^5.0.0'}, version: '13.1.0'},
-            brainPackageJson   = {dependencies: {'better-sqlite3': '12.11.1', 'neo.mjs': 'github:neomjs/neo#brain-pin'}, devDependencies: {chromadb: '3.5.0'}};
+            productPackageJson = {dependencies: {'neo.mjs': 'github:neomjs/neo#product-pin', chalk: '^6.0.0'}, devDependencies: {webpack: '^5.0.0', acorn: '^8.17.0'}, version: '13.1.0'},
+            brainPackageJson   = {dependencies: {'better-sqlite3': '12.11.1', 'neo.mjs': 'github:neomjs/neo#brain-pin', chalk: '^5.6.2'}, devDependencies: {chromadb: '3.5.0', acorn: '^8.17.0'}};
 
-        const manifest = buildOrganismManifest({
+        expect(buildOrganismManifest({
             brainPackageJson,
-            packages    : ['better-sqlite3', 'chromadb', 'neo.mjs', 'webpack'],
             productPackageJson,
-            supplemental: []
-        });
-
-        expect(manifest.dependencies).toEqual({
+            scanned     : {brain: ['acorn', 'better-sqlite3', 'chalk', 'chromadb', 'neo.mjs'], product: ['acorn', 'neo.mjs', 'webpack']},
+            supplemental: NO_SUPPLEMENTAL
+        }).dependencies).toEqual({
+            acorn           : '^8.17.0',                      // both import it, both agree
             'better-sqlite3': '12.11.1',
+            chalk           : '^5.6.2',                       // only the Brain imports it → the Brain's pin, not the product's ^6
             chromadb        : '3.5.0',
-            'neo.mjs'       : 'github:neomjs/neo#product-pin',
+            'neo.mjs'       : 'github:neomjs/neo#product-pin', // the named exception
             webpack         : '^5.0.0'
         });
+
+        // the red control: chalk imported by BOTH trees with different declarations is a hard error,
+        // never a silent winner
+        expect(() => buildOrganismManifest({
+            brainPackageJson,
+            productPackageJson,
+            scanned     : {brain: ['chalk'], product: ['chalk']},
+            supplemental: NO_SUPPLEMENTAL
+        })).toThrow(/owners disagree on chalk: brain \^5\.6\.2 vs product \^6\.0\.0/);
+
+        // supplemental names belong to an owner too
+        expect(buildOrganismManifest({
+            brainPackageJson  : {...brainPackageJson, dependencies: {...brainPackageJson.dependencies, '@chroma-core/default-embed': '1.0.0'}},
+            productPackageJson: {...productPackageJson, devDependencies: {...productPackageJson.devDependencies, '@fortawesome/fontawesome-free': '7.0.0'}},
+            scanned           : {brain: [], product: []}
+        }).dependencies).toEqual({'@chroma-core/default-embed': '1.0.0', '@fortawesome/fontawesome-free': '7.0.0'});
 
         // No Brain authority, no manifest — never a silently broken artifact (the pre-split
         // package.brain.json was optional; the Brain root's package.json is not).
         expect(() => buildOrganismManifest({
-            packages    : ['better-sqlite3'],
             productPackageJson,
-            supplemental: []
+            scanned     : {brain: ['better-sqlite3'], product: []},
+            supplemental: NO_SUPPLEMENTAL
         })).toThrow(/Brain package\.json/)
+    });
+
+    test('describeOwners ships role, name, version, pin and revision — no build-host coordinate survives in the staged metadata', () => {
+        const
+            roots = {brainRoot: '/Users/someone/checkouts/neo-agent-brain', enginePackageRoot: '/Users/someone/checkouts/product/node_modules/neo.mjs', productRoot: '/Users/someone/checkouts/product'},
+            info  = describeOwners({
+                brainPackageJson  : {name: 'neo-agent-brain', version: '0.0.0'},
+                enginePackageJson : {name: 'neo.mjs', version: '13.1.0'},
+                productPackageJson: {dependencies: {'neo.mjs': 'github:neomjs/neo#205bc52f'}, name: 'neo-agent-institution', version: '0.1.0'},
+                revisionOf        : root => root === roots.brainRoot ? 'abc123' : null,
+                roots
+            });
+
+        expect(info).toEqual({
+            brain  : {name: 'neo-agent-brain', revision: 'abc123', version: '0.0.0'},
+            engine : {name: 'neo.mjs', pin: 'github:neomjs/neo#205bc52f', version: '13.1.0'},
+            product: {name: 'neo-agent-institution', version: '0.1.0'}
+        });
+        expect(JSON.stringify(info)).not.toContain('/Users/');
+        expect(JSON.stringify(info)).not.toContain('checkouts')
     });
 
     test('the node shim fails loud without the runtime binary and execs it in node mode', () => {


### PR DESCRIPTION
Resolves #4

The pack stage assembles the organism from three explicit owners and nothing else: the PRODUCT root (this checkout: the allowlist-derived renderer graph and its `package.json`), the ENGINE package (the pinned `neo.mjs` install — its theme builder runs the pre-copy build, its pin lands in the manifest), and the BRAIN root (`NEO_AGENTOS_RUNTIME_ROOT`, the one absolute-only contract the checkout launcher already uses — its `ai/` tree, its `buildScripts/util/sanitizer.mjs`, its `package.json` as the runtime-dependency tier). Every owner is proven before the stage dir is touched; the install is verified to resolve every pin. The launcher half: `main.mjs` resolves the runtime root and loads the Fleet contracts only when the boot shape has a Brain root — packaged, or Brain leg on, or a root supplied — and a checkout with the leg off and no root boots as the UI alone, its fleet route rejecting with the named reason.

Evidence: L3 (`node harness/pack.mjs` run end-to-end on this Mac against the Brain checkout at this head — exit 0, 5 trees + 2 files, 22 pins, the closure over packages and relative imports green, `organism-build-info.json` naming the three owners without a path; unit arms for every root, manifest, closure, owner and launcher rule) → L3 required for AC-1…AC-6; AC-7 reaches L2 (unit arms + the static boot path — no Electron install on this machine to launch the checkout shell). Residual: AC-7's live checkout launch, Residual-Owner: #17 (its body now names this exact receipt; #4's AC-7 is annotated `[L3-deferred — operator handoff needed]`).

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `NEO_AGENTOS_RUNTIME_ROOT=/…/neo-agent-brain node harness/pack.mjs` from this checkout, at this head: themes built through `node_modules/neo.mjs/buildScripts/build/themes.mjs`, 5 trees + 2 files staged, 22 organism dependencies installed (223 packages), `@electron/rebuild` against Electron 43.1.0 (`better-sqlite3` rebuilt), fresh template configs plus one derived slot, the closure (packages + every relative import) green, exit 0 at 19:04:19Z. The Institution root carries no `ai/`, no `package.brain.json`, no `buildScripts/` builder — the run needed none. |
| AC-2 | same run; `git grep package.brain.json harness/` → no code reference left (one spec comment names the retired file as history). |
| AC-3 | `pack.spec.mjs` › *resolvePackRoots proves…*: missing env → `/NEO_AGENTOS_RUNTIME_ROOT/`, relative → `/absolute/`, a root without its markers → the named marker; › *stageOrganism fails before mutation…*: a sentinel inside the stage dir survives the throw — no `rm`, no build, no install. |
| AC-4 | › *buildOrganismManifest pins each tree's imports by the owner that stages it…* + › *…keeps owner authority at a collision…*: per-owner provenance, both tiers of each manifest, agreement required on a shared name (the `chalk` red control), `neo.mjs` the named exception, a missing Brain manifest a hard error. The staged `package.json` of the run at this head: 22 pins — `neo.mjs` at the product's `github:neomjs/neo#205bc52f…` (the named exception; the Brain's own tarball pin never enters), `better-sqlite3` 12.11.1 and `chromadb` 3.5.0 from the Brain root's `package.json`; neither tree imports `chalk`, so the live ^6/^5.6.2 disagreement stays outside the organism (the unit arm is its red control). `organism-build-info.json` → `owners.brain` {neo-agent-brain, 0.0.0, revision `80c551e8…`}, `owners.engine` {neo.mjs, 13.1.0, that pin}, `owners.product` {neo-agent-institution, 0.1.0} — `grep -c /Users/` on it: 0. |
| AC-5 | the overlay arm unchanged (template-sibling derivation + the stage assertion); `assertImportClosure` — › *…fails loud on a missing pinned package and on a staged module importing outside the stage* — package presence plus every relative import of every staged module, run on the complete stage; the first real run at round 1 would have flagged the four dangling Brain imports (measured by hand: three into the uncopied `src/`, one into the excluded daemon); the run at this head: 5 trees + 2 files staged (the Brain's `src/` beside the product's), 22 pins present, one overlay slot materialized (`src/evolution/config.mjs`), zero dangling relative imports — exit 0 at 19:04:19Z. |
| AC-6 | the four monorepo-shaped arms restated (`deriveCopySpecs` per owner, the two manifest arms, the scaffolded roots), eight arms added (roots, before-mutation, closure, launcher root, absent capability, collision, owners, the copy-and-scan boundary); harness specs **77/77**, unit **768/768**. |
| AC-7 | `brain.mjs#resolveLauncherRuntimeRoot` — › *packaged → the organism root; Brain on → the absolute checkout, required; Brain off → the supplied root or none, relative never*; `main.mjs` computes `brainMode` first and gates root + contracts on it; `createAbsentFleetCapability` — › *rejects every request with the named reason, sender trust first*. Live launch: Post-Merge Validation. |

## Deltas from ticket
- **A fourth monorepo path the ticket did not list:** the stage's theme build ran `buildScripts/build/themes.mjs` from the product root — post-split that script is the Engine package's. It now runs from `node_modules/neo.mjs`, and the Engine owner's markers include it (the first real run failed exactly there).
- **A fifth, found while answering round 1:** the Brain's `ai/` imports the Brain's OWN `src/` (composition, evolution) relatively, and the stage never copied it — the product's `src/` sat at that path. Three staged modules dangled (`Orchestrator.mjs`, `hostEdge.mjs`, `runSandman.mjs` → `../../../src/…`), a fourth imported the excluded temporal-summary daemon. `BRAIN_TREES` is `['ai', 'src']` (distinct subtrees beside the product's `src/`; a same-path collision between owners fails the copy), the aggregation script joins the exclude, and `BRAIN_FILES` is gone — the Brain imports the sanitizer bare from the Engine package (`neo.mjs/buildScripts/util/sanitizer.mjs`, nine sites), never the copy. The closure's next finding on the real stage: `src/evolution/RemDigestion.mjs → ./config.mjs` — an instance-overlay slot (template + gitignored config) the copy filter rightly leaves empty and the Brain's `initServerConfigs` does not know (it fills `ai/` and `ai/mcp/server/*` only). `materializeOverlaySlots` fills any such slot template-verbatim from the same derived predicate, after the setup script, before the closure check.
- **Round 2 (Euclid, RA-2 still open):** the provenance I built in the manifest was lost one step earlier — `stageOrganism` scanned the MERGED stage, and both owners land a `src/` there, so every import in either owner's `src/` was credited to both (a Brain-only import declared by the Brain alone read as `missing (product)`). `stageOwners` is the copy-and-scan boundary now: the copiers return the files each owner placed, each owner is scanned from ITS files (`collectBarePackages` over an explicit set replaces the directory walker), and the integration arm › *stageOwners keeps provenance across the shared src tree…* runs the boundary over fake roots with the merged scan as the red control and the same-file collision as a second.
- **Round 1 (Euclid):** the manifest keeps each import's OWNER — a name both trees import must carry the same declaration in both owners or the pack fails (red control: `chalk` ^6 vs ^5.6.2), `neo.mjs` is the one named exception, supplemental names belong to an owner; `organism-build-info.json` records role, name, version, the Engine pin and the Brain revision, never a build-host path; `assertImportClosure` now also resolves every relative import of a staged module on the complete stage.
- **The absent fleet route rejects instead of answering.** The ticket's "without loading Brain contracts" means the shell cannot mint a wire envelope in that shape; a hand-made one fails the renderer's `inspectFleetWireResponse` as *malformed* — a lie. The handler stays registered and rejects with the reason; the bridge reads a closed transport failure, which is the truth, and the shell logs `HARNESS_UI_FLEET none`.
- **Import closure made mechanical:** `assertImportClosure` after the staged install (AC-5's "verified").
- `organism-build-info.json` records the three owners (name, root, version; the Engine's pin and installed version).
- Left alone, out of scope: `TREE_EXCLUDES`' `ai/scripts/diagnostics/genesisProbe.mjs` entry names a file that exists in neither checkout now — dead, harmless; the spec arm that pins it is unchanged.

## Test Evidence
- The real stage run on this Mac (harness `node_modules` absent — `@electron/rebuild` ran through `npx`), four runs: the first failed at the theme build (`Cannot find module …/buildScripts/build/themes.mjs` — the fourth monorepo path, now the Engine package's); the second staged end-to-end but its Brain tree carried four dangling relative imports nothing checked (measured by hand against the stage); the third, with the Brain's `src/` staged and the closure check in place, stopped at the `src/evolution` overlay slot; the fourth, with the derived materialization, is the receipt in AC-1 / AC-4 / AC-5. `npm run dist` (electron-builder, unchanged code) was not run here.
- Everything else runs in CI: `npm run test-unit` 766/766 (harness specs 75/75).

## Post-Merge Validation
- [ ] A checkout launch with no `NEO_AGENTOS_RUNTIME_ROOT` and the Brain leg off (`cd harness && npm start`) boots the UI alone and logs `HARNESS_UI_FLEET none`; with the root supplied it self-supplies the transport as before (AC-7 live receipt — tracked on #17).

## Commits
- `206ee6c` — pack stage on three owners, launcher gating, arms, README (branched from `dev@0b0b33a`).
- `2feebb4` — round 1: per-owner manifest provenance (RA-2), path-free build info (RA-3), the Brain's `src/` staged with `ai/`, the closure over relative imports, the dead sanitizer copy dropped.
- `8fd6a3d` — round 1: the derived overlay-slot materialization the third real run demanded; the closure walks a shared tree once.
- `6d3dac9` — round 2: the copy-and-scan boundary (`stageOwners`) — each owner scanned from the files it copied; the merged-scan red control.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 46962d8b-08f3-49a3-8049-d74e2052af37.
