### PR TITLE
feat(fleet): preserve typed connection state through cockpit reads (#18)

### DIFF
--- a/apps/agentos/fleet/installFleetBridge.mjs
+++ b/apps/agentos/fleet/installFleetBridge.mjs
@@ -161,39 +161,58 @@ export function installFleetBridge({
                 throw new Error(FLEET_LOCAL_TRANSPORT_ERRORS.noBearer)
             }
             : async request => {
-                const response = await fetchImpl(fleetUrl.href, {
+                return fetchImpl(fleetUrl.href, {
                     method : 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         Authorization : `Bearer ${bearerToken}`
                     },
                     body: JSON.stringify(request)
-                });
-
-                return response.json()
+                })
             }
     }
 
-    // The browser's half of the wire contract: one async proxy per twin-listed verb, unwrapping the
-    // finite response envelope only after its selection matches this realm's offer. Browser mode
-    // sends that offer directly; shell mode relies on parity with main's independently owned offer.
+    /**
+     * @summary Unwrap one validated reply and preserve only evidence-backed connection failures.
+     *
+     * `Error.fleetConnectionState` is a finite client observation: `unreachable` means send/fetch
+     * rejected before returning a response; validated `refused` and operation failure/degradation
+     * mean `refused` and `failed-upstream`. Local launch failures, JSON decoding and protocol
+     * validation failures remain unclassified. Neither error text nor a transport-supplied Error
+     * property can assert a remote outcome. Browser requests carry this realm's offer; shell
+     * requests rely on parity with main's independently owned offer.
+     * @param {String} method
+     * @param {*} params
+     * @returns {Promise<*>} The validated operation result.
+     */
     const request = async (method, params) => {
         const
             offer       = createFleetWireOffer(),
             wireRequest = createFleetWireRequest(method, params, offer);
 
-        let envelope, inspection;
+        let envelope, inspection, response;
 
         try {
-            envelope = await transportSend(shellTransport
+            response = await transportSend(shellTransport
                 ? {method: wireRequest.method, params: wireRequest.params}
                 : wireRequest)
         } catch (error) {
-            const safeError = Object.values(FLEET_LOCAL_TRANSPORT_ERRORS).includes(error?.message)
-                ? error.message
-                : 'fleet: request transport failed';
+            const localFailure = Object.values(FLEET_LOCAL_TRANSPORT_ERRORS).includes(error?.message),
+                  safeError    = new Error(localFailure ? error.message : 'fleet: request transport failed');
 
-            throw new Error(safeError)
+            if (!localFailure) {
+                safeError.fleetConnectionState = 'unreachable'
+            }
+
+            throw safeError
+        }
+
+        try {
+            envelope = shellTransport ? response : await response.json()
+        } catch {
+            // A response arrived, but its body is unusable. Keep the established safe message
+            // without classifying that parsing failure as absence of a response.
+            throw new Error('fleet: request transport failed')
         }
 
         try {
@@ -207,7 +226,15 @@ export function installFleetBridge({
         }
 
         if (envelope.state !== FLEET_WIRE_RESPONSE_STATES.ok) {
-            throw new Error(envelope?.error || `fleet: '${method}' failed`);
+            const error = new Error(envelope.error || `fleet: '${method}' failed`);
+
+            if (envelope.state === FLEET_WIRE_RESPONSE_STATES.refused) {
+                error.fleetConnectionState = 'refused'
+            } else if ([FLEET_WIRE_RESPONSE_STATES.operationFailed, FLEET_WIRE_RESPONSE_STATES.degraded].includes(envelope.state)) {
+                error.fleetConnectionState = 'failed-upstream'
+            }
+
+            throw error
         }
 
         return envelope.result

--- a/apps/agentos/util/SpineBanner.mjs
+++ b/apps/agentos/util/SpineBanner.mjs
@@ -155,10 +155,42 @@ class SpineBanner extends Base {
     }
 
     /**
+     * @summary Describe the deciding read's observation without diagnosing another surface.
+     * A refusal can originate at an admitted shell boundary, so copy names the request, never
+     * an authentication decision or a claim that the remote server refused it. Timeout means
+     * the read bound elapsed; it says nothing about progress or whether waiting is safe.
+     * @param {Object} surface The read owner-held surface with an optional connection observation.
+     * @param {String} kind Existing banner skin: cold or degraded.
+     * @param {String} scope Fleet roster or activity feed label.
+     * @param {String} detail The data state this verdict is qualified to describe.
+     * @returns {Object|null} A banner verdict, or null for absent/unknown observations.
+     */
+    static connectionVerdict(surface, kind, scope, detail) {
+        const connection = surface?.connection,
+              subject = scope === 'fleet' ? 'Roster' : 'Activity',
+              copy = {
+                  connecting: ['connecting', `${subject} read in progress`],
+                  refused: ['refused', `${subject} request refused`],
+                  unreachable: ['unreachable', `${subject} connection unavailable`],
+                  timeout: ['timed out', `${subject} read timed out`],
+                  'failed-upstream': ['failed', `${subject} request reported an upstream failure`]
+              };
+
+        if (!connection || !Object.hasOwn(copy, connection.state)) return null;
+
+        const [word, sentence] = copy[connection.state],
+              reason = typeof connection.reason === 'string' ? connection.reason.trim() : '',
+              title = `${sentence} — ${detail}${reason ? ` · ${reason}` : ''}`;
+
+        return {hidden: false, kind, text: `${scope} ${word}`, title, ariaLabel: title}
+    }
+
+    /**
      * @summary Derives the spine banner from the owner-held surface truths.
      * @param {Object} options
-     * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
-     *     plus the safe cause the owner retained for THAT surface, if it learned one.
+     * @param {{state: String, reason: ?String, connection: ?Object}} options.grid The roster surface:
+     *     `'sample'|'stale'|'live'`, its retained cause and its read owner's optional connection
+     *     observation `{state, reason}`. Both reasons are sanitized before publication.
      * @param {{state: String, reason: ?String}} options.stream The activity surface, same shape.
      * @param {{state: String, reason: ?String}} [options.daemon] Brain daemon health:
      *     `'running'|'degraded'|'stopped'`, with the diagnosis pointer as its reason. Optional — a caller
@@ -195,6 +227,10 @@ class SpineBanner extends Base {
                 return verdict('cold', 'fleet offline', `Fleet data unavailable — showing the static roster · ${reason}`)
             }
 
+            const connection = SpineBanner.connectionVerdict(grid, 'cold', 'fleet', 'showing the static roster');
+
+            if (connection) return connection;
+
             const fallback = coldFallbackFor(transport);
 
             return verdict('cold', fallback.text, fallback.title)
@@ -222,7 +258,15 @@ class SpineBanner extends Base {
         }
 
         if (states.includes('stale')) {
-            const reason = reasonFor(surfaces, 'stale');
+            const reason = reasonFor(surfaces, 'stale'),
+                  // Follow the SAME surface whose retained reason decided the verdict. A live
+                  // sibling's pending read has no standing to relabel this loss.
+                  deciding = surfaces.find(surface => surface?.state === 'stale' &&
+                      (reason ? typeof surface.reason === 'string' && surface.reason.trim() === reason : true)),
+                  connection = reason && deciding?.connection?.state === 'connecting' ? null :
+                      SpineBanner.connectionVerdict(deciding, 'degraded', deciding === grid ? 'fleet' : 'feed', 'showing last-known data');
+
+            if (connection) return connection;
 
             return verdict('degraded', 'fleet degraded', reason
                 ? `Fleet feed degraded — showing last-known data · ${reason}`
@@ -235,6 +279,12 @@ class SpineBanner extends Base {
         // transport fact is deliberately not consulted (it belongs to the cold family alone).
         if (stream?.state === 'sample') {
             const reason = reasonFor([stream], 'sample');
+
+            if (!reason) {
+                const connection = SpineBanner.connectionVerdict(stream, 'degraded', 'feed', 'roster is live · showing sample activity');
+
+                if (connection) return connection
+            }
 
             return verdict('degraded', 'feed pending', reason
                 ? `Activity feed pending — roster is live · ${reason}`

--- a/apps/agentos/view/fleet/cockpit/LivenessController.mjs
+++ b/apps/agentos/view/fleet/cockpit/LivenessController.mjs
@@ -213,13 +213,13 @@ class LivenessController extends ComponentController {
         if (!store || typeof bridge?.fleetActivity !== 'function') {
             // no bridge/verb IS the cold truth; a never-wired surface's retained answered cause
             // must not outlive the bridge that answered it
-            if (provider?.getData('streamAdapterState') === 'sample') {
-                provider.setData('streamDegradedReason', null)
-            }
+            me.publishConnection('stream', {data: provider?.getData('streamAdapterState') === 'sample'
+                ? {streamDegradedReason: null} : {}});
             return
         }
 
         try {
+            me.publishConnection('stream', {pending: true});
             me.streamReadInFlight++;
 
             // invoked INSIDE the chain: a synchronous throw becomes a rejection of the tracked
@@ -239,22 +239,26 @@ class LivenessController extends ComponentController {
             if (capability?.state === 'wired') {
                 store.ingestSnapshot(Array.isArray(events) ? events : [], {replace: !me.activityWired});
                 me.activityWired = true;
-                provider?.setData({
+                me.publishConnection('stream', {data: {
                     activityCounts      : Array.isArray(counts) ? counts : [],
                     streamAdapterState  : 'live',
                     streamDegradedReason: null
-                });
+                }});
                 stream && (stream.adapterState = 'live')
             } else if (capability?.state === 'degraded') {
-                provider?.setData({
+                me.publishConnection('stream', {data: {
                     streamAdapterState  : 'stale',
                     streamDegradedReason: me.toSafeDegradedReason(capability.reason)
-                });
+                }});
                 stream && (stream.adapterState = 'stale')
             } else if (capability) {
                 // the producer ANSWERED not-wired: the sample seed stays (the stream really is
                 // showing sample events) but an answer is not silence — retain the cause
-                provider?.setData('streamDegradedReason', me.toSafeDegradedReason(capability.reason))
+                me.publishConnection('stream', {data: {
+                    streamDegradedReason: me.toSafeDegradedReason(capability.reason)
+                }})
+            } else {
+                me.publishConnection('stream')
             }
             // NO capability (torn/absent answer): keep the sample seed AND no reason — we learned
             // nothing, the banner falls back to generic copy rather than inventing a cause
@@ -286,13 +290,13 @@ class LivenessController extends ComponentController {
             generation = ++me.gridReadGeneration;
 
         if (!store || typeof bridge?.fleetRoster !== 'function') {
-            if (provider?.getData('gridAdapterState') === 'sample') {
-                provider.setData('gridDegradedReason', null)
-            }
+            me.publishConnection('grid', {data: provider?.getData('gridAdapterState') === 'sample'
+                ? {gridDegradedReason: null} : {}});
             return
         }
 
         try {
+            me.publishConnection('grid', {pending: true});
             me.gridReadInFlight++;
 
             const {capabilities, rows} = await me.boundedRead(
@@ -305,6 +309,7 @@ class LivenessController extends ComponentController {
             }
 
             if (!Array.isArray(rows)) {
+                me.publishConnection('grid');
                 return // malformed answer → keep the last-known roster
             }
 
@@ -316,7 +321,9 @@ class LivenessController extends ComponentController {
             if (!me.rosterWired && mapped.length === 0 && !bridge?.selected && cockpit.rosterSourceMode !== 'selected') {
                 // the server ANSWERED — retain the cause so the banner names "connected · registry
                 // empty" instead of advising a restart of a process that just replied
-                provider?.setData('gridDegradedReason', 'server connected · fleet registry empty — define agents to go live');
+                me.publishConnection('grid', {data: {
+                    gridDegradedReason: 'server connected · fleet registry empty — define agents to go live'
+                }});
                 return
             }
 
@@ -333,13 +340,13 @@ class LivenessController extends ComponentController {
                 me.reconcileSelection()
             }
 
-            provider?.setData({
+            me.publishConnection('grid', {data: {
                 gridAdapterState  : 'live',
                 gridDegradedReason: null,
                 // the presence-capability envelope rides every admitted snapshot; absent or
                 // malformed envelopes plumb null — the chip claims nothing
                 presenceCapability: capabilities?.presence ?? null
-            });
+            }});
             grid && (grid.adapterState = 'live');
 
             // roster-derived consumer refreshes: resident panes snapshot their options at
@@ -434,7 +441,8 @@ class LivenessController extends ComponentController {
      * @summary Advance ONE wired surface to the degraded truth and retain the safe reason. A
      * surface that never reached `live` stays on its honest `sample` seed — advancing it to
      * `stale` would claim last-known data that never existed — and a transport failure RETRACTS
-     * any answered-state cause it retained (the claim must not outlive the connection).
+     * any answered-state cause it retained (the claim must not outlive the connection). The
+     * current read's typed connection observation keeps its own sanitized reason on either path.
      * @param {String} surface `'grid'|'stream'`
      * @param {*} error The transport failure (untrusted — never rendered raw).
      * @param {Neo.component.Base|null} [consumer] The held child whose badge mirrors the state.
@@ -448,18 +456,46 @@ class LivenessController extends ComponentController {
 
         if (!provider) return;
 
-        if (provider.getData(stateKey) === 'sample') {
-            provider.setData(causeKey, null);
-            return
-        }
-
-        provider.setData({
-            [stateKey]: 'stale',
+        const state = provider.getData(stateKey) === 'sample' ? 'sample' : 'stale';
+        this.publishConnection(surface, {error, data: {
+            [stateKey]: state,
             // this surface's cause on this surface's field — never a shared slot a sibling clears
-            [causeKey]: this.toSafeDegradedReason(error)
-        });
+            [causeKey]: state === 'sample' ? null : this.toSafeDegradedReason(error)
+        }});
 
-        consumer && (consumer.adapterState = 'stale')
+        consumer && state === 'stale' && (consumer.adapterState = 'stale')
+    }
+
+    /**
+     * @summary Retain only a finite producer classification and its safe reason for this read.
+     * Message text never determines the class; unknown errors preserve ordinary fallback copy.
+     * @param {*} error The bridge failure or locally produced read-bound error.
+     * @returns {{state: String|null, reason: String|null}}
+     * @protected
+     */
+    connectionObservation(error) {
+        const state = ['refused', 'unreachable', 'timeout', 'failed-upstream'].includes(error?.fleetConnectionState)
+            ? error.fleetConnectionState : null;
+
+        return {state, reason: state ? this.toSafeDegradedReason(error) : null}
+    }
+
+    /**
+     * @summary Publish one read owner's observation with its other state in one Provider batch.
+     * The caller must pass its generation fence first; a new surface declares its own Provider
+     * leaves and reuses this path without sharing another surface's connection or reason.
+     * @param {String} surface The owner key, e.g. grid or stream.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.pending=false] The admitted read is still in flight.
+     * @param {*} [options.error=null] Its terminal failure, or null to clear the observation.
+     * @param {Object} [options.data={}] Additional validated state from this same read owner.
+     * @protected
+     */
+    publishConnection(surface, {pending=false, error=null, data={}}={}) {
+        this.component.getStateProvider()?.setData({
+            ...data,
+            [`${surface}Connection`]: pending ? {state: 'connecting', reason: null} : this.connectionObservation(error)
+        })
     }
 
     /**
@@ -507,7 +543,9 @@ class LivenessController extends ComponentController {
         return Promise.race([
             read.finally(() => clearTimeout(timerId)),
             new Promise((resolve, reject) => {
-                timerId = setTimeout(() => reject(new Error(`fleet read exceeded ${timeout}ms`)), timeout)
+                timerId = setTimeout(() => reject(Object.assign(new Error(`fleet read exceeded ${timeout}ms`), {
+                    fleetConnectionState: 'timeout'
+                })), timeout)
             })
         ])
     }

--- a/apps/agentos/view/fleet/cockpit/StateProvider.mjs
+++ b/apps/agentos/view/fleet/cockpit/StateProvider.mjs
@@ -14,8 +14,8 @@ import {sampleActivity}    from '../../../config/fleetSampleData.mjs';
  */
 const deriveBannerVerdict = data => SpineBanner.deriveSpineBanner({
     daemon   : {state: data.daemonState,        reason: data.daemonDegradedReason},
-    grid     : {state: data.gridAdapterState,   reason: data.gridDegradedReason},
-    stream   : {state: data.streamAdapterState, reason: data.streamDegradedReason},
+    grid     : {state: data.gridAdapterState,   reason: data.gridDegradedReason, connection: data.gridConnection},
+    stream   : {state: data.streamAdapterState, reason: data.streamDegradedReason, connection: data.streamConnection},
     transport: data.shellTransport
 });
 
@@ -85,6 +85,12 @@ class StateProvider extends Provider {
              */
             gridAdapterState: 'sample',
             /**
+             * The roster read owner's finite observation and sanitized reason. Leaf-complete so
+             * the banner and dot react to this surface independently of the activity read.
+             * @member {Object} gridConnection={state:null,reason:null}
+             */
+            gridConnection: {state: null, reason: null},
+            /**
              * The ROSTER surface's retained degrade reason. Per-surface, not shared: one field
              * for two independently-answering surfaces cannot know whose cause it holds.
              * @member {String|null} gridDegradedReason=null
@@ -129,6 +135,11 @@ class StateProvider extends Provider {
              * @member {String} streamAdapterState='sample'
              */
             streamAdapterState: 'sample',
+            /**
+             * Activity read observation; success/absence clears only this surface's fields.
+             * @member {Object} streamConnection={state:null,reason:null}
+             */
+            streamConnection: {state: null, reason: null},
             /**
              * The ACTIVITY surface's retained degrade reason — see {@link #data.gridDegradedReason}.
              * @member {String|null} streamDegradedReason=null

--- a/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/installFleetBridge.spec.mjs
@@ -497,8 +497,110 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
                 target           : {}
             });
 
-            await expect(bridge.listAgents()).rejects.toThrow(/malformed|unoffered/)
+            const error = await bridge.listAgents().catch(error => error);
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toMatch(/malformed|unoffered/);
+            expect(error).not.toHaveProperty('fleetConnectionState')
         }
+    });
+
+    test('validated wire failures retain their finite connection state through both proxy transports', async () => {
+        const cases = [
+            {state: FLEET_WIRE_RESPONSE_STATES.refused, expected: 'refused'},
+            {state: FLEET_WIRE_RESPONSE_STATES.operationFailed, expected: 'failed-upstream'},
+            {state: FLEET_WIRE_RESPONSE_STATES.degraded, expected: 'failed-upstream', degraded: 'source-unavailable'}
+        ];
+
+        for (const {state, expected, degraded} of cases) {
+            const envelope = createFleetWireResponse(state, {error: 'upstream report', degraded});
+            const bridges = [
+                installFleetBridge({credentialIngress: 'shell', send: async () => envelope, target: {}}),
+                installFleetBridge({
+                    bearerToken: testBearer,
+                    fetchImpl  : async () => ({json: async () => envelope}),
+                    target     : {},
+                    url        : fleetUrl
+                })
+            ];
+
+            for (const bridge of bridges) {
+                const error = await bridge.fleetRoster().catch(error => error);
+
+                expect(error).toBeInstanceOf(Error);
+                expect(error.message).toBe('upstream report');
+                expect(error.fleetConnectionState, state).toBe(expected)
+            }
+        }
+    });
+
+    test('unsupported and malformed outcomes gain no classification from refusal-shaped text', async () => {
+        const responses = [
+            ...[
+                FLEET_WIRE_RESPONSE_STATES.unsupportedCapability,
+                FLEET_WIRE_RESPONSE_STATES.unsupportedMethod,
+                FLEET_WIRE_RESPONSE_STATES.unsupportedProtocol
+            ].map(state => createFleetWireResponse(state, {error: 'request refused: failed-upstream'})),
+            {...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused), ok: true},
+            {...createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused), state: 'unknown'},
+            createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.degraded, {error: 'request refused'})
+        ];
+
+        for (const response of responses) {
+            const bridge = installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async () => response,
+                target           : {}
+            });
+            const error = await bridge.fleetActivity().catch(error => error);
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error).not.toHaveProperty('fleetConnectionState')
+        }
+    });
+
+    test('pre-response rejection is unreachable, and neither credentials nor an injected classification escape', async () => {
+        const unsafe = Object.assign(new Error(`Authorization: Bearer ${testBearer}; refused at ${fleetUrl}`), {
+            fleetConnectionState: 'refused'
+        });
+        const bridges = [
+            installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async () => { throw unsafe },
+                target           : {}
+            }),
+            installFleetBridge({
+                bearerToken: testBearer,
+                fetchImpl  : async () => { throw unsafe },
+                target     : {},
+                url        : fleetUrl
+            })
+        ];
+
+        for (const bridge of bridges) {
+            const error = await bridge.fleetRoster().catch(error => error);
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error).not.toBe(unsafe);
+            expect(error.message).toBe('fleet: request transport failed');
+            expect(error.fleetConnectionState).toBe('unreachable');
+            expect(error.message).not.toContain(testBearer);
+            expect(error.message).not.toContain(fleetUrl)
+        }
+    });
+
+    test('a response whose JSON cannot be read is unclassified, not an unreachable plane', async () => {
+        const bridge = installFleetBridge({
+            bearerToken: testBearer,
+            fetchImpl  : async () => ({json: async () => { throw new Error(`Bearer ${testBearer}`) }}),
+            target     : {},
+            url        : fleetUrl
+        });
+        const error = await bridge.fleetActivity().catch(error => error);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe('fleet: request transport failed');
+        expect(error).not.toHaveProperty('fleetConnectionState')
     });
 
     test('transport and JSON-parser rejection text is never relayed into the pane', async () => {
@@ -524,13 +626,17 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
     });
 
     test('known local launch-state errors retain their bounded remediation', async () => {
-        const bridge = installFleetBridge({
-            credentialIngress: 'shell',
-            send             : async () => { throw new Error(FLEET_LOCAL_TRANSPORT_ERRORS.noLiveWindow) },
-            target           : {}
-        });
+        for (const message of Object.values(FLEET_LOCAL_TRANSPORT_ERRORS)) {
+            const bridge = installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async () => { throw new Error(message) },
+                target           : {}
+            });
+            const error = await bridge.listAgents().catch(error => error);
 
-        await expect(bridge.listAgents()).rejects.toThrow(FLEET_LOCAL_TRANSPORT_ERRORS.noLiveWindow)
+            expect(error.message).toBe(message);
+            expect(error).not.toHaveProperty('fleetConnectionState')
+        }
     });
 
     test('fails loud before publishing when the fleet endpoint is missing or invalid', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/chromeBinding.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/chromeBinding.spec.mjs
@@ -14,6 +14,8 @@ import FleetActivityEvents  from '../../../../../../../../apps/agentos/store/Fle
 import FleetCockpit         from '../../../../../../../../apps/agentos/view/fleet/cockpit/Container.mjs';
 import FleetRoster          from '../../../../../../../../apps/agentos/store/FleetRoster.mjs';
 import ViewerWakeFeed       from '../../../../../../../../apps/agentos/store/ViewerWakeFeed.mjs';
+import {installFleetBridge} from '../../../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
+import {createFleetWireResponse} from '../../../../../../../../apps/agentos/config/fleetWireMethods.mjs';
 
 /**
  * The chrome-binding REVEAL witness over a real constructed cockpit: the declared chrome slots
@@ -59,6 +61,56 @@ test('the declared chrome binds the derived truths — banner revealed with the 
     expect(telltale.cls).toContain('fm-viewer-wake-degraded');
 
     cockpit.destroy()
+});
+
+test('typed wire refusal and recovery drive the real read owner, reactive banner and parent dot', async () => {
+    const previousFleet = globalThis.AgentOS?.fleet,
+          parent = Neo.create((await import('../../../../../../../../node_modules/neo.mjs/src/state/Provider.mjs')).default, {
+              data: {boundProfileId: null, instanceState: 'off'}
+          }),
+          cockpit = Neo.create(FleetCockpit, {
+              stateProvider: {
+                  module: CockpitStateProvider,
+                  parent,
+                  stores: {
+                      fleetActivityEvents: {module: FleetActivityEvents},
+                      fleetRoster: {module: FleetRoster, autoLoad: false},
+                      viewerWakeFeed: {module: ViewerWakeFeed}
+                  }
+              }
+          });
+
+    try {
+        await cockpit.refreshPromise;
+        const provider = cockpit.getStateProvider(),
+              banner = cockpit.getReference('fleet-spine-banner');
+        provider.setData({gridAdapterState: 'live', streamAdapterState: 'sample'});
+
+        let answer;
+        installFleetBridge({send: () => new Promise(resolve => { answer = resolve })});
+        const pending = cockpit.getController().loadActivity();
+        await expect.poll(() => banner.text).toBe('feed connecting');
+        answer(createFleetWireResponse('refused', {error: 'request denied; token=private-token'}));
+        await pending;
+
+        expect(banner.text).toBe('feed refused');
+        expect(banner.vdom.title).toContain('request denied');
+        expect(banner.vdom.title).not.toContain('private-token');
+        expect(banner.vdom['aria-label']).toBe(banner.vdom.title);
+        expect(parent.getData('instanceState')).toBe('limited');
+
+        installFleetBridge({send: async () => createFleetWireResponse('ok', {
+            result: {capability: {state: 'wired'}, events: []}
+        })});
+        await cockpit.getController().loadActivity();
+        expect(provider.getData('streamConnection.state')).toBeNull();
+        expect(banner.hidden).toBe(true);
+        expect(parent.getData('instanceState')).toBe('ok')
+    } finally {
+        cockpit.destroy();
+        parent.destroy();
+        previousFleet === undefined ? delete globalThis.AgentOS.fleet : globalThis.AgentOS.fleet = previousFleet
+    }
 });
 
 test('RA-1 witness: the cockpit derivation writes the PARENT-owned instanceState — live→ok, degraded→limited, never a child shadow', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/livenessLifecycle.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/livenessLifecycle.spec.mjs
@@ -16,7 +16,12 @@ import * as core                  from '../../../../../../../../node_modules/neo
 // the spec file stands in for the thread ENTRYPOINT (src/worker/App.mjs in production), which is
 // the one place that imports the instance manager — real Store/Record paths resolve Neo.get here
 import                                 '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs';
-import {makeActivityStoreHarness} from './cockpitFakes.mjs';
+import {makeActivityStoreHarness, makeProviderFake} from './cockpitFakes.mjs';
+import {installFleetBridge} from '../../../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
+import {
+    createFleetWireResponse,
+    FLEET_WIRE_RESPONSE_STATES
+} from '../../../../../../../../apps/agentos/config/fleetWireMethods.mjs';
 
 /**
  * The liveness owner's LIFECYCLE witness. A transition matrix proves the owner tells the truth while
@@ -31,10 +36,11 @@ import {makeActivityStoreHarness} from './cockpitFakes.mjs';
  * start on a live cockpit would silently double the poll rate against the bridge.
  */
 test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #15293)', () => {
-    let FleetCockpitController;
+    let FleetCockpitController, FleetRoster;
 
     test.beforeAll(async () => {
-        FleetCockpitController = (await import('../../../../../../../../apps/agentos/view/fleet/cockpit/Controller.mjs')).default
+        FleetCockpitController = (await import('../../../../../../../../apps/agentos/view/fleet/cockpit/Controller.mjs')).default;
+        FleetRoster = (await import('../../../../../../../../apps/agentos/store/FleetRoster.mjs')).default
     });
 
     /**
@@ -78,6 +84,202 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             _clearInterval: id => cleared.push(id)
         })
     };
+
+    test.describe('roster connection observations through the real bridge and loader', () => {
+        let previousFleet, stores;
+
+        test.beforeEach(() => {
+            previousFleet = globalThis.AgentOS?.fleet;
+            stores = []
+        });
+
+        test.afterEach(() => {
+            stores.forEach(store => store.destroy());
+            if (previousFleet === undefined) {
+                delete globalThis.AgentOS.fleet
+            } else {
+                globalThis.AgentOS.fleet = previousFleet
+            }
+        });
+
+        /**
+         * @summary Keeps the real roster loader, mapping and Store; only unrelated view seams
+         * are absent. Every capacity change comes from a real wire settlement, never a counter edit.
+         */
+        const makeRosterHost = ({state = 'sample', timeout = 2000} = {}) => {
+            const provider = makeProviderFake({
+                gridAdapterState: state,
+                gridConnection: {state: null, reason: null},
+                streamConnection: {state: 'failed-upstream', reason: 'activity source unavailable'}
+            });
+            const store = Neo.create(FleetRoster, {
+                autoLoad: false,
+                data: [{agentId: 'resident', displayName: 'Retained resident'}]
+            });
+            const grid = {adapterState: state};
+            const host = Object.assign(makeTimerHost(), {
+                getReference: reference => reference === 'fleet-grid' ? grid : null,
+                resolveFleetRosterStore: () => store,
+                rosterWired: state === 'live'
+            });
+
+            Object.assign(host.component, {
+                getCatchUpPane: () => null,
+                getMemoriesPane: () => null,
+                getOperatorMailboxPane: () => null,
+                getStateProvider: () => provider,
+                getWakeRoutesPane: () => null,
+                livenessReadTimeout: timeout,
+                rosterSourceMode: 'selected'
+            });
+            delete host.loadRoster;
+            stores.push(store);
+
+            return {grid, host, provider, store}
+        };
+
+        /** @summary Install the production proxy against a controllable envelope-producing wire. */
+        const installWire = send => installFleetBridge({credentialIngress: 'shell', send, target: globalThis});
+        const rosterReply = id => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.ok, {
+            result: {rows: [{id, displayName: id}]}
+        });
+        const refusedReply = error => createFleetWireResponse(FLEET_WIRE_RESPONSE_STATES.refused, {error});
+
+        test('a cold roster read publishes connecting, retains a safe refusal, and clears on real recovery', async () => {
+            const {host, provider, store} = makeRosterHost();
+            const wire = Promise.withResolvers();
+            let calls = 0;
+
+            installWire(() => ++calls === 1 ? wire.promise : rosterReply('recovered'));
+            const read = host.loadRoster();
+
+            expect(provider.data.gridConnection).toEqual({state: 'connecting', reason: null});
+            await expect.poll(() => calls).toBe(1);
+            wire.resolve(refusedReply('Authorization: Bearer secret-value; request refused'));
+            await read;
+
+            expect(provider.data.gridConnection.state).toBe('refused');
+            expect(provider.data.gridConnection.reason).toContain('[redacted]');
+            expect(provider.data.gridConnection.reason).not.toContain('secret-value');
+            expect(provider.data.gridAdapterState).toBe('sample');
+            expect(store.get('resident')).toBeTruthy();
+            expect(host.gridReadInFlight).toBe(0);
+
+            await host.loadRoster();
+
+            expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+            expect(provider.data.gridAdapterState).toBe('live');
+            expect(store.get('recovered')).toBeTruthy();
+            expect(store.get('resident')).toBeFalsy();
+            expect(provider.data.streamConnection).toEqual({state: 'failed-upstream', reason: 'activity source unavailable'})
+        });
+
+        test('a roster timeout preserves last-known data and wire capacity until its late reply settles', async () => {
+            const {host, provider, store} = makeRosterHost({state: 'live', timeout: 20});
+            const wire = Promise.withResolvers();
+
+            installWire(() => wire.promise);
+            const read = host.loadRoster();
+
+            expect(provider.data.gridConnection.state).toBe('connecting');
+            await read;
+
+            expect(provider.data.gridConnection).toEqual({state: 'timeout', reason: 'fleet read exceeded 20ms'});
+            expect(provider.data.gridAdapterState).toBe('stale');
+            expect(host.gridReadInFlight, 'the deadline did not settle the wire').toBe(1);
+            expect(store.get('resident')).toBeTruthy();
+
+            wire.resolve(rosterReply('late'));
+            await expect.poll(() => host.gridReadInFlight).toBe(0);
+
+            expect(provider.data.gridConnection.state).toBe('timeout');
+            expect(store.get('resident')).toBeTruthy();
+            expect(store.get('late')).toBeFalsy()
+        });
+
+        for (const newerState of ['connecting', 'refused']) {
+            test(`an older roster success cannot clear the newer ${newerState} observation`, async () => {
+                const {host, provider, store} = makeRosterHost();
+                const wires = [Promise.withResolvers(), Promise.withResolvers()];
+                let calls = 0;
+
+                installWire(() => wires[calls++].promise);
+                const older = host.loadRoster(), newer = host.loadRoster();
+
+                await expect.poll(() => calls).toBe(2);
+
+                if (newerState === 'refused') {
+                    wires[1].resolve(refusedReply('newer request refused'));
+                    await newer
+                }
+
+                wires[0].resolve(rosterReply('obsolete'));
+                await older;
+
+                expect(provider.data.gridConnection.state).toBe(newerState);
+                expect(store.get('resident')).toBeTruthy();
+                expect(store.get('obsolete')).toBeFalsy();
+
+                if (newerState === 'connecting') {
+                    expect(host.gridReadInFlight).toBe(1);
+                    wires[1].resolve(rosterReply('current'));
+                    await newer;
+                    expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+                    expect(store.get('current')).toBeTruthy()
+                }
+
+                expect(host.gridReadInFlight).toBe(0)
+            })
+        }
+
+        test('bridge absence clears a pending roster observation without releasing or admitting its old wire', async () => {
+            const {host, provider, store} = makeRosterHost();
+            const wire = Promise.withResolvers();
+
+            installWire(() => wire.promise);
+            const pending = host.loadRoster();
+
+            expect(provider.data.gridConnection.state).toBe('connecting');
+            delete globalThis.AgentOS.fleet.registryBridge;
+            await host.loadRoster();
+
+            expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+            expect(host.gridReadInFlight).toBe(1);
+
+            wire.resolve(rosterReply('obsolete'));
+            await pending;
+
+            expect(host.gridReadInFlight).toBe(0);
+            expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+            expect(store.get('resident')).toBeTruthy();
+            expect(store.get('obsolete')).toBeFalsy()
+        });
+
+        test('Reconnect admits the new bridge while an old refusal can only release its own capacity', async () => {
+            const {host, provider, store} = makeRosterHost();
+            const oldWire = Promise.withResolvers();
+
+            installWire(() => oldWire.promise);
+            const older = host.loadRoster();
+
+            expect(provider.data.gridConnection.state).toBe('connecting');
+            installWire(() => rosterReply('reconnected'));
+            host.reconnectFleet();
+
+            await expect.poll(() => provider.data.gridAdapterState).toBe('live');
+            expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+            expect(store.get('reconnected')).toBeTruthy();
+            expect(host.gridReadInFlight, 'the prior bridge still owns an unsettled request').toBe(1);
+
+            oldWire.resolve(refusedReply('obsolete bridge refused'));
+            await older;
+
+            expect(host.gridReadInFlight).toBe(0);
+            expect(provider.data.gridConnection).toEqual({state: null, reason: null});
+            expect(provider.data.gridAdapterState).toBe('live');
+            expect(store.get('reconnected')).toBeTruthy()
+        })
+    });
 
     test('start is idempotent: a second call never stacks a second timer', () => {
         const host     = makeTimerHost(),

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/spineBanner.spec.mjs
@@ -27,6 +27,63 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
 
     const HIDDEN_LIVE = {hidden: true, kind: 'live', text: '', title: '', ariaLabel: ''};
 
+    test.describe('connection observations belong to the deciding read', () => {
+        const cases = [
+            ['connecting', 'connecting'], ['refused', 'refused'], ['unreachable', 'unreachable'],
+            ['timeout', 'timed out'], ['failed-upstream', 'failed']
+        ];
+
+        for (const [state, word] of cases) {
+            test(`${state} distinguishes cold roster and last-known activity without a server diagnosis`, () => {
+                const connection = {state, reason: 'bounded read detail'},
+                      cold = SpineBanner.deriveSpineBanner({grid: {state: 'sample', connection}, stream: {state: 'live'}}),
+                      stale = SpineBanner.deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'stale', connection}});
+                expect(cold.text).toBe(`fleet ${word}`);
+                expect(cold.title).toContain('static roster');
+                expect(stale.text).toBe(`feed ${word}`);
+                expect(stale.title).toContain('last-known');
+                expect(stale.ariaLabel).toBe(stale.title);
+                expect(cold.title + stale.title).not.toMatch(/safe to wait|authentication refused|server offline/)
+            })
+        }
+
+        test('a live sibling cannot relabel the stale surface whose reason decided the verdict', () => {
+            const result = SpineBanner.deriveSpineBanner({
+                grid: {state: 'live', connection: {state: 'timeout', reason: 'wrong sibling'}},
+                stream: {state: 'stale', reason: 'activity source not wired'}
+            });
+            expect(result.text).toBe('fleet degraded');
+            expect(result.title).toContain('activity source not wired');
+            expect(result.title).not.toMatch(/timed out|wrong sibling/)
+        });
+
+        test('reason selection and connection selection agree when both surfaces are stale', () => {
+            const result = SpineBanner.deriveSpineBanner({
+                grid: {state: 'stale', reason: 42, connection: {state: 'timeout'}},
+                stream: {state: 'stale', reason: 'activity refused', connection: {state: 'refused', reason: 'activity refused'}}
+            });
+            expect(result.text).toBe('feed refused');
+            expect(result.title).toContain('activity refused');
+            expect(result.title).not.toContain('timed out')
+        });
+
+        test('a pending refresh preserves the retained producer reason; daemon and live precedence stand', () => {
+            const connection = {state: 'connecting', reason: null},
+                  grid = {state: 'stale', reason: 'source unavailable', connection};
+            expect(SpineBanner.deriveSpineBanner({grid, stream: {state: 'live'}}).title).toContain('source unavailable');
+            expect(SpineBanner.deriveSpineBanner({grid, stream: {state: 'live'}, daemon: {state: 'stopped'}}).text).toBe('agent os stopped');
+            expect(SpineBanner.deriveSpineBanner({grid: {state: 'live', connection}, stream: {state: 'live', connection}})).toEqual(HIDDEN_LIVE)
+        });
+
+        test('unknown observation states preserve the ordinary fallback, including prototype names', () => {
+            const plain = {grid: {state: 'sample'}, stream: {state: 'live'}};
+            for (const state of [null, 'slow', 'toString', 'constructor', 'unknown']) {
+                expect(SpineBanner.deriveSpineBanner({...plain, grid: {state: 'sample', connection: {state, reason: 'untrusted'}}}))
+                    .toEqual(SpineBanner.deriveSpineBanner(plain))
+            }
+        })
+    });
+
     // ⭐ The daemon surface: the shell spec's "tray-state change + ONE cockpit banner with the
     // diagnosis pointer — never a popup storm". The storm clause is a property of EPISODES, not
     // renders, so it is asserted as such below rather than assumed from the return type.

--- a/test/playwright/unit/apps/agentos/view/fleet/cockpit/spineBannerPipeline.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/cockpit/spineBannerPipeline.spec.mjs
@@ -20,6 +20,8 @@ import * as core                                                        from '..
 // the one place that imports the instance manager — real Store/Record paths resolve Neo.get here
 import                                                                       '../../../../../../../../node_modules/neo.mjs/src/manager/Instance.mjs';
 import {makeActivityStoreHarness, makeControllerFake, makeProviderFake} from './cockpitFakes.mjs';
+import {installFleetBridge} from '../../../../../../../../apps/agentos/fleet/installFleetBridge.mjs';
+import {createFleetWireResponse} from '../../../../../../../../apps/agentos/config/fleetWireMethods.mjs';
 
 /**
  * The slot-sync consumer witness: `syncSpineBanner` against a REAL recording banner slot — the
@@ -369,6 +371,48 @@ test.describe('Fleet cockpit — the spine-banner pipeline (formula → componen
             delete globalThis.AgentOS?.fleet
         }
     };
+
+    test('connection publication is owner-keyed for a third surface and cannot rewrite either sibling', () => {
+        const {host, provider} = makeLivenessHost(),
+              grid = {state: 'refused', reason: 'roster refused'},
+              stream = {state: 'timeout', reason: 'activity timed out'};
+        provider.setData({gridConnection: grid, streamConnection: stream});
+
+        host.publishConnection('system', {pending: true});
+        expect(provider.data.systemConnection).toEqual({state: 'connecting', reason: null});
+        host.publishConnection('system', {error: Object.assign(new Error('denied token=private'), {
+            fleetConnectionState: 'refused'
+        })});
+        expect(provider.data.systemConnection).toEqual({state: 'refused', reason: 'denied token=[redacted]'});
+        host.publishConnection('system');
+        expect(provider.data.systemConnection).toEqual({state: null, reason: null});
+        expect(provider.data.gridConnection).toBe(grid);
+        expect(provider.data.streamConnection).toBe(stream)
+    });
+
+    test('a real refused activity response reaches its own cold feed banner with a sanitized reason', async () => {
+        const {host, provider} = makeLivenessHost();
+        provider.data.streamAdapterState = 'sample';
+
+        let answer;
+        installFleetBridge({send: () => new Promise(resolve => { answer = resolve })});
+        const pending = host.loadActivity();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(verdictOf(provider.data).text).toBe('feed connecting');
+        answer(createFleetWireResponse('refused', {error: 'activity denied; Authorization: Bearer secret-value'}));
+        await pending;
+
+        expect(provider.data.streamConnection.state).toBe('refused');
+        expect(provider.data.streamConnection.reason).not.toContain('secret-value');
+        const verdict = verdictOf(provider.data);
+        expect(verdict.text).toBe('feed refused');
+        expect(verdict.title).toContain('activity denied');
+        expect(verdict.title).toContain('roster is live');
+        expect(verdict.title).not.toContain('server offline');
+        expect(titleAfterBannerTitle(verdict.title)).toBe(verdict.title);
+        expect(deriveTruths(provider.data).instanceState).toBe('limited')
+    });
 
     test('owner-truth MOBILITY: once live, a thrown load advances to stale and the verdict NAMES the loss', async () => {
         // `live` must stop meaning "was live once": a transport death the operator can\'t see is

--- a/test/playwright/visual/__screenshots__/baseline-inputs.json
+++ b/test/playwright/visual/__screenshots__/baseline-inputs.json
@@ -2,7 +2,7 @@
     "note": "Input-identity stamp for the Darwin visual baselines — regenerate via `npm run stamp-visual-baselines` whenever goldens are re-captured. The check compares digests only; it never grants CI pixel authority.",
     "engine": "6a7599cb3d6db8c6bde51aaa371d26b0754f7a26fd28f0291d51dec0e468c1ff",
     "inputs": {
-        "apps/agentos": "d65b370d31f75bf2b53fd9eaeaa2ea91001b393804445d15f68c5488aafd734c",
+        "apps/agentos": "2bb2a6668aaacbabd50b54564c971fbbf52a5aa689ea497370061a8c578d445e",
         "resources/scss": "3763ba2d0b27b827249f1f69415ee26c2bc092a772f7cd35d7bb9d5f8dad51a0",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs": "c459a5ea768be168243a62cdf83c11586719f551524b23f0f31dcf196125241e",
         "test/playwright/e2e/agentos/AgentCardSynthesisRenderNL.spec.mjs-snapshots": "4745760abc6192d424b6a26853db152daabb4251918c4101ca2e6e4794d6dccd",


### PR DESCRIPTION
Resolves #18

Related: #10

Fleet request failures now reach the cockpit as observations owned by the roster or activity read that produced them. The real read path distinguishes connecting, refused, unreachable, timeout and upstream failure, preserves a bounded sanitized reason, and updates the existing banner and parent-owned status dot through the same Provider derivation. Successful reads clear only their own observation; stale completions and another surface's state cannot overwrite the current cause.

Evidence: L2 (real bridge, read owner, reactive Provider and component pipeline with controlled responses; local browser regression checks) → L2 required (the eight close-target ACs). Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `installFleetBridge.spec.mjs` exercises both transports, valid refusal/operation failure, unsupported/malformed responses, forged Error fields, and sanitized pre-response failures. |
| AC-2 | CI-covered: `livenessLifecycle.spec.mjs` drives the real roster Store/loader and bridge; `spineBannerPipeline.spec.mjs` drives the activity loader. Each publishes its own Provider observation. |
| AC-3 | CI-covered: `spineBanner.spec.mjs` covers cold and last-known states; `chromeBinding.spec.mjs` drives a real cockpit from pending to sanitized refusal to recovery, including title/ARIA and the parent dot. |
| AC-4 | CI-covered: mixed-surface and retained-reason controls in `spineBanner.spec.mjs`; third-owner publication isolation in `spineBannerPipeline.spec.mjs`; daemon/live precedence remains covered. |
| AC-5 | CI-covered: `livenessLifecycle.spec.mjs` tests timeout followed by late settlement, newer reads, bridge absence and reconnect. Unsettled wire capacity remains held until the wire settles. |
| AC-6 | CI-covered: successful recovery, absent bridge and unknown observation controls across the bridge/lifecycle/banner suites. |
| AC-7 | CI-covered: the producer-to-reactive-component witness in `chromeBinding.spec.mjs` plus the existing bridge, liveness and banner pipeline suites. |
| AC-8 | Isolated unit/components/E2E checks, app-size guard and generated-doc reactive-tag check pass. Darwin visual + AgentCard synthesis comparisons and the refreshed input stamp are recorded below. |

## Deltas from ticket

None substantive. [Clio's three peer deltas](https://github.com/neomjs/neo-agent-institution/issues/18#issuecomment-5547003131) are folded: `publishConnection(surface, {pending, error, data})` is owner-keyed; `loadBrainHealth` preserves its established silence/retained-fault contract; wire-envelope `degraded` is reserved protocol support, while current result-level degradation remains data. Local launch and malformed-response failures remain unclassified. Refusal copy names the request because a validated refusal can originate at the shell boundary.

## Test Evidence

- Red control: the actual bridge → activity-loader → Provider-formula witness failed on `feed pending` instead of `feed connecting` before implementation; the completed path reaches sanitized refusal and recovery. Separate bridge controls were red on missing refusal/unreachable classifications.
- On rebased `dev@28bc313ac5`, Darwin `npm run test-visual -- --workers=1` and `AgentCardSynthesisRenderNL.spec.mjs` pass against the existing goldens; no pixel baseline changed. The latter used the explicitly configured Brain fixture. Only the visual input-identity stamp changes.
- The package does not declare `agent-preflight`, and its `check-data-tracking` script points to an absent file. Those commands were attempted and are unavailable; they are not reported as passes. Existing CI checks, app-size validation, JSDoc generation and reactive-tag checks supply the executable gates for this repository.

## Post-Merge Validation

None owed — no deployed service or operator-only action is required to validate this client slice.

Authored by Euclid (OpenAI GPT 6 Astra, Codex). Session 01a06e2f-1b39-7de0-9b90-4b8e75f683f1.

📐
