### PR TITLE
ci(institution): the shared PR baseline gets its thin caller, pinned to the Skills head (#64)

### DIFF
--- a/.github/workflows/shared-pr-baseline.yml
+++ b/.github/workflows/shared-pr-baseline.yml
@@ -1,0 +1,23 @@
+# Agent Institution owns only the event trigger and the immutable Skills coordinate. The called
+# workflow owns base admission, materialization, source archaeology, substrate size and the agent
+# PR-body gate, so their implementation cannot drift in this consumer. Product CI (ci.yml — the
+# isolated and explicit-Brain suites) stays a separate workflow: governance never gates the build.
+
+name: Shared PR Baseline
+
+permissions:
+  contents: read
+
+# Deliberately unfiltered: once these jobs become required contexts, every PR must emit a terminal
+# result. The called PR-base job rejects an unsupported base instead of leaving a context pending.
+on:
+  pull_request:
+
+jobs:
+  baseline:
+    name: Shared PR Baseline
+    # An exact commit, never a branch or tag: the coordinate is the Skills `dev` head at adoption
+    # (2026-09-04) — the reusable workflow moved four times after the ticket's original pin (the
+    # PR-body job, the caller-root measurement, the version-that-exists fix). Moving it is a reviewed
+    # change here, one line.
+    uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@7c9bd16f97a9b58309602431fc5b5741bf818e22

--- a/.github/workflows/shared-pr-baseline.yml
+++ b/.github/workflows/shared-pr-baseline.yml
@@ -5,8 +5,13 @@
 
 name: Shared PR Baseline
 
+# The called workflow's PR-body job reads the pull request live (never the event snapshot), so it
+# declares `pull-requests: read` for itself — and a called job may not hold more than its caller
+# grants: with `contents: read` alone the run fails at startup before any job exists (measured on
+# this repository's first caller run). Both grants stay read-only.
 permissions:
   contents: read
+  pull-requests: read
 
 # Deliberately unfiltered: once these jobs become required contexts, every PR must emit a terminal
 # result. The called PR-base job rejects an unsupported base instead of leaving a context pending.

--- a/.github/workflows/shared-pr-baseline.yml
+++ b/.github/workflows/shared-pr-baseline.yml
@@ -13,10 +13,14 @@ permissions:
   contents: read
   pull-requests: read
 
-# Deliberately unfiltered: once these jobs become required contexts, every PR must emit a terminal
-# result. The called PR-base job rejects an unsupported base instead of leaving a context pending.
+# Deliberately unfiltered by branch or path: once these jobs become required contexts, every PR
+# must emit a terminal result — the called PR-base job rejects an unsupported base instead of
+# leaving a context pending. The activity types are explicit because the callee reads the pull
+# request LIVE and says so in its own header: a body-only `edited` and a draft's `ready_for_review`
+# must re-run the gate, and GitHub's default set carries neither.
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 jobs:
   baseline:


### PR DESCRIPTION
Resolves #64

One tracked caller, `.github/workflows/shared-pr-baseline.yml`: the `pull_request` trigger with its activity types explicit (`opened`, `edited`, `synchronize`, `reopened`, `ready_for_review` — the callee's own header names them, and GitHub's default set carries neither `edited` nor `ready_for_review`), unfiltered by branch or path; read-only permissions (`contents: read` + `pull-requests: read` — the called PR-body job reads the pull request live and a called job may hold no more than its caller grants); one job that `uses:` the reusable baseline at the exact Skills commit `7c9bd16f97a9b58309602431fc5b5741bf818e22` — the Skills `dev` head at adoption. Nothing is copied into this repository; `ci.yml` (the product jobs) is untouched.

Evidence: L3 (this pull request's own runs are the receipt — the called jobs appear as its checks; a body-only edit starts them without a push) → L3 required (AC-3 and AC-4 are live-run facts). Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | the file: `pull_request` with explicit `types` (the five above), no branch or path filter, one job `baseline`, `permissions: contents: read` plus `pull-requests: read` — the ticket names `contents: read` alone, which predates the called PR-body job: with it alone the first run on this PR ended in `startup_failure` with no job (the callee's job asks for `pull-requests: read`, and a called job may not exceed its caller's grant); both grants are read-only. |
| AC-2 | `uses: neomjs/neo-agent-skills/.github/workflows/reusable-pr-baseline.yml@7c9bd16f97a9b58309602431fc5b5741bf818e22` — an exact commit, no branch, no tag. The ticket's `d6551c8a…` (2026-08-30) predates the PR-body job (skills #29), the caller-root measurement (#25) and the version-that-exists pin (#27); the restatement is on #64's intake comment. |
| AC-3 | this PR's checks carry the called contexts: `PR base`, `Skills materialized`, `Source comment archaeology` — and the two the workflow gained since the ticket, `Substrate size` and `PR body`. Five terminal results beside the two product jobs, on every admitted event: `synchronize` at `f9e3298` (7/7, run 33929896949) and `edited` on a body-only change with no push — run 33930101509, created 23:35:49Z, three seconds after the 23:35:46Z edit, completed/success; `Institution CI` did not run on it, its default activity set lacks `edited`. |
| AC-4 | `Skills materialized` on this PR installs the lockfile and runs `neo-agent-skills-materialize --check` against this checkout (`neo-agent-skills ^0.1.3`, `postinstall` materializes). |
| AC-5 | the diff touches one new file; `ci.yml` and every product job unchanged, running beside the baseline on this PR. |
| AC-6 | 29 lines, comments and coordinates only — no job body, policy array, archaeology logic, lint or hook runtime enters the repository. |

## Deltas from ticket
- The pin moves from `d6551c8a…` to the Skills head `7c9bd16f97…` — the same immutable discipline, a newer coordinate; at the ticket's coordinate the baseline would run without the PR-body gate.
- Five called jobs, not three: the workflow grew `Substrate size` and `PR body` after the ticket was written.
- `pull-requests: read` beside `contents: read`: the PR-body job's own declared grant, which the caller must cover (measured: `startup_failure`, zero jobs, on the `contents: read`-only first push). DevIndex's caller predates the job and needs nothing more at its pin.
- Explicit `pull_request.types` (round-1 RA): a bare `pull_request:` admits only the default activity set, so a corrected body kept its stale gate result and a promoted draft never re-ran the now-stricter close-target check; the callee's header requires `opened`, `edited`, `synchronize` and `ready_for_review`, and `reopened` stays compatible.

## Test Evidence
The caller has no unit surface; its evidence is the live runs on this pull request (AC-3, AC-4): `synchronize` at `f9e3298`, 7/7 (runs 33929896949 + 33929896566, 23:32:41Z); the `edited` event exercised by a body-only change without a push — run 33930101509 (https://github.com/neomjs/neo-agent-institution/actions/runs/33930101509), the only workflow that ran on it. All other coverage runs in CI.

## Post-Merge Validation
- [ ] The next agent PR after the merge carries the five baseline contexts; whether any becomes a required check is a branch-rule decision (out of scope here, the operator's).

## Commits
- `0caa73d` — the caller at the Skills head.
- `30be148` — the `pull-requests: read` grant the called PR-body job needs (the first run's `startup_failure`).
- `f9e3298` — the explicit activity types the callee's header requires.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 46962d8b-08f3-49a3-8049-d74e2052af37.
