### PR TITLE
fix(harness): the launcher and the test loaders follow the Fleet wire to Brain's canonical home (#115)

### DIFF
--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -93,6 +93,9 @@ export function resolveLauncherRuntimeRoot({brainMode, env = process.env, packag
 /**
  * Loads Fleet trust primitives from the selected organism instead of the shell bundle.
  * @summary Keeps checkout and packaged launchers on one canonical Fleet contract implementation.
+ * The wire vocabulary comes from the Brain's client-safe contract (`src/fleet/contract/wire.mjs`);
+ * the credential-bearing verb classification stays launcher-only and comes from the private
+ * `ai/services/fleet/fleetLaunchContract.mjs`, never from a client-facing module.
  * @param {String} [repoRoot=resolveAgentOsRuntimeRoot()] Authoritative Brain checkout or packaged organism root.
  * @returns {Promise<Object>}
  */
@@ -105,9 +108,9 @@ export function loadFleetRuntimeContracts(repoRoot = resolveAgentOsRuntimeRoot()
         contract = Promise.all([
             import(pathToFileURL(path.join(absoluteRoot, 'ai/graph/normalizeAgentIdentityNodeId.mjs')).href),
             import(pathToFileURL(path.join(absoluteRoot, 'ai/services/fleet/fleetLaunchContract.mjs')).href),
-            import(pathToFileURL(path.join(absoluteRoot, 'ai/services/fleet/fleetWireMethods.mjs')).href)
+            import(pathToFileURL(path.join(absoluteRoot, 'src/fleet/contract/wire.mjs')).href)
         ]).then(([identityContract, fleetContract, wireContract]) => ({
-            FLEET_CREDENTIAL_METHODS    : wireContract.FLEET_CREDENTIAL_METHODS,
+            FLEET_CREDENTIAL_METHODS    : fleetContract.FLEET_CREDENTIAL_METHODS,
             FLEET_WIRE_METHODS          : wireContract.FLEET_WIRE_METHODS,
             FLEET_WIRE_RESPONSE_STATES  : wireContract.FLEET_WIRE_RESPONSE_STATES,
             createFleetWireOffer        : wireContract.createFleetWireOffer,

--- a/test/playwright/e2e/agentos/authenticatedFleetHarness.mjs
+++ b/test/playwright/e2e/agentos/authenticatedFleetHarness.mjs
@@ -12,7 +12,7 @@ const [
     loadAgentOsModule('ai/mcp/server/shared/helpers/localBearer.mjs'),
     loadAgentOsModule('ai/mcp/server/shared/services/RequestContextService.mjs'),
     loadAgentOsModule('ai/services/fleet/FleetManager.mjs'),
-    loadAgentOsModule('ai/services/fleet/fleetWireMethods.mjs')
+    loadAgentOsModule('src/fleet/contract/wire.mjs')
 ]);
 
 const E2E_MANAGED_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'institution-fleet-e2e-'));

--- a/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs
@@ -31,7 +31,7 @@ const [
 ] = await Promise.all([
     loadAgentOsModule('ai/services/fleet/FleetRegistryService.mjs'),
     loadAgentOsModule('ai/services/fleet/fleetBridgeServer.mjs'),
-    loadAgentOsModule('ai/services/fleet/fleetWireMethods.mjs'),
+    loadAgentOsModule('src/fleet/contract/wire.mjs'),
     loadAgentOsModule('ai/mcp/server/shared/helpers/localBearer.mjs'),
     loadAgentOsModule('ai/mcp/server/shared/services/RequestContextService.mjs')
 ]);

--- a/test/playwright/unit/apps/agentos/view/fleet/util/kindRegistry.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/util/kindRegistry.spec.mjs
@@ -26,7 +26,7 @@ test.describe('Fleet event-kind registry — derived DTO coverage + --fm-kind-* 
 
         // DERIVE coverage from the DTO source constant — a new event type added there auto-fails
         // the coverage test below until the registry maps it, rather than a hardcoded second list.
-        ({FLEET_COCKPIT_EVENT_TYPES} = await loadAgentOsModule('ai/services/fleet/fleetCockpitStatus.mjs'))
+        ({FLEET_COCKPIT_EVENT_TYPES} = await loadAgentOsModule('src/fleet/contract/cockpit.mjs'))
     });
 
     test('every FLEET_COCKPIT_EVENT_TYPES kind resolves to a real --fm-kind-* token (derived from the DTO source)', () => {

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -32,7 +32,7 @@ import {
 } from '../../../../harness/brain.mjs';
 
 const {createFleetWireResponse, FLEET_WIRE_RESPONSE_STATES} =
-    await loadAgentOsModule('ai/services/fleet/fleetWireMethods.mjs');
+    await loadAgentOsModule('src/fleet/contract/wire.mjs');
 
 /**
  * A stub supervised child: EventEmitter shape matching the ChildProcess surface the lifecycle

--- a/test/playwright/unit/harness/fleetCapability.spec.mjs
+++ b/test/playwright/unit/harness/fleetCapability.spec.mjs
@@ -7,15 +7,22 @@ import {
 } from '../../../../harness/fleetCapability.mjs';
 import {loadAgentOsModule} from '../../fixtures.mjs';
 
-const {
-    createFleetWireOffer,
-    createFleetWireRequest,
-    createFleetWireResponse,
-    FLEET_CREDENTIAL_METHODS,
-    FLEET_WIRE_METHODS,
-    FLEET_WIRE_RESPONSE_STATES,
-    inspectFleetWireResponse
-} = await loadAgentOsModule('ai/services/fleet/fleetWireMethods.mjs');
+// the wire vocabulary is the Brain's client-safe contract; the credential-bearing verb
+// classification is launcher-private and lives beside the other launcher trust inputs
+const [
+    {
+        createFleetWireOffer,
+        createFleetWireRequest,
+        createFleetWireResponse,
+        FLEET_WIRE_METHODS,
+        FLEET_WIRE_RESPONSE_STATES,
+        inspectFleetWireResponse
+    },
+    {FLEET_CREDENTIAL_METHODS}
+] = await Promise.all([
+    loadAgentOsModule('src/fleet/contract/wire.mjs'),
+    loadAgentOsModule('ai/services/fleet/fleetLaunchContract.mjs')
+]);
 
 const bearerToken = 'B'.repeat(43);
 


### PR DESCRIPTION
Resolves #115

Related: #43 · #17 · neomjs/neo-agent-brain#217

The launcher and the test loaders follow the Fleet wire to the Brain's canonical home. `loadFleetRuntimeContracts` reads the wire vocabulary from `src/fleet/contract/wire.mjs` and the credential-bearing verb classification from the private `ai/services/fleet/fleetLaunchContract.mjs` it already imported; the five test loaders that named `ai/services/fleet/fleetWireMethods.mjs`, or `fleetCockpitStatus.mjs` for identifiers that moved, point at `src/fleet/contract/{wire,cockpit}.mjs`. No vocabulary, twin, parity-spec or package change — #43 stays whole. Against Brain `dev@a9e010d` the cross-repo job's witnesses go from three "Cannot find module" to green, and a dev harness over a Brain `dev` checkout boots its Fleet wire again.

Evidence: L2 (unit — the four affected specs through the real Brain modules at `a9e010d`; the e2e collection with the runtime root) → L2 required (every AC is spec- or grep-provable; the `Explicit Brain contract` job at this head is the CI form of AC-3). Residual: none.

Micro-review eligible: behavior-preserving — six loader paths follow the producer's move; the contract object keeps its keys and values.

## AC Evidence
| AC-1 | `harness/brain.mjs:106-110` — wire from `src/fleet/contract/wire.mjs`, `FLEET_CREDENTIAL_METHODS` from the already-imported `fleetLaunchContract`; `test/playwright/unit/harness/fleetCapability.spec.mjs` + `brain.spec.mjs` through the real modules: red on `dev` (`Cannot find module …/ai/services/fleet/fleetWireMethods.mjs`), green on the branch with `NEO_AGENTOS_RUNTIME_ROOT` at Brain `a9e010d` (56 passed across the four affected specs) |
| AC-2 | `git grep -n 'ai/services/fleet/fleetWireMethods\|fleetCockpitStatus.mjs' -- harness test` at `478b786` → only `fleetVocabularyParity.spec.mjs:25,28`, the self-gated spec #43 deletes |
| AC-3 | CI: `Explicit Brain contract` at this head against Brain `ref: dev` (red at PR #114's `fa5d435` with the same witness) |
| AC-4 | the diff: six files, +25/−15, nothing under `apps/agentos/config/`, no `package.json` change |

## Deltas from ticket
None substantive. The ticket's AC-2 was restated to exclude the self-gated parity spec it had forgotten.

## Test Evidence
Outside CI: with `NEO_AGENTOS_RUNTIME_ROOT` naming a Brain checkout at `a9e010d` — `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/harness/fleetCapability.spec.mjs test/playwright/unit/harness/brain.spec.mjs test/playwright/unit/apps/agentos/view/fleet/util/kindRegistry.spec.mjs test/playwright/unit/apps/agentos/fleet/fleetTransport.integration.spec.mjs` → 56 passed (on `dev` the same command fails at module load at three sites); `CI=1 npm run test-e2e -- --list` with the runtime root → 36 tests in 31 files collected, the `authenticatedFleetHarness` module loads. Isolated shape: `npm run test-unit` 790/790; the visual stamp is unchanged (no stamp input touched).

## Post-Merge Validation
- [ ] The next Institution PR after this merge shows `Explicit Brain contract` green against Brain `dev` — the job's own run is the receipt, no rerun owed.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 3a507e14-4d80-4512-bf0c-68ac34638902.
